### PR TITLE
basic framework to run integration tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,12 @@ test-php-unit:             ## Run php unit tests
 test-php-unit: vendor/bin/phpunit
 	vendor/bin/phpunit --configuration ./phpunit.xml --testsuite unit
 
+.PHONY: test-php-integration
+test-php-integration:             ## Run php integration tests
+test-php-integration: run-ocis-with-keycloak
+	vendor/bin/phpunit --configuration ./phpunit.xml --testsuite integration
+	$(MAKE) docker-clean
+
 .PHONY: test-php-style
 test-php-style:            ## Run php-cs-fixer and check code-style
 test-php-style: vendor/bin/php-cs-fixer
@@ -45,11 +51,11 @@ test-php-phpstan: vendor/bin/phpstan
 
 .PHONY: run-ocis-with-keycloak
 run-ocis-with-keycloak:
-	cd tests/integration && $(DCO) up
+	cd tests/integration && $(DCO) up -d --wait
 
 .PHONY: docker-clean
 docker-clean:
-	cd tests/integration && $(DCO) down -v --remove-orphans --rmi all
+	cd tests/integration && $(DCO) down -v --remove-orphans
 
 .PHONY: clean
 clean:

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -11,6 +11,9 @@
     <testsuite name="unit">
       <directory suffix="Test.php">./tests/unit</directory>
     </testsuite>
+    <testsuite name="integration">
+      <directory suffix="Test.php">./tests/integration</directory>
+    </testsuite>
   </testsuites>
   <coverage>
     <include>

