### PR TITLE
Use enum for DriveOrder DriveType OrderDirection

### DIFF
--- a/src/DriveOrder.php
+++ b/src/DriveOrder.php
@@ -2,17 +2,8 @@
 
 namespace Owncloud\OcisPhpSdk;
 
-abstract class DriveOrder
+enum DriveOrder: string
 {
-    public const LASTMODIFIED = "lastModifiedDateTime";
-    public const NAME = "name";
-
-    public static function isOrderValid(?string $order): bool
-    {
-        $reflector = new \ReflectionClass('Owncloud\OcisPhpSdk\DriveOrder');
-        if (!in_array($order, array_merge([null], $reflector->getConstants()))) {
-            return false;
-        }
-        return true;
-    }
+    case LASTMODIFIED = "lastModifiedDateTime";
+    case NAME = "name";
 }

--- a/src/DriveType.php
+++ b/src/DriveType.php
@@ -2,18 +2,9 @@
 
 namespace Owncloud\OcisPhpSdk;
 
-class DriveType
+enum DriveType: string
 {
-    public const PROJECT = "project";
-    public const PERSONAL = "personal";
-    public const VIRTUAL = "virtual";
-
-    public static function isTypeValid(?string $type): bool
-    {
-        $reflector = new \ReflectionClass('Owncloud\OcisPhpSdk\DriveType');
-        if (!in_array($type, array_merge([null], $reflector->getConstants()))) {
-            return false;
-        }
-        return true;
-    }
+    case PERSONAL = "personal";
+    case PROJECT = "project";
+    case VIRTUAL = "virtual";
 }

