### PR TITLE
reduce length of lines to permitted 120char

### DIFF
--- a/src/Drive.php
+++ b/src/Drive.php
@@ -30,7 +30,12 @@ class Drive
     private string $webDavUrl = '';
 
     /**
-     * @phpstan-var array{'headers'?:array<string, mixed>, 'verify'?:bool, 'webfinger'?:bool, 'guzzle'?:\GuzzleHttp\Client}
+     * @phpstan-var array{
+     *                      'headers'?:array<string, mixed>,
+     *                      'verify'?:bool,
+     *                      'webfinger'?:bool,
+     *                      'guzzle'?:\GuzzleHttp\Client
+     *                    }
      */
     private array $connectionConfig;
     private Configuration $graphApiConfig;
@@ -39,7 +44,12 @@ class Drive
     /**
      * @ignore The developer using the SDK does not need to create drives manually, but should use the Ocis class
      *         to get or create drives, so this constructor should not be listed in the documentation.
-     * @phpstan-param array{'headers'?:array<string, mixed>, 'verify'?:bool, 'webfinger'?:bool, 'guzzle'?:\GuzzleHttp\Client} $connectionConfig
+     * @phpstan-param array{
+     *                      'headers'?:array<string, mixed>,
+     *                      'verify'?:bool,
+     *                      'webfinger'?:bool,
+     *                      'guzzle'?:\GuzzleHttp\Client
+     *                      } $connectionConfig
      * @throws \InvalidArgumentException
      */
     public function __construct(
@@ -54,7 +64,8 @@ class Drive
         if (!Ocis::isConnectionConfigValid($connectionConfig)) {
             throw new \InvalidArgumentException('connection configuration not valid');
         }
-        $this->graphApiConfig = Configuration::getDefaultConfiguration()->setHost($this->serviceUrl . '/graph/v1.0');
+        $this->graphApiConfig = Configuration::getDefaultConfiguration()
+            ->setHost($this->serviceUrl . '/graph/v1.0');
 
         $this->connectionConfig = $connectionConfig;
     }