--- a/src/Drive.php
+++ b/src/Drive.php
@@ -157,7 +157,9 @@ class Drive
 
     /**
      * Deletes the current drive irreversibly.
-     * A drive can only be deleted if its has been disabled before.
+     * A drive can only be deleted if it has already been disabled.
+     * Calling this function on a drive that is not disabled will have no effect.
+     *
      * @throws UnauthorizedException
      * @throws ForbiddenException
      * @throws BadRequestException
@@ -188,7 +190,7 @@ class Drive
     /**
      * Disables the current drive without deleting it.
      * Disabling a drive is the prerequisite for deleting it.
-     * Calling this function on a drive that is not disabled will have no effect.
+     * Calling this function on a drive that is already disabled will have no effect.
      *
      * @throws UnauthorizedException
      * @throws ForbiddenException

--- a/src/Ocis.php
+++ b/src/Ocis.php
@@ -185,7 +185,12 @@ class Ocis
         $apiDrives = $allDrivesList->getValue();
         $apiDrives = $apiDrives ?? [];
         foreach ($apiDrives as $apiDrive) {
-            $drive = new Drive($apiDrive, $this->connectionConfig, $this->accessToken);
+            $drive = new Drive(
+                $apiDrive,
+                $this->connectionConfig,
+                $this->serviceUrl,
+                $this->accessToken
+            );
             $drives[] = $drive;
         }
 
@@ -239,7 +244,12 @@ class Ocis
         $apiDrives = $allDrivesList->getValue();
         $apiDrives = $apiDrives ?? [];
         foreach ($apiDrives as $apiDrive) {
-            $drive = new Drive($apiDrive, $this->connectionConfig, $this->accessToken);
+            $drive = new Drive(
+                $apiDrive,
+                $this->connectionConfig,
+                $this->serviceUrl,
+                $this->accessToken
+            );
             $drives[] = $drive;
         }
         return $drives;
@@ -264,11 +274,36 @@ class Ocis
     }
 
     /**
-     * @throws \Exception
+     * @throws BadRequestException
+     * @throws ForbiddenException
+     * @throws NotFoundException
+     * @throws UnauthorizedException
+     * @throws HttpException
+     * @throws InvalidResponseException
      */
     public function getDriveById(string $driveId): Drive
     {
-        throw new \Exception("This function is not implemented yet.");
+        $apiInstance = new DrivesApi(
+            $this->guzzle,
+            $this->graphApiConfig
+        );
+        try {
+            $apiDrive = $apiInstance->getDrive($driveId);
+        } catch (ApiException $e) {
+            throw ExceptionHelper::getHttpErrorException($e);
+        }
+
+        if ($apiDrive instanceof OdataError) {
+            throw new InvalidResponseException(
+                "getDrive returned an OdataError - " . $apiDrive->getError()
+            );
+        }
+        return new Drive(
+            $apiDrive,
+            $this->connectionConfig,
+            $this->serviceUrl,
+            $this->accessToken
+        );
     }
 
     /**
@@ -313,7 +348,12 @@ class Ocis
         }
 
         if ($newlyCreatedDrive instanceof ApiDrive) {
-            return new Drive($newlyCreatedDrive, $this->connectionConfig, $this->accessToken);
+            return new Drive(
+                $newlyCreatedDrive,
+                $this->connectionConfig,
+                $this->serviceUrl,
+                $this->accessToken
+            );
         }
         throw new InvalidResponseException(
             "Drive could not be created. '" .

--- a/tests/integration/Owncloud/OcisSdkPhp/OcisTest.php
+++ b/tests/integration/Owncloud/OcisSdkPhp/OcisTest.php
@@ -1,0 +1,129 @@
+<?php
+
+namespace integration\Owncloud\OcisPhpSdk;
+
+use GuzzleHttp\Client;
+use Owncloud\OcisPhpSdk\Exception\ForbiddenException;
+use Owncloud\OcisPhpSdk\Ocis;
+use PHPUnit\Framework\TestCase;
+
+class OcisTest extends TestCase
+{
+    private const CLIENT_ID = 'xdXOt13JKxym1B1QcEncf2XDkLAexMBFwiT9j6EfhhHFJhs2KM9jbjTmf8JBXE69';
+    private const CLIENT_SECRET = 'UBntmLjC2yYCeHwsyj73Uwo9TAaecAetRwMw0xYcvNL9yRdLSUi0hUAHfvCHFeFh';
+    private const UUID_REGEX_PATTERN = '/^[0-9A-F]{8}-[0-9A-F]{4}-4[0-9A-F]{3}-[89AB][0-9A-F]{3}-[0-9A-F]{12}\$[0-9A-F]{8}-[0-9A-F]{4}-4[0-9A-F]{3}-[89AB][0-9A-F]{3}-[0-9A-F]{12}$/i';
+    private string $ocisUrl = 'https://ocis.sdk.test:9009';
+    private ?string $tokenUrl = null;
+    private ?Client $guzzleClient = null;
+    /**
+     * @var array <string>
+     */
+    private $createdDrives = [];
+
+    public function setUp(): void
+    {
+        $guzzleClient = $this->getGuzzleClient();
+        $response = $guzzleClient->get('.well-known/openid-configuration');
+        $openIdConfigurationRaw = $response->getBody()->getContents();
+        $openIdConfiguration = json_decode($openIdConfigurationRaw, true);
+        if ($openIdConfiguration === null) {
+            throw new \Exception('Could not decode openid configuration');
+        }
+        // @phpstan-ignore-next-line
+        $this->tokenUrl = $openIdConfiguration['token_endpoint'];
+    }
+
+    public function tearDown(): void
+    {
+        $token = $this->getAccessToken('admin', 'admin');
+        $ocis = new Ocis($this->ocisUrl, $token, ['verify' => false]);
+        foreach ($this->createdDrives as $driveId) {
+            $drive = $ocis->getDriveById($driveId);
+            $drive->disable();
+            $drive->delete();
+        }
+    }
+
+    private function getGuzzleClient(): Client
+    {
+        if ($this->guzzleClient !== null) {
+            return $this->guzzleClient;
+        }
+        $guzzleClient = new Client([
+            'base_uri' => $this->ocisUrl,
+            'verify' => false
+        ]);
+        $this->guzzleClient = $guzzleClient;
+        return $this->guzzleClient;
+    }
+
+    private function getAccessToken(string $username, string $password): string
+    {
+        $guzzleClient = $this->getGuzzleClient();
+        $response = $guzzleClient->post((string)$this->tokenUrl, [
+            'form_params' => [
+                'grant_type' => 'password',
+                'client_id' => self::CLIENT_ID,
+                'client_secret' => self::CLIENT_SECRET,
+                'username' => $username,
+                'password' => $password,
+                'scope' => 'openid profile email offline_access'
+            ]
+        ]);
+        $accessTokenResponse = json_decode($response->getBody()->getContents(), true);
+        if ($accessTokenResponse === null) {
+            throw new \Exception('Could not decode token response');
+        }
+        // @phpstan-ignore-next-line
+        return $accessTokenResponse['access_token'];
+    }
+
+    public function testCreateDrive(): void
+    {
+        $token = $this->getAccessToken('admin', 'admin');
+        $ocis = new Ocis($this->ocisUrl, $token, ['verify' => false]);
+        $countDrivesAtStart = count(
+            $ocis->listMyDrives()
+        );
+        $drive = $ocis->createDrive('first test drive');
+        $this->createdDrives[] = $drive->getId();
+        $this->assertMatchesRegularExpression(self::UUID_REGEX_PATTERN, $drive->getId());
+        // there should be one more drive
+        $this->assertCount($countDrivesAtStart + 1, $ocis->listMyDrives());
+    }
+
+    public function testCreateDriveNoPermissions(): void
+    {
+        $token = $this->getAccessToken('einstein', 'relativity');
+        $ocis = new Ocis($this->ocisUrl, $token, ['verify' => false]);
+        $this->expectException(ForbiddenException::class);
+        $countDrivesAtStart = count($ocis->listMyDrives());
+        $ocis->createDrive('first test drive');
+        // no new drive should have been created
+        $this->assertCount($countDrivesAtStart, $ocis->listMyDrives());
+    }
+
+    /**
+     * @return array<int,array<int,int>>
+     */
+    public function invalidQuotaProvider()
+    {
+        return [
+            [-1],
+            [-100],
+        ];
+    }
+    /**
+     * @dataProvider invalidQuotaProvider
+     */
+    public function testCreateDriveInvalidQuota(int $quota): void
+    {
+        $token = $this->getAccessToken('admin', 'admin');
+        $ocis = new Ocis($this->ocisUrl, $token, ['verify' => false]);
+        $this->expectException(\InvalidArgumentException::class);
+        $countDrivesAtStart = count($ocis->listMyDrives());
+        $ocis->createDrive('drive with quota', $quota);
+        // no new drive should have been created
+        $this->assertCount($countDrivesAtStart, $ocis->listMyDrives());
+    }
+}