--- a/src/Ocis.php
+++ b/src/Ocis.php
@@ -140,9 +140,9 @@ class Ocis
      * @throws \Exception
      */
     public function listAllDrives(
-        string $orderBy = DriveOrder::NAME,
-        string $orderDirection = OrderDirection::ASC,
-        string $type = null
+        DriveOrder     $orderBy = DriveOrder::NAME,
+        OrderDirection $orderDirection = OrderDirection::ASC,
+        DriveType      $type = null
     ): array {
         if ($this->drivesGetDrivesApiInstance === null) {
             $apiInstance = new DrivesGetDrivesApi(
@@ -185,9 +185,9 @@ class Ocis
      * @throws \Exception
      */
     public function listMyDrives(
-        string $orderBy = DriveOrder::NAME,
-        string $orderDirection = OrderDirection::ASC,
-        string $type = null
+        DriveOrder     $orderBy = DriveOrder::NAME,
+        OrderDirection $orderDirection = OrderDirection::ASC,
+        DriveType      $type = null
     ): array {
         $apiInstance = new MeDrivesApi(
             $this->guzzle,
@@ -219,27 +219,17 @@ class Ocis
     }
 
     private function getListDrivesOrderString(
-        string $orderBy = DriveOrder::NAME,
-        string $orderDirection = OrderDirection::ASC
+        DriveOrder     $orderBy = DriveOrder::NAME,
+        OrderDirection $orderDirection = OrderDirection::ASC
     ): string {
-        if (!DriveOrder::isOrderValid($orderBy)) {
-            throw new \InvalidArgumentException('$orderBy is invalid');
-        }
-        if (!OrderDirection::isOrderDirectionValid($orderDirection)) {
-            throw new \InvalidArgumentException('$orderDirection is invalid');
-        }
-        return $orderBy . ' ' . $orderDirection;
+        return $orderBy->value . ' ' . $orderDirection->value;
     }
 
     private function getListDrivesFilterString(
-        string $type = null
+        DriveType $type = null
     ): ?string {
-        if (!DriveType::isTypeValid($type)) {
-            throw new \InvalidArgumentException('$type is invalid');
-        }
-
         if ($type !== null) {
-            $filter = 'driveType eq \'' . $type . '\'';
+            $filter = 'driveType eq \'' . $type->value . '\'';
         } else {
             $filter = null;
         }

--- a/src/OrderDirection.php
+++ b/src/OrderDirection.php
@@ -2,17 +2,8 @@
 
 namespace Owncloud\OcisPhpSdk;
 
-abstract class OrderDirection
+enum OrderDirection: string
 {
-    public const ASC = "asc";
-    public const DESC = "desc";
-
-    public static function isOrderDirectionValid(?string $direction): bool
-    {
-        $reflector = new \ReflectionClass('Owncloud\OcisPhpSdk\OrderDirection');
-        if (!in_array($direction, array_merge([null], $reflector->getConstants()))) {
-            return false;
-        }
-        return true;
-    }
+    case ASC = "asc";
+    case DESC = "desc";
 }

--- a/tests/unit/Owncloud/OcisSdkPhp/DriveOrderTest.php
+++ b/tests/unit/Owncloud/OcisSdkPhp/DriveOrderTest.php
@@ -8,27 +8,21 @@ use PHPUnit\Framework\TestCase;
 class DriveOrderTest extends TestCase
 {
     /**
-     * @return array<int,array<int, string|null>>
+     * @return array<int,array{0:DriveOrder,1:string}>
      */
-    public function validDriveTypes(): array
+    public function validDriveOrders(): array
     {
         return [
-            [null],
-            ["name"],
-            ["lastModifiedDateTime"]
+            [DriveOrder::LASTMODIFIED, "lastModifiedDateTime"],
+            [DriveOrder::NAME, "name"],
         ];
     }
 
     /**
-     * @dataProvider validDriveTypes
+     * @dataProvider validDriveOrders
      */
-    public function testValidDriveType(?string $type): void
+    public function testDriveOrderString(DriveOrder $order, string $driveOrderString): void
     {
-        $this->assertTrue(DriveOrder::isOrderValid($type));
-    }
-
-    public function testInvalidDriveType(): void
-    {
-        $this->assertFalse(DriveOrder::isOrderValid("some string"));
+        $this->assertEquals($driveOrderString, $order->value);
     }
 }

--- a/tests/unit/Owncloud/OcisSdkPhp/DriveTypeTest.php
+++ b/tests/unit/Owncloud/OcisSdkPhp/DriveTypeTest.php
@@ -8,28 +8,21 @@ use PHPUnit\Framework\TestCase;
 class DriveTypeTest extends TestCase
 {
     /**
-     * @return array<int,array<int, string|null>>
-     */
+     * @return array<int,array{0:DriveType,1:string}>     */
     public function validDriveTypes(): array
     {
         return [
-            [null],
-            ["project"],
-            ["personal"],
-            ["virtual"],
+            [DriveType::PERSONAL, "personal"],
+            [DriveType::PROJECT, "project"],
+            [DriveType::VIRTUAL, "virtual"],
         ];
     }
 
     /**
      * @dataProvider validDriveTypes
      */
-    public function testValidDriveType(?string $type): void
+    public function testDriveTypeString(DriveType $type, string $driveTypeString): void
     {
-        $this->assertTrue(DriveType::isTypeValid($type));
-    }
-
-    public function testInvalidDriveType(): void
-    {
-        $this->assertFalse(DriveType::isTypeValid("some string"));
+        $this->assertEquals($driveTypeString, $type->value);
     }
 }

--- a/tests/unit/Owncloud/OcisSdkPhp/OrderDirectionTest.php
+++ b/tests/unit/Owncloud/OcisSdkPhp/OrderDirectionTest.php
@@ -8,27 +8,21 @@ use PHPUnit\Framework\TestCase;
 class OrderDirectionTest extends TestCase
 {
     /**
-     * @return array<int,array<int, string|null>>
+     * @return array<int,array{0:OrderDirection,1:string}>
      */
-    public function validDriveTypes(): array
+    public function validOrderDirections(): array
     {
         return [
-            [null],
-            ["asc"],
-            ["desc"]
+            [OrderDirection::ASC, "asc"],
+            [OrderDirection::DESC, "desc"],
         ];
     }
 
     /**
-     * @dataProvider validDriveTypes
+     * @dataProvider validOrderDirections
      */
-    public function testValidDriveType(?string $type): void
+    public function testOrderDirectionString(OrderDirection $direction, string $directionString): void
     {
-        $this->assertTrue(OrderDirection::isOrderDirectionValid($type));
-    }
-
-    public function testInvalidDriveType(): void
-    {
-        $this->assertFalse(OrderDirection::isOrderDirectionValid("some string"));
+        $this->assertEquals($directionString, $direction->value);
     }
 }


### PR DESCRIPTION
We already use `enum` for https://github.com/owncloud/ocis-php-sdk/blob/main/src/ResourceMetadata.php

Refactor to use `enum` for DriveOrder DriveType OrderDirection

This prevents the possibility of anyone passing an invalid value. If they do, PHP itself will complain straight away, we do not have to write code to check.

I looked at `README.md` and I don't think that the examples there need any changes. Methods like `listMyDrives` still take parameters specified like `DriveOrder::NAME` `OrderDirection::ASC` `DriveType::PERSONAL` - they are now `enum`s but they are specified the same way as when they were public constants.