--- a/src/Notification.php
+++ b/src/Notification.php
@@ -39,7 +39,12 @@ class Notification
     private array $connectionConfig;
 
     /**
-     * @phpstan-param array{'headers'?:array<string, mixed>, 'verify'?:bool, 'webfinger'?:bool, 'guzzle'?:\GuzzleHttp\Client} $connectionConfig
+     * @phpstan-param array{
+     *                        'headers'?:array<string, mixed>,
+     *                        'verify'?:bool,
+     *                        'webfinger'?:bool,
+     *                        'guzzle'?:\GuzzleHttp\Client
+     *                        } $connectionConfig
      * @param array<mixed> $messageRichParameters
      * @throws \InvalidArgumentException
      * @ignore The developer using the SDK does not need to create notifications manually, but should use the Ocis class

--- a/src/Ocis.php
+++ b/src/Ocis.php
@@ -40,7 +40,12 @@ class Ocis
     private array $connectionConfig;
 
     /**
-     * @phpstan-param array{'headers'?:array<string, mixed>, 'verify'?:bool, 'webfinger'?:bool, 'guzzle'?:Client} $connectionConfig
+     * @phpstan-param array{
+     *                        'headers'?:array<string, mixed>,
+     *                        'verify'?:bool,
+     *                        'webfinger'?:bool,
+     *                        'guzzle'?:Client
+     *                        } $connectionConfig
      *        valid config keys are: headers, verify, webfinger, guzzle
      *        headers has to be an array in the form like
      *        [
@@ -93,7 +98,8 @@ class Ocis
 
     /**
      * @param array<mixed> $connectionConfig
-     * @ignore This function is used for internal purposes only and should not be shown in the documentation. The function is public to make it testable and because its also used from other classes.
+     * @ignore This function is used for internal purposes only and should not be shown in the documentation.
+     *         The function is public to make it testable and because its also used from other classes.
      */
     public static function isConnectionConfigValid(array $connectionConfig): bool
     {
@@ -132,10 +138,16 @@ class Ocis
      * Combines passed-in config settings for guzzle with the default settings needed
      * for the class and returns the complete array
      *
-     * @ignore This function is used for internal purposes only and should not be shown in the documentation. The function is public to make it testable.
-     * @phpstan-param array{'headers'?:array<string, mixed>, 'verify'?:bool, 'webfinger'?:bool, 'guzzle'?:Client} $connectionConfig
      * @return array<string, mixed>
      * @throws \InvalidArgumentException
+     * @ignore This function is used for internal purposes only and should not be shown in the documentation.
+     *         The function is public to make it testable.
+     * @phpstan-param array{
+     *                       'headers'?:array<string, mixed>,
+     *                       'verify'?:bool,
+     *                       'webfinger'?:bool,
+     *                       'guzzle'?:Client
+     *                       } $connectionConfig
      */
     public static function createGuzzleConfig(array $connectionConfig, string $accessToken): array
     {

--- a/src/OcisResource.php
+++ b/src/OcisResource.php
@@ -38,7 +38,9 @@ class OcisResource
             $metadata[$property->getKey()] = $this->metadata[$property->value];
         }
         if ($metadata === []) {
-            throw new InvalidResponseException('Could not find property "' . $property->getKey() . '" in response');
+            throw new InvalidResponseException(
+                'Could not find property "' . $property->getKey() . '" in response'
+            );
         }
         if ($metadata[$property->getKey()] === null && $property->getKey() !== "tags") {
             throw new InvalidResponseException('Invalid response from server');
@@ -46,8 +48,11 @@ class OcisResource
         if ($metadata[$property->getKey()] instanceof ResourceType) {
             return $metadata[$property->getKey()]->getValue();
         }
+        if ($metadata[$property->getKey()] === null) {
+            return (string)$metadata[$property->getKey()];
+        }
         /** @phpstan-ignore-next-line because next line might return mixed data*/
-        return  $metadata[$property->getKey()] === null ? (string)$metadata[$property->getKey()] : $metadata[$property->getKey()];
+        return $metadata[$property->getKey()];
     }
 
     /**
@@ -140,7 +145,9 @@ class OcisResource
         } elseif ($resourceType === []) {
             return "file";
         }
-        throw new InvalidResponseException("Received invalid data for the key \"resourcetype\" in the response array");
+        throw new InvalidResponseException(
+            "Received invalid data for the key \"resourcetype\" in the response array"
+        );
     }
 
     /**

--- a/src/WebDavClient.php
+++ b/src/WebDavClient.php
@@ -44,7 +44,12 @@ class WebDavClient extends Client
     }
 
     /**
-     * @phpstan-param array{'headers'?:array<string, mixed>, 'verify'?:bool, 'webfinger'?:bool, 'guzzle'?:\GuzzleHttp\Client} $connectionConfig
+     * @phpstan-param array{
+     *                      'headers'?:array<string, mixed>,
+     *                      'verify'?:bool,
+     *                      'webfinger'?:bool,
+     *                      'guzzle'?:\GuzzleHttp\Client
+     *                     } $connectionConfig
      * @return array<int, mixed>
      */
     public function createCurlSettings(array $connectionConfig, string $accessToken): array
@@ -67,8 +72,12 @@ class WebDavClient extends Client
     /**
      * set curl settings
      * enable exceptions for send method
-     * @phpstan-param array{'headers'?:array<string, mixed>, 'verify'?:bool, 'webfinger'?:bool, 'guzzle'?:\GuzzleHttp\Client} $connectionConfig
-     *
+     * @phpstan-param array{
+     *                       'headers'?:array<string, mixed>,
+     *                       'verify'?:bool,
+     *                       'webfinger'?:bool,
+     *                       'guzzle'?:\GuzzleHttp\Client
+     *                      } $connectionConfig     *
      */
     public function setCustomSetting(array $connectionConfig, string $accessToken): void
     {

--- a/tests/unit/Owncloud/OcisSdkPhp/OcisTest.php
+++ b/tests/unit/Owncloud/OcisSdkPhp/OcisTest.php
@@ -80,7 +80,9 @@ class OcisTest extends TestCase
     {
         $this->expectException(HttpException::class);
         $this->expectExceptionMessage(
-            "[0] cURL error 6: Could not resolve host: localhost-does-not-exist (see https://curl.haxx.se/libcurl/c/libcurl-errors.html) for https://localhost-does-not-exist:9200/graph/v1.0/drives"
+            "[0] cURL error 6: Could not resolve host: localhost-does-not-exist ".
+            "(see https://curl.haxx.se/libcurl/c/libcurl-errors.html) ".
+            "for https://localhost-does-not-exist:9200/graph/v1.0/drives"
         );
         $ocis = new Ocis('https://localhost-does-not-exist:9200', 'doesNotMatter');
         $ocis->createDrive('driveName');

--- a/tests/unit/Owncloud/OcisSdkPhp/OcisWebfingerTest.php
+++ b/tests/unit/Owncloud/OcisSdkPhp/OcisWebfingerTest.php
@@ -81,13 +81,27 @@ class OcisWebfingerTest extends TestCase
         return [
             ["onlyHeaderNoPayload"],
             ["header.butPäylöädNötBäs€64"],
-            ["header.cGF5bG9hZElzTm90SlNPTgo="], // payload is not JSON
-            ["header.InBheWxvYWRJc05vdEFuT2JqZWN0Igo="], // payload is not an JSON object
-            ["header.eyJrZXkiOiAidmFsdWUifQo="], // payload is a JSON object, but does not contain 'iss' key
-            ["header.eyJpc3MiOiBudWxsfQo="], // payload contains 'iss' key but the value is null
-            ["header.eyJpc3MiOiAiaHR0cHM6Ly8ifQo="], // payload contains 'iss' key but the value is 'https://'
-            ["header.eyJpc3MiOiAiaG9zdCJ9Cg=="], // payload contains 'iss' key but the value is 'host'
-            ["header.eyJpc3MiOiAiaHR0cHM6Ly86OTAwMCJ9Cg=="], // payload contains 'iss' key but the value is 'https://:9000'
+
+            // payload is not JSON
+            ["header.cGF5bG9hZElzTm90SlNPTgo="],
+
+            // payload is not an JSON object
+            ["header.InBheWxvYWRJc05vdEFuT2JqZWN0Igo="],
+
+            // payload is a JSON object, but does not contain 'iss' key
+            ["header.eyJrZXkiOiAidmFsdWUifQo="],
+
+            // payload contains 'iss' key but the value is null
+            ["header.eyJpc3MiOiBudWxsfQo="],
+
+            // payload contains 'iss' key but the value is 'https://'
+            ["header.eyJpc3MiOiAiaHR0cHM6Ly8ifQo="],
+
+            // payload contains 'iss' key but the value is 'host'
+            ["header.eyJpc3MiOiAiaG9zdCJ9Cg=="],
+
+            // payload contains 'iss' key but the value is 'https://:9000'
+            ["header.eyJpc3MiOiAiaHR0cHM6Ly86OTAwMCJ9Cg=="],
         ];
     }
     /**
@@ -115,11 +129,21 @@ class OcisWebfingerTest extends TestCase
     {
         return [
             ["notJson"],
-            ['{"subject": "acct:einstein@drive.ocis.test"}'], // no links
-            ['{"links": "string"}'], // links is not array
-            ['{"links": []}'], // links is an empty array
-            ['{"links": [{"rel": "http://openid.net/specs/connect/1.0/issuer"},{"rel": "http://something-unrelated"}]}'], //links don't have the correct rel
-            ['{"links": [{"rel": "http://webfinger.owncloud/rel/server-instance"}]}'], //correct rel, but no href
+
+            // no links
+            ['{"subject": "acct:einstein@drive.ocis.test"}'],
+
+            // links is not array
+            ['{"links": "string"}'],
+
+            // links is an empty array
+            ['{"links": []}'],
+
+            //links don't have the correct rel
+            ['{"links": [{"rel": "http://openid.net/specs/connect/1.0/issuer"},{"rel": "http://unrelated"}]}'],
+
+            //correct rel, but no href
+            ['{"links": [{"rel": "http://webfinger.owncloud/rel/server-instance"}]}'],
         ];
     }
 

--- a/tests/unit/Owncloud/OcisSdkPhp/ResourceTest.php
+++ b/tests/unit/Owncloud/OcisSdkPhp/ResourceTest.php
@@ -103,8 +103,12 @@ class ResourceTest extends TestCase
      *
      * @return void
      */
-    public function testGetSize(int|string $actualSize, int|string $expectedSize, null|string $data, string $sizeKey): void
-    {
+    public function testGetSize(
+        int|string $actualSize,
+        int|string $expectedSize,
+        null|string $data,
+        string $sizeKey
+    ): void {
         $metadata = [];
         $metadata['{DAV:}resourcetype'] = new ResourceType($data);
         $metadata[$sizeKey] = $actualSize;

--- a/tests/unit/Owncloud/OcisSdkPhp/WebDavClientTest.php
+++ b/tests/unit/Owncloud/OcisSdkPhp/WebDavClientTest.php
@@ -34,7 +34,12 @@ class WebDavClientTest extends TestCase
     }
 
     /**
-     * @phpstan-param array{'headers'?:array<string, mixed>, 'verify'?:bool, 'webfinger'?:bool, 'guzzle'?:\GuzzleHttp\Client} $connectionConfig
+     * @phpstan-param array{
+     *                      'headers'?:array<string, mixed>,
+     *                      'verify'?:bool,
+     *                      'webfinger'?:bool,
+     *                      'guzzle'?:\GuzzleHttp\Client
+     *                     } $connectionConfig
      * @param array<mixed> $expectedCurlSettingsArray
      * @dataProvider connectionConfigProvider
      */


### PR DESCRIPTION
Sonarcloud allows only 120char per line, what is a sensible maximum, so this PR splits the lines that are too long.

fixes #28
