### PR TITLE
fix typos in integration tests

### DIFF
--- a/tests/integration/Owncloud/OcisPhpSdk/OcisPhpSdkTestCase.php
+++ b/tests/integration/Owncloud/OcisPhpSdk/OcisPhpSdkTestCase.php
@@ -8,7 +8,7 @@ use GuzzleHttp\Client;
 use Owncloud\OcisPhpSdk\Ocis;
 use PHPUnit\Framework\TestCase;
 
-class OcisPhpStdTestCase extends TestCase
+class OcisPhpSdkTestCase extends TestCase
 {
     private const CLIENT_ID = 'xdXOt13JKxym1B1QcEncf2XDkLAexMBFwiT9j6EfhhHFJhs2KM9jbjTmf8JBXE69';
     private const CLIENT_SECRET = 'UBntmLjC2yYCeHwsyj73Uwo9TAaecAetRwMw0xYcvNL9yRdLSUi0hUAHfvCHFeFh';

--- a/tests/integration/Owncloud/OcisPhpSdk/OcisTest.php
+++ b/tests/integration/Owncloud/OcisPhpSdk/OcisTest.php
@@ -9,7 +9,7 @@ use Owncloud\OcisPhpSdk\Group;
 use Owncloud\OcisPhpSdk\Ocis;
 use Owncloud\OcisPhpSdk\OrderDirection;
 
-class OcisTest extends OcisPhpStdTestCase
+class OcisTest extends OcisPhpSdkTestCase
 {
     private const GROUP_COUNT = 0;
 

--- a/tests/integration/Owncloud/OcisPhpSdk/UsersTest.php
+++ b/tests/integration/Owncloud/OcisPhpSdk/UsersTest.php
@@ -7,7 +7,7 @@ require_once __DIR__ . '/OcisPhpSdkTestCase.php';
 use Owncloud\OcisPhpSdk\Exception\UnauthorizedException;
 use Owncloud\OcisPhpSdk\Ocis;
 
-class UsersTest extends OcisPhpStdTestCase
+class UsersTest extends OcisPhpSdkTestCase
 {
     /**
      * init a user


### PR DESCRIPTION
1. the folder was called "OcisSdkPhp", but should be "OcisPhpSdk"
2. the main class for the testscase had a typo "Std" should be "Sdk"