### PR TITLE
get coverage of integration tests

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -29,4 +29,4 @@ sonar.pullrequest.branch=${env.SONAR_PULL_REQUEST_BRANCH}
 sonar.pullrequest.key=${env.SONAR_PULL_REQUEST_KEY}
 
 # Properties specific to language plugins:
-sonar.php.coverage.reportPaths=results/clover-php-unit-test-8.1.xml
+sonar.php.coverage.reportPaths=results/clover-php-unit-test-8.1.xml,results/clover-php-integration-test-8.1.xml


### PR DESCRIPTION
with this PR we
1. run the integration tests with PHP 8.1 and 8.2
2. collect the coverage data from the integration tests and make sonar analyze it

current coverage shows 61% and after this PR its estimated to be 71.2%, so sonarcloud did pick up the changes

fixes #17 