### PR TITLE
improve integration tests docker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,7 @@ test-php-unit: vendor/bin/phpunit
 .PHONY: test-php-integration
 test-php-integration:             ## Run php integration tests
 test-php-integration: run-ocis-with-keycloak
+	composer install
 	$(PHPUNIT) --configuration ./phpunit.xml --testsuite integration
 	$(MAKE) docker-clean
 
@@ -62,6 +63,7 @@ docker-clean:
 clean:
 	rm -f composer.lock .php-cs-fixer.cache .phpunit.result.cache
 	rm -Rf vendor
+	cd tests/integration && $(DCO) down -v --remove-orphans --rmi local
 
 #
 # Dependency management

--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ To test, simply open a browser and head to http://url-of-this-file.
 ### Integration tests
 The integration tests start a full oCIS server with keycloak and other services using docker.
 To run the tests locally
-1. Install and setup `docker` and `docker compose`.
+1. Install and setup `docker` (min version 24) and `docker compose` (min version 2.21).
 2. add these lines to your `/etc/hosts` file:
    ```
    127.0.0.1	ocis.owncloud.test

--- a/README.md
+++ b/README.md
@@ -183,3 +183,20 @@ If you're working in a development environment where you might need to bypass SS
 ```
 
 To test, simply open a browser and head to http://url-of-this-file.
+
+
+## Development
+
+### Integration tests
+The integration tests start a full oCIS server with keycloak and other services using docker.
+To run the tests locally
+1. Install and setup `docker` and `docker compose`.
+2. add these lines to your `/etc/hosts` file:
+   ```
+   127.0.0.1	ocis.owncloud.test
+   127.0.0.1	keycloak.owncloud.test
+   ```
+3. run `make test-php-integration`
+
+If something goes wrong, use `make clean` to clean the created containers and volumes. 
+

--- a/tests/integration/Owncloud/OcisSdkPhp/OcisTest.php
+++ b/tests/integration/Owncloud/OcisSdkPhp/OcisTest.php
@@ -12,7 +12,7 @@ class OcisTest extends TestCase
     private const CLIENT_ID = 'xdXOt13JKxym1B1QcEncf2XDkLAexMBFwiT9j6EfhhHFJhs2KM9jbjTmf8JBXE69';
     private const CLIENT_SECRET = 'UBntmLjC2yYCeHwsyj73Uwo9TAaecAetRwMw0xYcvNL9yRdLSUi0hUAHfvCHFeFh';
     private const UUID_REGEX_PATTERN = '/^[0-9A-F]{8}-[0-9A-F]{4}-4[0-9A-F]{3}-[89AB][0-9A-F]{3}-[0-9A-F]{12}\$[0-9A-F]{8}-[0-9A-F]{4}-4[0-9A-F]{3}-[89AB][0-9A-F]{3}-[0-9A-F]{12}$/i';
