### PR TITLE
return DriveType object from drive->getType()

### DIFF
--- a/src/Drive.php
+++ b/src/Drive.php
@@ -59,9 +59,19 @@ class Drive
         return (string)$this->apiDrive->getDriveAlias();
     }
 
-    public function getType(): string
+    /**
+     * @throws \Exception
+     */
+    public function getType(): DriveType
     {
-        return (string)$this->apiDrive->getDriveType();
+        $driveTypeString = (string)$this->apiDrive->getDriveType();
+        $driveType = DriveType::tryFrom($driveTypeString);
+        if ($driveType instanceof DriveType) {
+            return $driveType;
+        }
+        throw new \Exception(
+            'invalid DriveType returned by apiDrive: "' . print_r($driveTypeString, true) . '"'
+        );
     }
 
     public function getId(): string


### PR DESCRIPTION
Maybe it will be nicer if drive->getType() returns a DriveType object (an instance of the DriveType enum) and throws an exception if and invalid drive type happens. That will allow the consumer to always work with the DriveType enum object, rather than potentially processing strings that happen to be the "known values" like "personal" "project" etc.