### PR TITLE
use webfinger

### DIFF
--- a/.phan/config.php
+++ b/.phan/config.php
@@ -11,7 +11,7 @@ return [
     // If this is set to null,
     // then Phan assumes the PHP version which is closest to the minor version
     // of the php executable used to execute phan.
-    'target_php_version' => '8.0',
+    'target_php_version' => '8.1',
 
     // A list of directories that should be parsed for class and
     // method information. After excluding the directories

--- a/src/Drive.php
+++ b/src/Drive.php
@@ -30,7 +30,7 @@ class Drive
     private string $webDavUrl = '';
 
     /**
-     * @phpstan-var array{'headers'?:array<string, mixed>, 'verify'?:bool}
+     * @phpstan-var array{'headers'?:array<string, mixed>, 'verify'?:bool, 'webfinger'?:bool, 'guzzle'?:\GuzzleHttp\Client}
      */
     private array $connectionConfig;
     private Configuration $graphApiConfig;
@@ -39,7 +39,7 @@ class Drive
     /**
      * @ignore The developer using the SDK does not need to create drives manually, but should use the Ocis class
      *         to get or create drives, so this constructor should not be listed in the documentation.
-     * @phpstan-param array{'headers'?:array<string, mixed>, 'verify'?:bool} $connectionConfig
+     * @phpstan-param array{'headers'?:array<string, mixed>, 'verify'?:bool, 'webfinger'?:bool, 'guzzle'?:\GuzzleHttp\Client} $connectionConfig
      * @throws \InvalidArgumentException
      */
     public function __construct(

--- a/src/Notification.php
+++ b/src/Notification.php
@@ -39,7 +39,7 @@ class Notification
     private array $connectionConfig;
 
     /**
-     * @phpstan-param array{'headers'?:array<string, mixed>, 'verify'?:bool} $connectionConfig
+     * @phpstan-param array{'headers'?:array<string, mixed>, 'verify'?:bool, 'webfinger'?:bool, 'guzzle'?:\GuzzleHttp\Client} $connectionConfig
      * @param array<mixed> $messageRichParameters
      * @throws \InvalidArgumentException
      * @ignore The developer using the SDK does not need to create notifications manually, but should use the Ocis class

--- a/src/WebDavClient.php
+++ b/src/WebDavClient.php
@@ -44,7 +44,7 @@ class WebDavClient extends Client
     }
 
     /**
-     * @phpstan-param array{'headers'?:array<string, mixed>, 'verify'?:bool} $connectionConfig
+     * @phpstan-param array{'headers'?:array<string, mixed>, 'verify'?:bool, 'webfinger'?:bool, 'guzzle'?:\GuzzleHttp\Client} $connectionConfig
      * @return array<int, mixed>
      */
     public function createCurlSettings(array $connectionConfig, string $accessToken): array
@@ -67,7 +67,7 @@ class WebDavClient extends Client
     /**
      * set curl settings
      * enable exceptions for send method
-     * @phpstan-param array{'headers'?:array<string, mixed>, 'verify'?:bool} $connectionConfig
+     * @phpstan-param array{'headers'?:array<string, mixed>, 'verify'?:bool, 'webfinger'?:bool, 'guzzle'?:\GuzzleHttp\Client} $connectionConfig
      *
      */
     public function setCustomSetting(array $connectionConfig, string $accessToken): void

--- a/tests/unit/Owncloud/OcisSdkPhp/OcisTest.php
+++ b/tests/unit/Owncloud/OcisSdkPhp/OcisTest.php
@@ -2,6 +2,7 @@
 
 namespace unit\Owncloud\OcisPhpSdk;
 
+use GuzzleHttp\Client;
 use OpenAPI\Client\Api\DrivesApi;
 use OpenAPI\Client\Api\DrivesGetDrivesApi;
 use OpenAPI\Client\ApiException;
@@ -141,16 +142,13 @@ class OcisTest extends TestCase
         string $responseContent,
         string $token = 'doesNotMatter'
     ): Ocis {
-        $ocis = new Ocis('https://localhost:9200', $token);
         $streamMock = $this->createMock(StreamInterface::class);
         $streamMock->method('getContents')->willReturn($responseContent);
         $responseMock = $this->createMock(ResponseInterface::class);
         $responseMock->method('getBody')->willReturn($streamMock);
         $guzzleMock = $this->createMock(\GuzzleHttp\Client::class);
         $guzzleMock->method('get')->willReturn($responseMock);
-        /* @phan-suppress-next-line PhanTypeMismatchArgument */
-        $ocis->setGuzzle($guzzleMock);
-        return $ocis;
+        return new Ocis('https://localhost:9200', $token, ['guzzle' => $guzzleMock]);
     }
 
     /**
@@ -319,6 +317,35 @@ class OcisTest extends TestCase
                 ['crud' => 'some value', 'verify' => false],
                 false
             ],
+            [
+                ['webfinger' => true],
+                true
+            ]
+            ,
+            [
+                ['webfinger' => false],
+                true
+            ],
+            [
+                ['webfinger' => 'true'],
+                false
+            ],
+            [
+                ['webfinger' => null],
+                false
+            ],
+            [
+                ['guzzle' => new Client()],
+                true
+            ],
+            [
+                ['guzzle' => null],
+                false
+            ],
+            [
+                ['guzzle' => 'Guzzle'],
+                false
+            ]
         ];
     }
 

--- a/tests/unit/Owncloud/OcisSdkPhp/OcisWebfingerTest.php
+++ b/tests/unit/Owncloud/OcisSdkPhp/OcisWebfingerTest.php
@@ -1,0 +1,143 @@
+<?php
+
+namespace unit\Owncloud\OcisPhpSdk;
+
+use GuzzleHttp\Client;
+use Owncloud\OcisPhpSdk\Exception\InvalidResponseException;
+use Owncloud\OcisPhpSdk\Ocis;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamInterface;
+
+class OcisWebfingerTest extends TestCase
+{
+    private function getValidToken(): string
+    {
+        $tokenHeader = [
+            "alg" => "PS256",
+            "kid" => "private-key",
+            "typ" => "JWT"
+        ];
+        $tokenPayload = [
+            "iss" => "https://sso.example.com",
+        ];
+        return base64_encode((string)json_encode($tokenHeader)) . "." .
+            base64_encode((string)json_encode($tokenPayload)) .
+            ".signatureDoesNotMatter";
+    }
+    private function getGuzzleMock(?string $responseContent = null): MockObject
+    {
+        if ($responseContent === null) {
+            $responseContent = '
+                {
+                    "subject": "acct:einstein@drive.ocis.test",
+                    "links": [
+                        {
+                            "rel": "http://openid.net/specs/connect/1.0/issuer",
+                            "href": "https://sso.example.org/cas/oidc/"
+                        },
+                        {
+                            "rel": "http://webfinger.owncloud/rel/server-instance",
+                            "href": "https://abc.drive.example.com",
+                            "titles": {
+                                "en": "oCIS Instance"
+                            }
+                        }
+                    ]
+                }';
+        }
+
+        $streamMock = $this->createMock(StreamInterface::class);
+        $streamMock->method('getContents')->willReturn($responseContent);
+        $responseMock = $this->createMock(ResponseInterface::class);
+        $responseMock->method('getBody')->willReturn($streamMock);
+        $guzzleMock = $this->createMock(Client::class);
+        $guzzleMock->method('get')
+            /** @phan-suppress-next-line PhanTypeMismatchArgumentProbablyReal */
+            ->with('https://webfinger.example.com?resource=acct:me@sso.example.com')
+            ->willReturn($responseMock);
+        return $guzzleMock;
+    }
+    public function testWebfinger(): void
+    {
+        $ocis = new Ocis(
+            'https://webfinger.example.com',
+            $this->getValidToken(),
+            /* @phpstan-ignore-next-line because receiving a MockObject */
+            [
+                'webfinger' => true,
+                'guzzle' => $this->getGuzzleMock()
+            ]
+        );
+        $this->assertSame("https://abc.drive.example.com", $ocis->getServiceUrl());
+    }
+
+    /**
+     * @return array<array<string>>
+     **/
+    public function invalidTokenProvider(): array
+    {
+        return [
+            ["onlyHeaderNoPayload"],
+            ["header.butPäylöädNötBäs€64"],
+            ["header.cGF5bG9hZElzTm90SlNPTgo="], // payload is not JSON
+            ["header.InBheWxvYWRJc05vdEFuT2JqZWN0Igo="], // payload is not an JSON object
+            ["header.eyJrZXkiOiAidmFsdWUifQo="], // payload is a JSON object, but does not contain 'iss' key
+            ["header.eyJpc3MiOiBudWxsfQo="], // payload contains 'iss' key but the value is null
+            ["header.eyJpc3MiOiAiaHR0cHM6Ly8ifQo="], // payload contains 'iss' key but the value is 'https://'
+            ["header.eyJpc3MiOiAiaG9zdCJ9Cg=="], // payload contains 'iss' key but the value is 'host'
+            ["header.eyJpc3MiOiAiaHR0cHM6Ly86OTAwMCJ9Cg=="], // payload contains 'iss' key but the value is 'https://:9000'
+        ];
+    }
+    /**
+     * @dataProvider invalidTokenProvider
+     */
+    public function testWebfingerInvalidToken(string $token): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage("could not decode token");
+        $ocis = new Ocis(
+            'https://webfinger.example.com',
+            $token,
+            /* @phpstan-ignore-next-line because receiving a MockObject */
+            [
+                'webfinger' => true,
+                'guzzle' => $this->getGuzzleMock()
+            ]
+        );
+    }
+
+    /**
+     * @return array<array<string>>
+     **/
+    public function invalidResponseContentProvider(): array
+    {
+        return [
+            ["notJson"],
+            ['{"subject": "acct:einstein@drive.ocis.test"}'], // no links
+            ['{"links": "string"}'], // links is not array
+            ['{"links": []}'], // links is an empty array
+            ['{"links": [{"rel": "http://openid.net/specs/connect/1.0/issuer"},{"rel": "http://something-unrelated"}]}'], //links don't have the correct rel
+            ['{"links": [{"rel": "http://webfinger.owncloud/rel/server-instance"}]}'], //correct rel, but no href
+        ];
+    }
+
+    /**
+     * @dataProvider invalidResponseContentProvider
+     */
+    public function testWebfingerInvalidResponse(string $responseContent): void
+    {
+        $this->expectException(InvalidResponseException::class);
+        $this->expectExceptionMessage("invalid webfinger response");
+        $ocis = new Ocis(
+            'https://webfinger.example.com',
+            $this->getValidToken(),
+            /* @phpstan-ignore-next-line because receiving a MockObject */
+            [
+                'webfinger' => true,
+                'guzzle' => $this->getGuzzleMock($responseContent)
+            ]
+        );
+    }
+}

