### PR TITLE
fix triggers for CI

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -38,12 +38,11 @@ config = {
 
 trigger = {
     "ref": [
-        "refs/head/main",
+        "refs/heads/main",
         "refs/pull/**",
         "refs/tags/**",
     ],
 }
-
 
 def main(ctx):
     return (
@@ -184,12 +183,7 @@ def docs():
                 },
             },
         ],
-        "trigger": {
-            "ref": [
-                "refs/heads/main",
-                "refs/pull/**",
-            ],
-        },
+        "trigger": trigger,
     }]
 
 def sonarAnalysis(ctx, phpVersion = DEFAULT_PHP_VERSION):
@@ -268,12 +262,6 @@ def sonarAnalysis(ctx, phpVersion = DEFAULT_PHP_VERSION):
         "depends_on": [
             "php-unit-test-%s" % DEFAULT_PHP_VERSION,
         ],
-        "trigger": {
-            "ref": [
-                "refs/heads/master",
-                "refs/pull/**",
-                "refs/tags/**",
-            ],
-        },
+        "trigger": trigger,
     }]
     return result


### PR DESCRIPTION
CI is only partly running on merges.
example:

![grafik](https://github.com/owncloud/ocis-php-sdk/assets/2425577/02c0f7f8-b3fa-41f6-a8cc-77bdc30745d3)


This should fix that by unifying all the triggers. There have been 2 mistakes with the triggers:
1. `"refs/head/main"` should be `"refs/heads/main"`
2. there is no master branch, so `"refs/heads/master"` should be `"refs/heads/main"`