-    private string $ocisUrl = 'https://ocis.sdk.test:9009';
+    private string $ocisUrl = 'https://ocis.owncloud.test';
     private ?string $tokenUrl = null;
     private ?Client $guzzleClient = null;
     /**

--- a/tests/integration/compose.yaml
+++ b/tests/integration/compose.yaml
@@ -1,57 +1,116 @@
 version: '3.8'
 
 services:
+  traefik:
+    image: traefik:v2.9.1
+    networks:
+      ocis-net:
+        aliases:
+          - ${OCIS_DOMAIN:-ocis.owncloud.test}
+          - ${KEYCLOAK_DOMAIN:-keycloak.owncloud.test}
+    command:
+      - "--log.level=${TRAEFIK_LOG_LEVEL:-ERROR}"
+      # letsencrypt configuration
+      - "--certificatesResolvers.http.acme.email=${TRAEFIK_ACME_MAIL:-example@example.org}"
+      - "--certificatesResolvers.http.acme.storage=/certs/acme.json"
+      - "--certificatesResolvers.http.acme.httpChallenge.entryPoint=http"
+      # enable dashboard
+      - "--api.dashboard=true"
+      # define entrypoints
+      - "--entryPoints.http.address=:80"
+      - "--entryPoints.http.http.redirections.entryPoint.to=https"
+      - "--entryPoints.http.http.redirections.entryPoint.scheme=https"
+      - "--entryPoints.https.address=:443"
+      # docker provider (get configuration from container labels)
+      - "--providers.docker.endpoint=unix:///var/run/docker.sock"
+      - "--providers.docker.exposedByDefault=false"
+      # access log
+      - "--accessLog=true"
+      - "--accessLog.format=json"
+      - "--accessLog.fields.headers.names.X-Request-Id=keep"
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - "${DOCKER_SOCKET_PATH:-/var/run/docker.sock}:/var/run/docker.sock:ro"
+      - "certs:/certs"
+    labels:
+      - "traefik.enable=${TRAEFIK_DASHBOARD:-false}"
+      - "traefik.http.middlewares.traefik-auth.basicauth.users=${TRAEFIK_BASIC_AUTH_USERS:-admin:$$apr1$$4vqie50r$$YQAmQdtmz5n9rEALhxJ4l.}" # defaults to admin:admin
+      - "traefik.http.routers.traefik.entrypoints=https"
+      - "traefik.http.routers.traefik.rule=Host(`${TRAEFIK_DOMAIN:-traefik.owncloud.test}`)"
+      - "traefik.http.routers.traefik.middlewares=traefik-auth"
+      - "traefik.http.routers.traefik.tls.certresolver=http"
+      - "traefik.http.routers.traefik.service=api@internal"
+    logging:
+      driver: ${LOG_DRIVER:-local}
+    restart: always
+    healthcheck:
+      test: ["CMD-SHELL", "wget https://ocis.owncloud.test/.well-known/openid-configuration --no-check-certificate --quiet --tries=1 --spider"]
+      interval: 1s
+      retries: 120
+
+
   ocis:
     image: owncloud/ocis:${OCIS_VERSION:-latest}
-    extra_hosts:
-      - ocis.sdk.test:host-gateway
+    networks:
+      ocis-net:
     entrypoint: /bin/sh
     command: [ "-c", "ocis init || true; ocis server" ]
-    ports:
-      - 9009:9200
     environment:
-      OCIS_URL: https://ocis.sdk.test:9009
+      OCIS_URL: https://${OCIS_DOMAIN:-ocis.owncloud.test}
       OCIS_INSECURE: true
       IDM_ADMIN_PASSWORD: admin
       PROXY_AUTOPROVISION_ACCOUNTS: true
       PROXY_ROLE_ASSIGNMENT_DRIVER: oidc
-      OCIS_OIDC_ISSUER: https://ocis.sdk.test:8443/realms/oCIS
+      OCIS_OIDC_ISSUER: https://${KEYCLOAK_DOMAIN:-keycloak.owncloud.test}/realms/${KEYCLOAK_REALM:-oCIS}
       PROXY_OIDC_REWRITE_WELLKNOWN: true
       WEB_OIDC_CLIENT_ID: web
+      PROXY_TLS: "false" # do not use SSL between Traefik and oCIS
       PROXY_USER_OIDC_CLAIM: preferred_username
       PROXY_USER_CS3_CLAIM: username
       OCIS_ADMIN_USER_ID: ''
       OCIS_EXCLUDE_RUN_SERVICES: idp
       GRAPH_ASSIGN_DEFAULT_USER_ROLE: false
       GRAPH_USERNAME_MATCH: "none"
+      OCIS_LOG_LEVEL: "debug"
     restart: unless-stopped
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.ocis.entrypoints=https"
+      - "traefik.http.routers.ocis.rule=Host(`${OCIS_DOMAIN:-ocis.owncloud.test}`)"
+      - "traefik.http.routers.ocis.tls.certresolver=http"
+      - "traefik.http.routers.ocis.service=ocis"
+      - "traefik.http.services.ocis.loadbalancer.server.port=9200"
     healthcheck:
-      test: ["CMD", "curl", "https://ocis.sdk.test:9009/.well-known/openid-configuration", "-k", "-f"]
-      interval: 10s
-      timeout: 300s
+      test: ["CMD-SHELL", "curl http://localhost:9200/.well-known/openid-configuration | grep authorization_endpoint"]
+      interval: 1s
+      retries: 120
+      start_period: 20s
 
   postgres:
     image: postgres:alpine
-    extra_hosts:
-      - ocis.sdk.test:host-gateway
+    networks:
+      ocis-net:
     environment:
       POSTGRES_DB: keycloak
       POSTGRES_USER: keycloak
       POSTGRES_PASSWORD: keycloak
     volumes:
       - keycloak_data:/var/lib/postgresql/data
+    healthcheck:
+      test: [ "CMD", "pg_isready", "-q", "-U", "keycloak", "-d", "keycloak" ]
+      interval: 1s
+      retries: 120
 
   keycloak:
     build:
       context: docker/keycloak
-    extra_hosts:
-      - ocis.sdk.test:host-gateway
-    ports:
-      - 8443:8443
-      - 8080:8080
+    networks:
+      ocis-net:
     environment:
-      OCIS_DOMAIN: ocis.sdk.test:9009
-      KC_HOSTNAME: ocis.sdk.test:8443
+      OCIS_DOMAIN: ${OCIS_DOMAIN:-ocis.owncloud.test}
+      KC_HOSTNAME: ${KEYCLOAK_DOMAIN:-keycloak.owncloud.test}
       KC_DB: postgres
       KC_DB_URL: 'jdbc:postgresql://postgres:5432/keycloak'
       KC_DB_USERNAME: keycloak
@@ -62,8 +121,23 @@ services:
     volumes:
       - ./docker/keycloak/ocis-realm.dist.json:/opt/keycloak/data/import/ocis-realm.json
     depends_on:
-      - postgres
+      postgres:
+        condition: service_healthy
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.keycloak.entrypoints=https"
+      - "traefik.http.routers.keycloak.rule=Host(`${KEYCLOAK_DOMAIN:-keycloak.owncloud.test}`)"
+      - "traefik.http.routers.keycloak.tls.certresolver=http"
+      - "traefik.http.routers.keycloak.service=keycloak"
+      - "traefik.http.services.keycloak.loadbalancer.server.port=8080"
+    healthcheck:
+      test: ["CMD", "/opt/curl", "--head", "-k", "-f", "s", "S", "https://localhost:8443/health/ready"]
+      interval: 1s
+      retries: 120
 
 volumes:
   keycloak_data:
+  certs:
 
+networks:
+  ocis-net:

--- a/tests/integration/docker/keycloak/Dockerfile
+++ b/tests/integration/docker/keycloak/Dockerfile
@@ -1,19 +1,25 @@
-FROM ubuntu:22.04 AS gen-certs
+FROM ubuntu:22.04 AS dependencies
 
-RUN apt update && apt install -y openssl && \
+RUN apt update && apt install -y openssl wget && \
     mkdir -p /certs && cd /certs &&\
     openssl req -x509 -newkey rsa:2048 \
     -keyout keycloak.key \
     -out keycloak.crt \
     -sha256 -days 365 -batch -nodes && \
     mv keycloak.key keycloak.pem && \
-    cat keycloak.crt >> keycloak.pem
+    cat keycloak.crt >> keycloak.pem && \
+    wget https://github.com/moparisthebest/static-curl/releases/download/v8.4.0/curl-amd64 -O /tmp/curl && \
+    # download a static cURL binary and check its SHA sum
+    if [ "`sha256sum /tmp/curl | cut -d" " -f1`" != "f19a1ca90973ee955ae8e933f10158b60e8b5a7ed553d099d119e1e2bafc4270" ]; then echo "SHA sum of cURL binary not valid"; exit 1; fi
+
 
 FROM quay.io/keycloak/keycloak:22.0.4
 
 USER root
-COPY --from=gen-certs /certs /opt/keycloak/certs
+COPY --from=dependencies /certs /opt/keycloak/certs
+COPY --from=dependencies /tmp/curl /opt/curl
 RUN chown -R keycloak:root /opt/keycloak/certs
+RUN chmod +x /opt/curl
 
 USER keycloak
 
@@ -28,5 +34,6 @@ CMD [ \
     "--https-certificate-file=/opt/keycloak/certs/keycloak.crt", \
     "--https-certificate-key-file=/opt/keycloak/certs/keycloak.pem", \
     "--spi-connections-http-client-default-disable-trust-manager=true", \
-    "--import-realm" \
+    "--import-realm", \
+    "--health-enabled=true" \
     ]

--- a/tests/integration/docker/keycloak/ocis-realm.dist.json
+++ b/tests/integration/docker/keycloak/ocis-realm.dist.json
@@ -1115,18 +1115,18 @@
       "clientId": "web",
       "name": "",
       "description": "",
-      "rootUrl": "https://ocis.sdk.test:9009",
-      "adminUrl": "https://ocis.sdk.test:9009",
+      "rootUrl": "https://ocis.owncloud.test",
+      "adminUrl": "https://ocis.owncloud.test",
       "baseUrl": "",
       "surrogateAuthRequired": false,
       "enabled": true,
       "alwaysDisplayInConsole": false,
       "clientAuthenticatorType": "client-secret",
       "redirectUris": [
-        "https://ocis.sdk.test:9009/*"
+        "https://ocis.owncloud.test/*"
       ],
       "webOrigins": [
-        "https://ocis.sdk.test:9009"
+        "https://ocis.owncloud.test"
       ],
       "notBefore": 0,
       "bearerOnly": false,


### PR DESCRIPTION
1. use `ocis.owncloud.test` and `keycloak.owncloud.test` instead of ocis.sdk.test
2. don't use `host-gateway` to avoid firewall issues
3. add healthchecks for every service
4. start depending service only when the healthcheck of the previous passed, to make sure the tests are not executed too early
5. show more log messages for ocis
6. added instructions how to run integration tests into the README
