### PR TITLE
Update documentation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,10 +35,10 @@ test-php-unit: vendor/bin/phpunit
 	$(PHPUNIT) --configuration ./phpunit.xml --testsuite unit
 
 .PHONY: test-php-integration
-test-php-integration:             ## Run php integration tests
+test-php-integration:             ## Run single or whole php integration tests
 test-php-integration: run-ocis-with-keycloak
 	composer install
-	$(call run-with-cleanup, $(PHPUNIT) --configuration ./phpunit.xml --testsuite integration, $(MAKE) docker-clean)
+	$(call run-with-cleanup, $(PHPUNIT) --configuration ./phpunit.xml --testsuite integration $(if $(filter-out $@,$(MAKECMDGOALS)),--filter $(filter-out $@,$(MAKECMDGOALS)),), $(MAKE) docker-clean)
 
 .PHONY: test-php-integration-ci
 test-php-integration-ci:            ## Run php integration tests in CI

--- a/README.md
+++ b/README.md
@@ -18,8 +18,6 @@ docker run --rm -v ${PWD}:/data phpdoc/phpdoc:3
 
 After that you will find the documentation inside the `docs` folder.
 
-:exclamation: This SDK is still under heavy development and is not yet ready for production use, the API might change!
-
 ## Getting started
 Create an Ocis object using the service Url and an access token:
 ```php
@@ -86,14 +84,14 @@ $roles = $resources[0]->getRoles();
 
 // find the role that is allowed to read and write the shared file or folder 
 for ($roles as $role) {
-    if ($role->getDisplayName() === 'Editor') {
+    if ($role->getDisplayName() === 'Can edit') {
         $editorRole = $role;
         break;
     }
 }
 
 // find all users with a specific surname
-$users = $ocis->getUsers("gurung");
+$users = $ocis->getUsers("einstein")[0];
 
 // share the resource with the users
 $resources[0]->invite($users, $editorRole);
@@ -220,15 +218,29 @@ To test, simply open a browser and head to http://url-of-this-file.
 ## Development
 
 ### Integration tests
-The integration tests start a full oCIS server with keycloak and other services using docker.
 To run the tests locally
 1. Install and setup `docker` (min version 24) and `docker compose` (min version 2.21).
-2. add these lines to your `/etc/hosts` file:
+2. Ensure that the following php dependencies are installed for executing the integration tests:
+   ```
+   - php-curl
+   - php-dom
+   - php-phpdbg
+   - php-mbstring
+   - php-ast
+   ``` 
+3. add these lines to your `/etc/hosts` file:
    ```
    127.0.0.1	ocis.owncloud.test
    127.0.0.1	keycloak.owncloud.test
    ```
-3. run `make test-php-integration`
+4. run whole tests 
+   ```
+   make test-php-integration        // start a full oCIS server with keycloak and other services using docker before running tests
+   ```
+5. run single test 
+   ```
+   make test-php-integration testGetResources   // start a full oCIS server with keycloak and other services using docker before running single test
+   ```
 
-If something goes wrong, use `make clean` to clean the created containers and volumes. 
+   If something goes wrong, use `make clean` to clean the created containers and volumes. 
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,27 @@ docker run --rm -v ${PWD}:/data phpdoc/phpdoc:3
 
 After that you will find the documentation inside the `docs` folder.
 
+## Installation via Composer
+Add "owncloud/ocis-php-sdk" to the `require` block in your composer.json and then run composer install.
+> [!WARNING]  
+> The ocis-php-sdk currently relies on a development version of the "owncloud/libre-graph-api-php" package. To ensure proper dependency resolution, it is necessary to set "minimum-stability": "dev" and "prefer-stable": true in your composer.json file.
+
+```json
+{
+    "minimum-stability": "dev",
+    "prefer-stable": true,
+    "require": {
+        "owncloud/ocis-php-sdk": "^1.0"
+    }
+}
+```
+Alternatively, you can simply run the following from the command line:
+```bash
+composer config minimum-stability dev
+composer config prefer-stable true
+composer require owncloud/ocis-php-sdk
+```
+
 ## Getting started
 Create an Ocis object using the service Url and an access token:
 ```php


### PR DESCRIPTION
This PR adds documentation regarding php library required to run tests and updates documentation
added docs to install ocis-php-sdk using composer


Related issue
- https://github.com/owncloud/ocis-php-sdk/issues/19 https://github.com/owncloud/ocis-php-sdk/issues/191