### PR TITLE
function to get/search users

### DIFF
--- a/tests/integration/Owncloud/OcisSdkPhp/OcisPhpSdkTestCase.php
+++ b/tests/integration/Owncloud/OcisSdkPhp/OcisPhpSdkTestCase.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace integration\Owncloud\OcisPhpSdk;
+
+require_once __DIR__ . '/OcisPhpSdkTestCase.php';
+
+use GuzzleHttp\Client;
+use Owncloud\OcisPhpSdk\Ocis;
+use PHPUnit\Framework\TestCase;
+
+class OcisPhpStdTestCase extends TestCase
+{
+    private const CLIENT_ID = 'xdXOt13JKxym1B1QcEncf2XDkLAexMBFwiT9j6EfhhHFJhs2KM9jbjTmf8JBXE69';
+    private const CLIENT_SECRET = 'UBntmLjC2yYCeHwsyj73Uwo9TAaecAetRwMw0xYcvNL9yRdLSUi0hUAHfvCHFeFh';
+    protected const UUID_REGEX_PATTERN = '/^[0-9A-F]{8}-[0-9A-F]{4}-4[0-9A-F]{3}-[89AB][0-9A-F]{3}-[0-9A-F]{12}\$[0-9A-F]{8}-[0-9A-F]{4}-4[0-9A-F]{3}-[89AB][0-9A-F]{3}-[0-9A-F]{12}$/i';
+    protected string $ocisUrl;
+    private ?string $tokenUrl = null;
+    private ?Client $guzzleClient = null;
+    /**
+     * @var array <string>
+     */
+    protected $createdDrives = [];
+
+    public function setUp(): void
+    {
+        $this->ocisUrl = getenv('OCIS_URL') ?: 'https://ocis.owncloud.test';
+        $guzzleClient = $this->getGuzzleClient();
+        $response = $guzzleClient->get('.well-known/openid-configuration');
+        $openIdConfigurationRaw = $response->getBody()->getContents();
+        $openIdConfiguration = json_decode($openIdConfigurationRaw, true);
+        if ($openIdConfiguration === null) {
+            throw new \Exception('Could not decode openid configuration');
+        }
+        // @phpstan-ignore-next-line
+        $this->tokenUrl = $openIdConfiguration['token_endpoint'];
+    }
+
+    public function tearDown(): void
+    {
+        $token = $this->getAccessToken('admin', 'admin');
+        $ocis = new Ocis($this->ocisUrl, $token, ['verify' => false]);
+        foreach ($this->createdDrives as $driveId) {
+            $drive = $ocis->getDriveById($driveId);
+            $drive->disable();
+            $drive->delete();
+        }
+    }
+
+    protected function getGuzzleClient(): Client
+    {
+        if ($this->guzzleClient !== null) {
+            return $this->guzzleClient;
+        }
+        $guzzleClient = new Client([
+            'base_uri' => $this->ocisUrl,
+            'verify' => false
+        ]);
+        $this->guzzleClient = $guzzleClient;
+        return $this->guzzleClient;
+    }
+
+    protected function getAccessToken(string $username, string $password): string
+    {
+        $guzzleClient = $this->getGuzzleClient();
+        $response = $guzzleClient->post((string)$this->tokenUrl, [
+            'form_params' => [
+                'grant_type' => 'password',
+                'client_id' => self::CLIENT_ID,
+                'client_secret' => self::CLIENT_SECRET,
+                'username' => $username,
+                'password' => $password,
+                'scope' => 'openid profile email offline_access'
+            ]
+        ]);
+        $accessTokenResponse = json_decode($response->getBody()->getContents(), true);
+        if ($accessTokenResponse === null) {
+            throw new \Exception('Could not decode token response');
+        }
+        // @phpstan-ignore-next-line
+        return $accessTokenResponse['access_token'];
+    }
+}

--- a/tests/integration/Owncloud/OcisSdkPhp/OcisTest.php
+++ b/tests/integration/Owncloud/OcisSdkPhp/OcisTest.php
@@ -2,85 +2,16 @@
 
 namespace integration\Owncloud\OcisPhpSdk;
 
-use GuzzleHttp\Client;
+require_once __DIR__ . '/OcisPhpSdkTestCase.php';
+
 use Owncloud\OcisPhpSdk\Exception\ForbiddenException;
 use Owncloud\OcisPhpSdk\Group;
 use Owncloud\OcisPhpSdk\Ocis;
 use Owncloud\OcisPhpSdk\OrderDirection;
-use PHPUnit\Framework\TestCase;
 