--- a/tests/integration/compose.yaml
+++ b/tests/integration/compose.yaml
@@ -23,7 +23,12 @@ services:
       OCIS_ADMIN_USER_ID: ''
       OCIS_EXCLUDE_RUN_SERVICES: idp
       GRAPH_ASSIGN_DEFAULT_USER_ROLE: false
+      GRAPH_USERNAME_MATCH: "none"
     restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "curl", "https://ocis.sdk.test:9009/.well-known/openid-configuration", "-k", "-f"]
+      interval: 10s
+      timeout: 300s
 
   postgres:
     image: postgres:alpine

--- a/tests/integration/docker/keycloak/Dockerfile
+++ b/tests/integration/docker/keycloak/Dockerfile
@@ -9,7 +9,7 @@ RUN apt update && apt install -y openssl && \
     mv keycloak.key keycloak.pem && \
     cat keycloak.crt >> keycloak.pem
 
-FROM quay.io/keycloak/keycloak:22.0.1
+FROM quay.io/keycloak/keycloak:22.0.4
 
 USER root
 COPY --from=gen-certs /certs /opt/keycloak/certs


### PR DESCRIPTION
basic framework and first small set of integration tests
`make test-php-integration` should make it run locally

1. ocis is started with keycloak and some well known users
2. tokens are fetched using oidc flow type `Resource Owner Password Flow` setting `grant_type=password`
3. tokens are used to do various operations through the SDK