### PR TITLE
check the connection config dynamically

### DIFF
--- a/src/Ocis.php
+++ b/src/Ocis.php
@@ -103,7 +103,7 @@ class Ocis
      * Helper function to check if the variable is a guzzle client
      * we need this because we want to call the check with call_user_func
      *
-     * @phpstan-ignore-next-line phpstan does not understand that this mdethod was called via call_user_func
+     * @phpstan-ignore-next-line phpstan does not understand that this method was called via call_user_func
      */
     private static function isGuzzleClient(mixed $guzzle): bool
     {

--- a/src/Ocis.php
+++ b/src/Ocis.php
@@ -103,7 +103,7 @@ class Ocis
      * Helper function to check if the variable is a guzzle client
      * we need this because we want to call the check with call_user_func
      *
-     * @phpstan-ignore-next-line phpstan does not understand that the was called via call_user_func
+     * @phpstan-ignore-next-line phpstan does not understand that this mdethod was called via call_user_func
      */
     private static function isGuzzleClient(mixed $guzzle): bool
     {
@@ -128,7 +128,7 @@ class Ocis
                 return false;
             }
 
-            // @phpstan-ignore-next-line phpstan does not understand that the `$check` is callable
+            // @phpstan-ignore-next-line phpstan does not understand that the `$validConnectionConfigKeys` array has values that are callable
             if (!\call_user_func($validConnectionConfigKeys[$key], $check)) {
                 return false;
             }

--- a/src/Ocis.php
+++ b/src/Ocis.php
@@ -100,6 +100,17 @@ class Ocis
     }
 
     /**
+     * Helper function to check if the variable is a guzzle client
+     * we need this because we want to call the check with call_user_func
+     *
+     * @phpstan-ignore-next-line phpstan does not understand that the was called via call_user_func
+     */
+    private static function isGuzzleClient(mixed $guzzle): bool
+    {
+        return $guzzle instanceof Client;
+    }
+
+    /**
      * @param array<mixed> $connectionConfig
      * @ignore This function is used for internal purposes only and should not be shown in the documentation.
      *         The function is public to make it testable and because its also used from other classes.
@@ -107,30 +118,18 @@ class Ocis
     public static function isConnectionConfigValid(array $connectionConfig): bool
     {
         $validConnectionConfigKeys = [
-            'headers' => [],
-            'verify' => true,
-            'webfinger' => true,
-            'guzzle' => Client::class
+            'headers' => 'is_array',
+            'verify' => 'is_bool',
+            'webfinger' => 'is_bool',
+            'guzzle' => 'self::isGuzzleClient'
         ];
-        foreach ($connectionConfig as $key => $value) {
+        foreach ($connectionConfig as $key => $check) {
             if (!array_key_exists($key, $validConnectionConfigKeys)) {
                 return false;
             }
-        }
-        if (array_key_exists('verify', $connectionConfig) && !is_bool($connectionConfig['verify'])) {
-            return false;
-        }
-        if (array_key_exists('webfinger', $connectionConfig) && !is_bool($connectionConfig['webfinger'])) {
-            return false;
-        }
-        if (
-            array_key_exists('guzzle', $connectionConfig) &&
-            !($connectionConfig['guzzle'] instanceof $validConnectionConfigKeys['guzzle'])
-        ) {
-            return false;
-        }
-        if (array_key_exists('headers', $connectionConfig)) {
-            if (!is_array($connectionConfig['headers'])) {
+
+            // @phpstan-ignore-next-line phpstan does not understand that the `$check` is callable
+            if (!\call_user_func($validConnectionConfigKeys[$key], $check)) {
                 return false;
             }
         }


### PR DESCRIPTION
with this check we don't need to write an `if` statement for every key, but can just give the check in the value of `$validConnectionConfigKeys`
this should also fix the sonar issue with too many return statements, see https://sonarcloud.io/project/issues?impactSeverities=MEDIUM&resolved=false&id=owncloud_ocis-php-sdk&open=AYsY7u6LwCB8P94PULzk

fixes #35