-class OcisTest extends TestCase
+class OcisTest extends OcisPhpStdTestCase
 {
-    private const CLIENT_ID = 'xdXOt13JKxym1B1QcEncf2XDkLAexMBFwiT9j6EfhhHFJhs2KM9jbjTmf8JBXE69';
-    private const CLIENT_SECRET = 'UBntmLjC2yYCeHwsyj73Uwo9TAaecAetRwMw0xYcvNL9yRdLSUi0hUAHfvCHFeFh';
-    private const UUID_REGEX_PATTERN = '/^[0-9A-F]{8}-[0-9A-F]{4}-4[0-9A-F]{3}-[89AB][0-9A-F]{3}-[0-9A-F]{12}\$[0-9A-F]{8}-[0-9A-F]{4}-4[0-9A-F]{3}-[89AB][0-9A-F]{3}-[0-9A-F]{12}$/i';
-    private string $ocisUrl;
-    private ?string $tokenUrl = null;
-    private ?Client $guzzleClient = null;
-    /**
-     * @var array <string>
-     */
-    private $createdDrives = [];
     private const GROUP_COUNT = 0;
-
-    public function setUp(): void
-    {
-        $this->ocisUrl = getenv('OCIS_URL') ?: 'https://ocis.owncloud.test';
-        $guzzleClient = $this->getGuzzleClient();
-        $response = $guzzleClient->get('.well-known/openid-configuration');
-        $openIdConfigurationRaw = $response->getBody()->getContents();
-        $openIdConfiguration = json_decode($openIdConfigurationRaw, true);
-        if ($openIdConfiguration === null) {
-            throw new \Exception('Could not decode openid configuration');
-        }
-        // @phpstan-ignore-next-line
-        $this->tokenUrl = $openIdConfiguration['token_endpoint'];
-    }
-
-    public function tearDown(): void
-    {
-        $token = $this->getAccessToken('admin', 'admin');
-        $ocis = new Ocis($this->ocisUrl, $token, ['verify' => false]);
-        foreach ($this->createdDrives as $driveId) {
-            $drive = $ocis->getDriveById($driveId);
-            $drive->disable();
-            $drive->delete();
-        }
-    }
-
-    private function getGuzzleClient(): Client
-    {
-        if ($this->guzzleClient !== null) {
-            return $this->guzzleClient;
-        }
-        $guzzleClient = new Client([
-            'base_uri' => $this->ocisUrl,
-            'verify' => false
-        ]);
-        $this->guzzleClient = $guzzleClient;
-        return $this->guzzleClient;
-    }
-
-    private function getAccessToken(string $username, string $password): string
-    {
-        $guzzleClient = $this->getGuzzleClient();
-        $response = $guzzleClient->post((string)$this->tokenUrl, [
-            'form_params' => [
-                'grant_type' => 'password',
-                'client_id' => self::CLIENT_ID,
-                'client_secret' => self::CLIENT_SECRET,
-                'username' => $username,
-                'password' => $password,
-                'scope' => 'openid profile email offline_access'
-            ]
-        ]);
-        $accessTokenResponse = json_decode($response->getBody()->getContents(), true);
-        if ($accessTokenResponse === null) {
-            throw new \Exception('Could not decode token response');
-        }
-        // @phpstan-ignore-next-line
-        return $accessTokenResponse['access_token'];
-    }
 
     public function testServiceUrlTrailingSlash(): void
     {

--- a/tests/integration/Owncloud/OcisSdkPhp/UsersTest.php
+++ b/tests/integration/Owncloud/OcisSdkPhp/UsersTest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace integration\Owncloud\OcisPhpSdk;
+
+require_once __DIR__ . '/OcisPhpSdkTestCase.php';
+
+use Owncloud\OcisPhpSdk\Exception\UnauthorizedException;
+use Owncloud\OcisPhpSdk\Ocis;
+
+class UsersTest extends OcisPhpStdTestCase
+{
+    /**
+     * init a user
+     * ocis is only aware of users after the first login, because we are using keycloak
+     */
+    private function initUser(string $name, string $password): void
+    {
+        $token = $this->getAccessToken($name, $password);
+        $ocis = new Ocis($this->ocisUrl, $token, ['verify' => false]);
+        $ocis->listMyDrives();
+    }
+
+    public function testGetAllUsers(): void
+    {
+        $this->initUser('einstein', 'relativity');
+        $this->initUser('marie', 'radioactivity');
+        $token = $this->getAccessToken('admin', 'admin');
+
+        $ocis = new Ocis($this->ocisUrl, $token, ['verify' => false]);
+        $users = $ocis->getUsers();
+        $this->assertContainsOnly('Owncloud\OcisPhpSdk\User', $users);
+        $this->assertGreaterThanOrEqual(3, $users);
+    }
+
+    public function testSearchUsers(): void
+    {
+        $this->initUser('marie', 'radioactivity');
+        $this->initUser('einstein', 'relativity');
+        $this->initUser('moss', 'vista');
+        $this->initUser('katherine', 'gemini');
+        $token = $this->getAccessToken('admin', 'admin');
+        $ocis = new Ocis($this->ocisUrl, $token, ['verify' => false]);
+        $users = $ocis->getUsers('Albert');
+        $this->assertContainsOnly('Owncloud\OcisPhpSdk\User', $users);
+        $this->assertCount(1, $users);
+        $this->assertSame('Albert Einstein', $users[0]->getDisplayName());
+    }
+
+    public function testGetAllUsersAsUnprivilegedUser(): void
+    {
+        $this->expectException(UnauthorizedException::class);
+        $this->initUser('marie', 'radioactivity');
+        $token = $this->getAccessToken('einstein', 'relativity');
+
+        $ocis = new Ocis($this->ocisUrl, $token, ['verify' => false]);
+        $users = $ocis->getUsers();
+        $this->assertContainsOnly('Owncloud\OcisPhpSdk\User', $users);
+        $this->assertGreaterThanOrEqual(3, $users);
+    }
+}


### PR DESCRIPTION
To do sharing, we first need user objects to share with. We don't want the programmer to have to initiate users, so they need to come from ocis.
This PR implements a function to get users from oCIS
