### PR TITLE
implementing sharing functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ for ($roles as $role) {
 }
 
 // find all users with a specific surname
-$users = $ocis->listUsers("gurung");
+$users = $ocis->getUsers("gurung");
 
 // share the resource with the users
 $resources[0]->invite($users, $editorRole);

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Notifications can be listed using the `listNotifications` method, which will ret
 The `Notification` object can retrieve details of the corresponding notification and mark it as read (delete).
 
 ## Sharing
-Given the correct permissions, an `OcisResouce` can be shared with a group or a user. To define the access permissions of the receiver the every share has to set `SharingRole`(s).
+Given the correct permissions, an `OcisResource` can be shared with a group or a user. To define the access permissions of the receiver every share has to set `SharingRole`(s).
 
 ```php
 // get the resources of a subfolder inside a drive

--- a/README.md
+++ b/README.md
@@ -74,6 +74,31 @@ Notifications can be listed using the `listNotifications` method, which will ret
 
 The `Notification` object can retrieve details of the corresponding notification and mark it as read (delete).
 
+## Sharing
+Given the correct permissions, an `OcisResouce` can be shared with a group or a user. To define the access permissions of the receiver the every share has to set `SharingRole`(s).
+
+```php
+// get the resources of a subfolder inside a drive
+$resources = $drive->listResources("/documents");
+
+// get all roles that are possible for that particular resource
+$roles = $resources[0]->getRoles();
+
+// find the role that is allowed to read and write the shared file or folder 
+for ($roles as $role) {
+    if ($role->getDisplayName() === 'Editor') {
+        $editorRole = $role;
+        break;
+    }
+}
+
+// find all users with a specific surname
+$users = $ocis->listUsers("gurung");
+
+// share the resource with the users
+$resources[0]->invite($users, $editorRole);
+```
+
 ## Requirements
 - PHP 8.1 or higher
 - oCIS 4.0.0 or higher

--- a/src/Drive.php
+++ b/src/Drive.php
@@ -292,7 +292,12 @@ class Drive
         try {
             $responses = $webDavClient->propFind(rawurlencode(ltrim($path, "/")), [], 1);
             foreach ($responses as $response) {
-                $resources[] = new OcisResource($response);
+                $resources[] = new OcisResource(
+                    $response,
+                    $this->connectionConfig,
+                    $this->serviceUrl,
+                    $this->accessToken
+                );
             }
             unset($resources[0]);
         } catch (SabreClientHttpException|SabreClientException $e) {

--- a/src/Ocis.php
+++ b/src/Ocis.php
@@ -7,6 +7,7 @@ use GuzzleHttp\Exception\ClientException as GuzzleClientException;
 use GuzzleHttp\Exception\GuzzleException;
 use OpenAPI\Client\Api\DrivesApi;
 use OpenAPI\Client\Api\DrivesGetDrivesApi;
+use OpenAPI\Client\Api\DrivesPermissionsApi;
 use OpenAPI\Client\Api\MeDrivesApi;
 use OpenAPI\Client\Api\UsersApi;
 use OpenAPI\Client\ApiException;
@@ -114,6 +115,17 @@ class Ocis
     }
 
     /**
+     * Helper function to check if the variable is a DrivesPermissionsApi
+     * we need this because we want to call the check with call_user_func
+     *
+     * @phpstan-ignore-next-line phpstan does not understand that this method was called via call_user_func
+     */
+    private static function isDrivesPermissionsApi(mixed $api): bool
+    {
+        return $api instanceof DrivesPermissionsApi;
+    }
+
+    /**
      * @param array<mixed> $connectionConfig
      * @ignore This function is used for internal purposes only and should not be shown in the documentation.
      *         The function is public to make it testable and because its also used from other classes.
@@ -124,7 +136,8 @@ class Ocis
             'headers' => 'is_array',
             'verify' => 'is_bool',
             'webfinger' => 'is_bool',
-            'guzzle' => 'self::isGuzzleClient'
+            'guzzle' => 'self::isGuzzleClient',
+            'drivesPermissionsApi' => 'self::isDrivesPermissionsApi'
         ];
         foreach ($connectionConfig as $key => $check) {
             if (!array_key_exists($key, $validConnectionConfigKeys)) {

--- a/src/OcisResource.php
+++ b/src/OcisResource.php
@@ -173,20 +173,20 @@ class OcisResource
      */
     public function invite($recipients, SharingRole $role, ?\DateTime $expiration = null): bool
     {
-        $requestObject = [];
-        $requestObject['recipients'] = [];
+        $driveItemInviteData = [];
+        $driveItemInviteData['recipients'] = [];
         foreach ($recipients as $recipient) {
-            $recipientRequestObject = [];
-            $recipientRequestObject['object_id'] = $recipient->getId();
+            $recipientData = [];
+            $recipientData['object_id'] = $recipient->getId();
             if ($recipient instanceof Group) {
-                $recipientRequestObject['at_libre_graph_recipient_type'] = "group";
+                $recipientData['at_libre_graph_recipient_type'] = "group";
             }
-            $requestObject['recipients'][] = new DriveRecipient($recipientRequestObject);
+            $driveItemInviteData['recipients'][] = new DriveRecipient($recipientData);
         }
-        $requestObject['roles'] = [$role->getId()];
+        $driveItemInviteData['roles'] = [$role->getId()];
         if ($expiration !== null) {
             $expiration->setTimezone(new \DateTimeZone('Z'));
-            $requestObject['expiration_date_time'] = $expiration->format('Y-m-d\TH:i:s:up');
+            $driveItemInviteData['expiration_date_time'] = $expiration->format('Y-m-d\TH:i:s:up');
         }
 
         if (array_key_exists('drivesPermissionsApi', $this->connectionConfig)) {
@@ -201,7 +201,7 @@ class OcisResource
             );
         }
 
-        $inviteData = new DriveItemInvite($requestObject);
+        $inviteData = new DriveItemInvite($driveItemInviteData);
         try {
             $permission = $apiInstance->invite($this->getSpaceId(), $this->getId(), $inviteData);
         } catch (ApiException $e) {

--- a/src/OcisResource.php
+++ b/src/OcisResource.php
@@ -179,7 +179,7 @@ class OcisResource
             $recipientRequestObject = [];
             $recipientRequestObject['object_id'] = $recipient->getId();
             if ($recipient instanceof Group) {
-                $recipientRequestObject['@libre.graph.recipient.type'] = "group";
+                $recipientRequestObject['at_libre_graph_recipient_type'] = "group";
             }
             $requestObject['recipients'][] = new DriveRecipient($recipientRequestObject);
         }

--- a/src/OcisResource.php
+++ b/src/OcisResource.php
@@ -64,7 +64,7 @@ class OcisResource
             throw new \InvalidArgumentException('connection configuration not valid');
         }
         $this->graphApiConfig = Configuration::getDefaultConfiguration()
-            ->setHost($this->serviceUrl . '/graph/v1.0');
+            ->setHost($this->serviceUrl . '/graph');
 
         $this->connectionConfig = $connectionConfig;
     }

--- a/src/OcisResource.php
+++ b/src/OcisResource.php
@@ -142,7 +142,7 @@ class OcisResource
             );
         }
         try {
-            $collectionOfPermissions = $apiInstance->listPermissions($this->getSpaceId(), $this->getId());
+            $collectionOfPermissions = $apiInstance->listPermissions($this->getId(), $this->getId());
         } catch (ApiException $e) {
             throw ExceptionHelper::getHttpErrorException($e);
         }
@@ -203,7 +203,7 @@ class OcisResource
 
         $inviteData = new DriveItemInvite($driveItemInviteData);
         try {
-            $permission = $apiInstance->invite($this->getSpaceId(), $this->getId(), $inviteData);
+            $permission = $apiInstance->invite($this->getId(), $this->getId(), $inviteData);
         } catch (ApiException $e) {
             throw ExceptionHelper::getHttpErrorException($e);
         }

--- a/src/OcisResource.php
+++ b/src/OcisResource.php
@@ -3,6 +3,7 @@
 namespace Owncloud\OcisPhpSdk;
 
 use Owncloud\OcisPhpSdk\Exception\InvalidResponseException;
+use phpDocumentor\Descriptor\Interfaces\FunctionInterface;
 use Sabre\DAV\Xml\Property\ResourceType;
 
 /**
@@ -73,6 +74,24 @@ class OcisResource
         return $metadata[$property->getKey()];
     }
 
+    /**
+     * gets all possible permissions for the resource
+     * @return array<SharingRole>
+     */
+    public function getRoles(): array
+    {
+
+    }
+
+    /**
+     * @param $recipients array<User|Group>
+     * @param $role SharingRole
+     * @return void
+     */
+    public function invite($recipients, $role, ?\DateTime $expiration = null)
+    {
+
+    }
     /**
      * @return string
      * @throws InvalidResponseException

--- a/src/SharingRole.php
+++ b/src/SharingRole.php
@@ -2,11 +2,70 @@
 
 namespace Owncloud\OcisPhpSdk;
 
+use OpenAPI\Client\Model\Permission;
+use OpenAPI\Client\Model\UnifiedRoleDefinition;
+use Owncloud\OcisPhpSdk\Exception\InvalidResponseException;
+
 /**
  * class to define a role of a user or group in a share
  * every role contains specific permissions
  */
 class SharingRole
 {
+    private string $id;
+    private string $displayName;
+    private string $description;
+    private int $weight;
+
+    /**
+     */
+    public function __construct(UnifiedRoleDefinition $apiRole)
+    {
+        $this->id = !is_string($apiRole->getId()) ?
+            throw new InvalidResponseException(
+                "Invalid id returned for role '" . print_r($apiRole->getId(), true) . "'"
+            )
+            : $apiRole->getId();
+        $this->displayName = !is_string($apiRole->getDisplayName()) ?
+            throw new InvalidResponseException(
+                "Invalid display name returned for role '" . print_r($apiRole->getId(), true) . "'"
+            )
+            : $apiRole->getDisplayName();
+        $this->description = !is_string($apiRole->getDescription()) ? "" : $apiRole->getDescription();
+        $this->weight = (int)$apiRole->getAtLibreGraphWeight();
+    }
+
+    /**
+     * @return string
+     */
+    public function getId(): string
+    {
+        return $this->id;
+    }
+
+    /**
+     * @return string
+     */
+    public function getDisplayName(): string
+    {
+        return $this->displayName;
+    }
+
+    /**
+     * @return string
+     */
+    public function getDescription(): string
+    {
+        return $this->description;
+    }
+
+    /**
+     * @return int
+     */
+    public function getWeight(): int
+    {
+        return $this->weight;
+    }
+
 
 }

--- a/src/SharingRole.php
+++ b/src/SharingRole.php
@@ -2,7 +2,6 @@
 
 namespace Owncloud\OcisPhpSdk;
 
-use OpenAPI\Client\Model\Permission;
 use OpenAPI\Client\Model\UnifiedRoleDefinition;
 use Owncloud\OcisPhpSdk\Exception\InvalidResponseException;
 

--- a/src/SharingRole.php
+++ b/src/SharingRole.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Owncloud\OcisPhpSdk;
+
+/**
+ * class to define a role of a user or group in a share
+ * every role contains specific permissions
+ */
+class SharingRole
+{
+
+}

--- a/src/SharingRole.php
+++ b/src/SharingRole.php
@@ -23,12 +23,14 @@ class SharingRole
     {
         $this->id = !is_string($apiRole->getId()) ?
             throw new InvalidResponseException(
-                "Invalid id returned for role '" . print_r($apiRole->getId(), true) . "'"
+                "Invalid id returned for sharing role '" . print_r($apiRole->getId(), true) . "'"
             )
             : $apiRole->getId();
         $this->displayName = !is_string($apiRole->getDisplayName()) ?
             throw new InvalidResponseException(
-                "Invalid display name returned for role '" . print_r($apiRole->getId(), true) . "'"
+                "Invalid display name returned for sharing role '" .
+                print_r($apiRole->getId(), true) .
+                "'"
             )
             : $apiRole->getDisplayName();
         $this->description = !is_string($apiRole->getDescription()) ? "" : $apiRole->getDescription();

--- a/tests/unit/Owncloud/OcisPhpSdk/ResourceInviteTest.php
+++ b/tests/unit/Owncloud/OcisPhpSdk/ResourceInviteTest.php
@@ -130,7 +130,7 @@ class ResourceInviteTest extends TestCase
         $drivesPermissionsApi = $this->createMock(DrivesPermissionsApi::class);
         $drivesPermissionsApi->method('invite')
             /** @phan-suppress-next-line PhanTypeMismatchArgumentProbablyReal */
-            ->with('uuid-of-the-space', 'uuid-of-the-resource', $expectedInviteData)
+            ->with('uuid-of-the-resource', 'uuid-of-the-resource', $expectedInviteData)
             ->willReturn($this->createMock(Permission::class));
         $accessToken = 'an-access-token';
         $connectionConfig = [
@@ -138,7 +138,6 @@ class ResourceInviteTest extends TestCase
         ];
         $resourceMetadata = [
             '{http://owncloud.org/ns}id' => 'uuid-of-the-resource',
-            '{http://owncloud.org/ns}spaceid' => 'uuid-of-the-space',
         ];
 
         $resource = new OcisResource(

--- a/tests/unit/Owncloud/OcisPhpSdk/ResourceInviteTest.php
+++ b/tests/unit/Owncloud/OcisPhpSdk/ResourceInviteTest.php
@@ -17,6 +17,9 @@ use PHPUnit\Framework\TestCase;
 
 class ResourceInviteTest extends TestCase
 {
+    /**
+     * @return array<mixed>
+     */
     public function inviteDataProvider(): array
     {
         $openAPIUser = new OpenAPIUser(
@@ -120,11 +123,13 @@ class ResourceInviteTest extends TestCase
 
     /**
      * @dataProvider inviteDataProvider
+     * @param array<int, User|Group> $recipients
      */
-    public function testInvite($recipients, $expiration, $expectedInviteData)
+    public function testInvite($recipients, \DateTime $expiration, DriveItemInvite $expectedInviteData): void
     {
         $drivesPermissionsApi = $this->createMock(DrivesPermissionsApi::class);
         $drivesPermissionsApi->method('invite')
+            /** @phan-suppress-next-line PhanTypeMismatchArgumentProbablyReal */
             ->with('uuid-of-the-space', 'uuid-of-the-resource', $expectedInviteData)
             ->willReturn($this->createMock(Permission::class));
         $accessToken = 'an-access-token';

--- a/tests/unit/Owncloud/OcisPhpSdk/ResourceInviteTest.php
+++ b/tests/unit/Owncloud/OcisPhpSdk/ResourceInviteTest.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace unit\Owncloud\OcisPhpSdk;
+
+use OpenAPI\Client\Api\DrivesPermissionsApi;
+use OpenAPI\Client\Model\Group as OpenAPIGroup;
+use OpenAPI\Client\Model\User as OpenAPIUser;
+use OpenAPI\Client\Model\Permission;
+use OpenAPI\Client\Model\UnifiedRoleDefinition;
+use Owncloud\OcisPhpSdk\Group;
+use Owncloud\OcisPhpSdk\OcisResource;
+use Owncloud\OcisPhpSdk\SharingRole;
+use Owncloud\OcisPhpSdk\User;
+use PHPUnit\Framework\TestCase;
+
+class ResourceInviteTest extends TestCase
+{
+    public function inviteDataProvider(): array
+    {
+        $openAPIUser = new OpenAPIUser(
+            [
+                'id' => 'uuid-of-einstein',
+                'display_name' => 'Albert Einstein',
+                'mail' => 'einstein@owncloud.np',
+                'on_premises_sam_account_name' => 'albert-einstein',
+            ]
+        );
+        $einstein = new User($openAPIUser);
+
+        $openAPIGroup = new OpenAPIGroup(
+            [
+                'id' => 'uuid-of-smart-people-group',
+                'display_name' => 'smart-people',
+            ]
+        );
+        $smartPeopleGroup = new Group($openAPIGroup);
+
+        return [
+            // invite for a single recipient
+            [[$einstein], null, '{"recipients":[{"objectId":"uuid-of-einstein"}],"roles":["uuid-of-the-role"]}'],
+            // invite a user and a group
+            [
+                [$einstein, $smartPeopleGroup],
+                null,
+                '{'.
+                    '"recipients":' .
+                        '[' .
+                            '{"objectId":"uuid-of-einstein"},' .
+                            '{"objectId":"uuid-of-smart-people-group","@libre.graph.recipient.type":"group"}],' .
+                    '"roles":["uuid-of-the-role"]' .
+                '}'
+            ],
+            // invite a user and set expiry time
+            [
+                [$einstein],
+                new \DateTime('2021-01-01 17:45:43.123456', new \DateTimeZone('Asia/Kathmandu')),
+                '{' .
+                    '"recipients":[{"objectId":"uuid-of-einstein"}],' .
+                    '"roles":["uuid-of-the-role"],' .
+                    '"expirationDateTime":"2021-01-01T12:00:43:123456Z"' .
+                '}'
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider inviteDataProvider
+     */
+    public function testInvite($recipients, $expiration, $expectedBody)
+    {
+        $drivesPermissionsApi = $this->createMock(DrivesPermissionsApi::class);
+        $drivesPermissionsApi->method('invite')
+            ->with('uuid-of-the-space', 'uuid-of-the-resource', $expectedBody)
+            ->willReturn($this->createMock(Permission::class));
+        $accessToken = 'an-access-token';
+        $connectionConfig = [
+            'drivesPermissionsApi' => $drivesPermissionsApi,
+        ];
+        $resourceMetadata = [
+            '{http://owncloud.org/ns}id' => 'uuid-of-the-resource',
+            '{http://owncloud.org/ns}spaceid' => 'uuid-of-the-space',
+        ];
+
+        $resource = new OcisResource(
+            $resourceMetadata,
+            $connectionConfig,
+            'http://ocis',
+            $accessToken
+        );
+
+        $openAPIRole = new UnifiedRoleDefinition(
+            [
+                'id' => 'uuid-of-the-role',
+                'display_name' => 'Manager'
+            ],
+        );
+        $role = new SharingRole($openAPIRole);
+
+        $result = $resource->invite($recipients, $role, $expiration);
+        $this->assertTrue($result);
+    }
+}

--- a/tests/unit/Owncloud/OcisPhpSdk/ResourceInviteTest.php
+++ b/tests/unit/Owncloud/OcisPhpSdk/ResourceInviteTest.php
@@ -125,7 +125,7 @@ class ResourceInviteTest extends TestCase
      * @dataProvider inviteDataProvider
      * @param array<int, User|Group> $recipients
      */
-    public function testInvite($recipients, \DateTime $expiration, DriveItemInvite $expectedInviteData): void
+    public function testInvite($recipients, ?\DateTime $expiration, DriveItemInvite $expectedInviteData): void
     {
         $drivesPermissionsApi = $this->createMock(DrivesPermissionsApi::class);
         $drivesPermissionsApi->method('invite')

--- a/tests/unit/Owncloud/OcisPhpSdk/ResourceTest.php
+++ b/tests/unit/Owncloud/OcisPhpSdk/ResourceTest.php
@@ -34,20 +34,6 @@ class ResourceTest extends TestCase
     }
 
     /**
-     * @param array<mixed> $metadata
-     * @return OcisResource
-     */
-    private function createOcisResouce(array $metadata): OcisResource
-    {
-        $accessToken = 'aaa';
-        return new OcisResource(
-            $metadata,
-            [],
-            '',
-            $accessToken
-        );
-    }
-    /**
      * @return void
      * @dataProvider dataProviderValidFileType
      */
@@ -55,7 +41,7 @@ class ResourceTest extends TestCase
     {
         $metadata = [];
         $metadata['{DAV:}resourcetype'] = new ResourceType($resourceType);
-        $resource = $this->createOcisResouce($metadata);
+        $resource = new OcisResource($metadata);
         $result = $resource->getType();
         $this->assertSame($expectedResult, $result);
     }
@@ -85,7 +71,7 @@ class ResourceTest extends TestCase
         $this->expectException(InvalidResponseException::class);
         $this->expectExceptionMessage("Received invalid data for the key \"resourcetype\" in the response array");
         $metadata['{DAV:}resourcetype'] = new ResourceType($resourceType);
-        $resource = $this->createOcisResouce($metadata);
+        $resource = new OcisResource($metadata);
         $result = $resource->getType();
     }
 
@@ -126,7 +112,7 @@ class ResourceTest extends TestCase
         $metadata = [];
         $metadata['{DAV:}resourcetype'] = new ResourceType($data);
         $metadata[$sizeKey] = $actualSize;
-        $resource = $this->createOcisResouce($metadata);
+        $resource = new OcisResource($metadata);
         $result = $resource->getSize();
         $this->assertSame($expectedSize, $result);
     }
@@ -152,7 +138,7 @@ class ResourceTest extends TestCase
         $this->expectExceptionMessage("Received an invalid value for size in the response");
         $metadata['{DAV:}resourcetype'] = new ResourceType($data);
         $metadata[$sizeKey] = $actualSize;
-        $resource = $this->createOcisResouce($metadata);
+        $resource = new OcisResource($metadata);
         $result = $resource->getSize();
     }
 
@@ -181,7 +167,7 @@ class ResourceTest extends TestCase
         $metadata = [];
         $metadata['{DAV:}resourcetype'] = new ResourceType($fileType);
         $metadata['{DAV:}getcontenttype'] = $expectedResult;
-        $resource = $this->createOcisResouce($metadata);
+        $resource = new OcisResource($metadata);
         $result = $resource->getContentType();
         $this->assertSame($expectedResult, $result);
     }
@@ -195,7 +181,7 @@ class ResourceTest extends TestCase
         $tags = [["mytag"], ["asd", "asd"], [''], [null]];
         foreach ($tags as $tag) {
             $metadata['{http://owncloud.org/ns}tags'] = implode(',', $tag);
-            $resource = $this->createOcisResouce($metadata);
+            $resource = new OcisResource($metadata);
             $result = $resource->getTags();
             if ($tag === [null] || $tag === ['']) {
                 $tag = [];
@@ -223,7 +209,7 @@ class ResourceTest extends TestCase
     {
         $metadata = [];
         $metadata['{http://owncloud.org/ns}favorite'] = $value;
-        $resource = $this->createOcisResouce($metadata);
+        $resource = new OcisResource($metadata);
         $result = $resource->isFavorited();
         $this->assertIsBool($result);
         $this->assertSame($result, (bool)$value);
@@ -249,7 +235,7 @@ class ResourceTest extends TestCase
         $this->expectException(InvalidResponseException::class);
         $this->expectExceptionMessage("Value of property \"favorite\" invalid in the server response");
         $metadata['{http://owncloud.org/ns}favorite'] = $value;
-        $resource = $this->createOcisResouce($metadata);
+        $resource = new OcisResource($metadata);
         $resource->isFavorited();
     }
 
@@ -278,7 +264,7 @@ class ResourceTest extends TestCase
         $metadata['{DAV:}resourcetype'] = new ResourceType($fileType);
         $metadata['{DAV:}getcontentlength'] = 1;
         $metadata['{http://owncloud.org/ns}checksums'] = $value;
-        $resource = $this->createOcisResouce($metadata);
+        $resource = new OcisResource($metadata);
         $result = $resource->getCheckSums();
         $this->assertEquals($value, $result);
     }
@@ -295,7 +281,7 @@ class ResourceTest extends TestCase
             } else {
                 $metadata['{http://owncloud.org/ns}' . $property] = $property;
             }
-            $resource = $this->createOcisResouce($metadata);
+            $resource = new OcisResource($metadata);
             $result = $resource->$properytFunc();
             $this->assertSame($property, $result);
         }
@@ -309,7 +295,7 @@ class ResourceTest extends TestCase
         $metadata = [];
         foreach ($this->properties as ['property' => $property, "function" => $properytFunc]) {
             $metadata[''] = $property;
-            $resource = $this->createOcisResouce($metadata);
+            $resource = new OcisResource($metadata);
             $result = null;
             try {
                 $result = $resource->$properytFunc();
@@ -332,7 +318,7 @@ class ResourceTest extends TestCase
             } else {
                 $metadata['{http://owncloud.org/ns}' . $property] = null;
             }
-            $resource = $this->createOcisResouce($metadata);
+            $resource = new OcisResource($metadata);
             $result = null;
             try {
                 $result = $resource->$properytFunc();

--- a/tests/unit/Owncloud/OcisPhpSdk/ResourceTest.php
+++ b/tests/unit/Owncloud/OcisPhpSdk/ResourceTest.php
@@ -34,6 +34,20 @@ class ResourceTest extends TestCase
     }
 
     /**
+     * @param array<mixed> $metadata
+     * @return OcisResource
+     */
+    private function createOcisResouce(array $metadata): OcisResource
+    {
+        $accessToken = 'aaa';
+        return new OcisResource(
+            $metadata,
+            [],
+            '',
+            $accessToken
+        );
+    }
+    /**
      * @return void
      * @dataProvider dataProviderValidFileType
      */
@@ -41,7 +55,7 @@ class ResourceTest extends TestCase
     {
         $metadata = [];
         $metadata['{DAV:}resourcetype'] = new ResourceType($resourceType);
-        $resource = new OcisResource($metadata);
+        $resource = $this->createOcisResouce($metadata);
         $result = $resource->getType();
         $this->assertSame($expectedResult, $result);
     }
@@ -71,7 +85,7 @@ class ResourceTest extends TestCase
         $this->expectException(InvalidResponseException::class);
         $this->expectExceptionMessage("Received invalid data for the key \"resourcetype\" in the response array");
         $metadata['{DAV:}resourcetype'] = new ResourceType($resourceType);
-        $resource = new OcisResource($metadata);
+        $resource = $this->createOcisResouce($metadata);
         $result = $resource->getType();
     }
 
@@ -112,7 +126,7 @@ class ResourceTest extends TestCase
         $metadata = [];
         $metadata['{DAV:}resourcetype'] = new ResourceType($data);
         $metadata[$sizeKey] = $actualSize;
-        $resource = new OcisResource($metadata);
+        $resource = $this->createOcisResouce($metadata);
         $result = $resource->getSize();
         $this->assertSame($expectedSize, $result);
     }
@@ -138,7 +152,7 @@ class ResourceTest extends TestCase
         $this->expectExceptionMessage("Received an invalid value for size in the response");
         $metadata['{DAV:}resourcetype'] = new ResourceType($data);
         $metadata[$sizeKey] = $actualSize;
-        $resource = new OcisResource($metadata);
+        $resource = $this->createOcisResouce($metadata);
         $result = $resource->getSize();
     }
 
@@ -167,7 +181,7 @@ class ResourceTest extends TestCase
         $metadata = [];
         $metadata['{DAV:}resourcetype'] = new ResourceType($fileType);
         $metadata['{DAV:}getcontenttype'] = $expectedResult;
-        $resource = new OcisResource($metadata);
+        $resource = $this->createOcisResouce($metadata);
         $result = $resource->getContentType();
         $this->assertSame($expectedResult, $result);
     }
@@ -181,7 +195,7 @@ class ResourceTest extends TestCase
         $tags = [["mytag"], ["asd", "asd"], [''], [null]];
         foreach ($tags as $tag) {
             $metadata['{http://owncloud.org/ns}tags'] = implode(',', $tag);
-            $resource = new OcisResource($metadata);
+            $resource = $this->createOcisResouce($metadata);
             $result = $resource->getTags();
             if ($tag === [null] || $tag === ['']) {
                 $tag = [];
@@ -209,7 +223,7 @@ class ResourceTest extends TestCase
     {
         $metadata = [];
         $metadata['{http://owncloud.org/ns}favorite'] = $value;
-        $resource = new OcisResource($metadata);
+        $resource = $this->createOcisResouce($metadata);
         $result = $resource->isFavorited();
         $this->assertIsBool($result);
         $this->assertSame($result, (bool)$value);
@@ -235,7 +249,7 @@ class ResourceTest extends TestCase
         $this->expectException(InvalidResponseException::class);
         $this->expectExceptionMessage("Value of property \"favorite\" invalid in the server response");
         $metadata['{http://owncloud.org/ns}favorite'] = $value;
-        $resource = new OcisResource($metadata);
+        $resource = $this->createOcisResouce($metadata);
         $resource->isFavorited();
     }
 
@@ -264,7 +278,7 @@ class ResourceTest extends TestCase
         $metadata['{DAV:}resourcetype'] = new ResourceType($fileType);
         $metadata['{DAV:}getcontentlength'] = 1;
         $metadata['{http://owncloud.org/ns}checksums'] = $value;
-        $resource = new OcisResource($metadata);
+        $resource = $this->createOcisResouce($metadata);
         $result = $resource->getCheckSums();
         $this->assertEquals($value, $result);
     }
@@ -281,7 +295,7 @@ class ResourceTest extends TestCase
             } else {
                 $metadata['{http://owncloud.org/ns}' . $property] = $property;
             }
-            $resource = new OcisResource($metadata);
+            $resource = $this->createOcisResouce($metadata);
             $result = $resource->$properytFunc();
             $this->assertSame($property, $result);
         }
@@ -295,7 +309,7 @@ class ResourceTest extends TestCase
         $metadata = [];
         foreach ($this->properties as ['property' => $property, "function" => $properytFunc]) {
             $metadata[''] = $property;
-            $resource = new OcisResource($metadata);
+            $resource = $this->createOcisResouce($metadata);
             $result = null;
             try {
                 $result = $resource->$properytFunc();
@@ -318,7 +332,7 @@ class ResourceTest extends TestCase
             } else {
                 $metadata['{http://owncloud.org/ns}' . $property] = null;
             }
-            $resource = new OcisResource($metadata);
+            $resource = $this->createOcisResouce($metadata);
             $result = null;
             try {
                 $result = $resource->$properytFunc();


### PR DESCRIPTION
Implementing sharing of resources.

Sharing (invite) can happen on any resource.
Before the invite we need recipients (groups or users) and a role. The possible roles are retrieved from the item `"@libre.graph.permissions.roles.allowedValues"` in [/v1beta1/drives/{drive-id}/items/{item-id}/permissions](https://owncloud.dev/libre-graph-api/#/drives.permissions/ListPermissions)