--- a/tests/unit/Owncloud/OcisSdkPhp/WebDavClientTest.php
+++ b/tests/unit/Owncloud/OcisSdkPhp/WebDavClientTest.php
@@ -34,7 +34,7 @@ class WebDavClientTest extends TestCase
     }
 
     /**
-     * @phpstan-param array{'headers'?:array<string, mixed>, 'verify'?:bool} $connectionConfig
+     * @phpstan-param array{'headers'?:array<string, mixed>, 'verify'?:bool, 'webfinger'?:bool, 'guzzle'?:\GuzzleHttp\Client} $connectionConfig
      * @param array<mixed> $expectedCurlSettingsArray
      * @dataProvider connectionConfigProvider
      */


### PR DESCRIPTION
In more complex setups the service Url might not be known at the beginning but the webfinger service needs to be asked.
As the SDK expects a token to be present it only does authenticated requests to webfinger.

In this PR I'm introducing a new parameter to `$connectionConfig` to switch on the webfinger discovery.
so the object creation would be:
`$ocis = new Ocis($webfinger_url, $access_token->token, ['webfinger' => true]);`

The SDK then contacts the webfinger service, finds the first link with `"rel": "http://webfinger.owncloud/rel/server-instance"` and uses that as the service URL to do Graph & WebDAV requests.

The corresponding PR for moodle: https://github.com/owncloud/moodle-repository_ocis/pull/5

For the unit tests I've refactored the `$connectionConfig`, so that it can also take a guzzle(Mock). The reason is, that we need guzzle already in the constructor and so it does not work for the tests to call `setGuzzle`.

@phil-davis @amrita-shrestha @S-Panta @nirajacharya2 is the design using `['webfinger' => true]` in `$connectionConfig` good, or should we introduce an other parameter to `Ocis::__constructor`?

@micbar 
1. would that approach for webfinger discovery work in bigger instances?
2. I set the `resource` parameter in the webfinger URL to `acct:me@<host of the iss in the token>`. Is that correct or does it even matter?