### PR TITLE
Ignore files in /tests/output/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 composer.lock
 .php-cs-fixer.cache
 .phpunit.result.cache
-
+/tests/output/
 # phpDocumentor
 /cache/
 


### PR DESCRIPTION
to avoid accidentally committing things like `clover.xml` that can be generated locally when running unit tests.