### PR TITLE
reduce amount of parameters

### DIFF
--- a/src/Notification.php
+++ b/src/Notification.php
@@ -45,7 +45,18 @@ class Notification
      *                        'webfinger'?:bool,
      *                        'guzzle'?:\GuzzleHttp\Client
      *                        } $connectionConfig
-     * @param array<mixed> $messageRichParameters
+     * @phpstan-param object{
+     *    app: string,
+     *    user: string,
+     *    datetime: string,
+     *    object_id: string,
+     *    object_type: string,
+     *    subject: string,
+     *    subjectRich: string,
+     *    message: string,
+     *    messageRich: string,
+     *    messageRichParameters:array{int, mixed}
+     * } $notificationContent
      * @throws \InvalidArgumentException
      * @ignore The developer using the SDK does not need to create notifications manually, but should use the Ocis class
      *         to retrieve them, so this constructor should not be listed in the documentation.
@@ -55,28 +66,19 @@ class Notification
         array $connectionConfig,
         string $serviceUrl,
         string $id,
-        string $app,
-        string $user,
-        string $datetime,
-        string $objectId,
-        string $objectType,
-        string $subject,
-        string $subjectRich,
-        string $message,
-        string $messageRich,
-        array $messageRichParameters
+        $notificationContent
     ) {
         $this->id = $id;
-        $this->app = $app;
-        $this->user = $user;
-        $this->datetime = $datetime;
-        $this->objectId = $objectId;
-        $this->objectType = $objectType;
-        $this->subject = $subject;
-        $this->subjectRich = $subjectRich;
-        $this->message = $message;
-        $this->messageRich = $messageRich;
-        $this->messageRichParameters = $messageRichParameters;
+        $this->app = $notificationContent->app;
+        $this->user = $notificationContent->user;
+        $this->datetime = $notificationContent->datetime;
+        $this->objectId = $notificationContent->object_id;
+        $this->objectType = $notificationContent->object_type;
+        $this->subject = $notificationContent->subject;
+        $this->subjectRich = $notificationContent->subjectRich;
+        $this->message = $notificationContent->message;
+        $this->messageRich = $notificationContent->messageRich;
+        $this->messageRichParameters = $notificationContent->messageRichParameters;
         $this->accessToken = &$accessToken;
         $this->serviceUrl = $serviceUrl;
         if (!Ocis::isConnectionConfigValid($connectionConfig)) {

--- a/src/Ocis.php
+++ b/src/Ocis.php
@@ -20,6 +20,7 @@ use Owncloud\OcisPhpSdk\Exception\NotFoundException;
 use Owncloud\OcisPhpSdk\Exception\UnauthorizedException;
 use Owncloud\OcisPhpSdk\Exception\InvalidResponseException;
 use Sabre\HTTP\ResponseInterface;
+use stdClass;
 
 /**
  * Basic class to establish the connection to an ownCloud Infinite Scale instance
@@ -607,7 +608,21 @@ class Ocis
                 );
             }
             $id = $ocsData["notification_id"];
-            $notificationContent = [];
+            /**
+             * @phpstan-var object{
+             *    app: string,
+             *    user: string,
+             *    datetime: string,
+             *    object_id: string,
+             *    object_type: string,
+             *    subject: string,
+             *    subjectRich: string,
+             *    message: string,
+             *    messageRich: string,
+             *    messageRichParameters: array{int, mixed}
+             *  } $notificationContent
+             */
+            $notificationContent = new stdClass();
             foreach (
                 [
                     "app",
@@ -622,26 +637,18 @@ class Ocis
                 ] as $key
             ) {
                 if (!isset($ocsData[$key])) {
-                    $notificationContent[$key] = "";
+                    $notificationContent->$key = "";
                 }
             }
-            $messageRichParams = (isset($ocsData["messageRichParameters"])) ? $ocsData["messageRichParameters"] : [];
+            $notificationContent->{'messageRichParameters'} =
+                (isset($ocsData["messageRichParameters"])) ? $ocsData["messageRichParameters"] : [];
 
             $notifications[] = new Notification(
                 $this->accessToken,
                 $this->connectionConfig,
                 $this->serviceUrl,
                 $id,
-                $notificationContent["app"],
-                $notificationContent["user"],
-                $notificationContent["datetime"],
-                $notificationContent["object_id"],
-                $notificationContent["object_type"],
-                $notificationContent["subject"],
-                $notificationContent["subjectRich"],
-                $notificationContent["message"],
-                $notificationContent["messageRich"],
-                $messageRichParams
+                $notificationContent
             );
         }
         return $notifications;


### PR DESCRIPTION
this makes sonar cloud happy, see https://sonarcloud.io/project/issues?impactSeverities=MEDIUM&resolved=false&id=owncloud_ocis-php-sdk&open=AYsY7u7CwCB8P94PUL0R&tab=code
but I'm not sure if we should do that, feels like having less control over the types
