### PR TITLE
Always run docker-clean after integration tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@
 # for v2: set this as docker-compose using the environment variable
 DCO:=docker compose
 PHPUNIT=phpdbg -qrr -d memory_limit=4096M -d zend.enable_gc=0 "vendor/bin/phpunit"
+run-with-cleanup = $(1) && $(2) || (ret=$$?; $(2) && exit $$ret)
 
 #
 # Catch-all rules
@@ -28,8 +29,7 @@ test-php-unit: vendor/bin/phpunit
 test-php-integration:             ## Run php integration tests
 test-php-integration: run-ocis-with-keycloak
 	composer install
-	$(PHPUNIT) --configuration ./phpunit.xml --testsuite integration
-	$(MAKE) docker-clean
+	$(call run-with-cleanup, $(PHPUNIT) --configuration ./phpunit.xml --testsuite integration, $(MAKE) docker-clean)
 
 .PHONY: test-php-style
 test-php-style:            ## Run php-cs-fixer and check code-style


### PR DESCRIPTION
Fixes #36 

I purposely ran a set of integration tests without ocis properly set up, so that they failed. This was the result:
```
ERRORS!
Tests: 5, Assertions: 0, Errors: 5.

Generating code coverage report in Clover XML format ... done [00:00.234]
make[1]: Entering directory '/home/phil/git/owncloud/ocis-php-sdk'
cd tests/integration && docker compose down -v --remove-orphans
[+] Running 7/7
 ✔ Container integration-keycloak-1  Removed                                                                                        0.4s 
 ✔ Container integration-traefik-1   Removed                                                                                        0.0s 
 ✔ Container integration-ocis-1      Removed                                                                                        0.4s 
 ✔ Container integration-postgres-1  Removed                                                                                        0.3s 
 ✔ Volume integration_certs          Removed                                                                                        0.0s 
 ✔ Volume integration_keycloak_data  Removed                                                                                        0.0s 
 ✔ Network integration_ocis-net      Removed                                                                                        0.1s 
make[1]: Leaving directory '/home/phil/git/owncloud/ocis-php-sdk'
make: *** [Makefile:32: test-php-integration] Error 2
phil@phil-Inspiron-5468:~/git/owncloud/ocis-php-sdk$ echo $?
2
```

`docker-clean` gets run, and the error code `2` of the integration test run is returned at the end of the "make".

Note: acknowledgement that I took the idea from https://gist.github.com/APTy/9a9eb218f68bc0b4beb133b89c9def14