### PR TITLE
fix naming of functions according to agreed conventions

### DIFF
--- a/src/Drive.php
+++ b/src/Drive.php
@@ -285,7 +285,7 @@ class Drive
      * @throws UnauthorizedException
      * @throws HttpException
      */
-    public function listResources(string $path = "/"): array
+    public function getResources(string $path = "/"): array
     {
         $resources = [];
         $webDavClient = $this->createWebDavClient();

--- a/src/Ocis.php
+++ b/src/Ocis.php
@@ -264,7 +264,7 @@ class Ocis
      * @throws InvalidResponseException
      * @throws HttpException
      */
-    public function listAllDrives(
+    public function getAllDrives(
         DriveOrder     $orderBy = DriveOrder::NAME,
         OrderDirection $orderDirection = OrderDirection::ASC,
         DriveType      $type = null
@@ -326,7 +326,7 @@ class Ocis
      * @throws InvalidResponseException
      * @throws HttpException
      */
-    public function listMyDrives(
+    public function getMyDrives(
         DriveOrder     $orderBy = DriveOrder::NAME,
         OrderDirection $orderDirection = OrderDirection::ASC,
         DriveType      $type = null

--- a/tests/integration/Owncloud/OcisPhpSdk/OcisTest.php
+++ b/tests/integration/Owncloud/OcisPhpSdk/OcisTest.php
@@ -17,7 +17,7 @@ class OcisTest extends OcisPhpSdkTestCase
     {
         $token = $this->getAccessToken('admin', 'admin');
         $ocis = new Ocis($this->ocisUrl . '///', $token, ['verify' => false]);
-        $drives = $ocis->listMyDrives();
+        $drives = $ocis->getMyDrives();
         $this->assertTrue((is_array($drives) && count($drives) > 1));
     }
 
@@ -26,13 +26,13 @@ class OcisTest extends OcisPhpSdkTestCase
         $token = $this->getAccessToken('admin', 'admin');
         $ocis = new Ocis($this->ocisUrl, $token, ['verify' => false]);
         $countDrivesAtStart = count(
-            $ocis->listMyDrives()
+            $ocis->getMyDrives()
         );
         $drive = $ocis->createDrive('first test drive');
         $this->createdDrives[] = $drive->getId();
         $this->assertMatchesRegularExpression(self::UUID_REGEX_PATTERN, $drive->getId());
         // there should be one more drive
-        $this->assertCount($countDrivesAtStart + 1, $ocis->listMyDrives());
+        $this->assertCount($countDrivesAtStart + 1, $ocis->getMyDrives());
     }
 
     public function testCreateDriveNoPermissions(): void
@@ -40,10 +40,10 @@ class OcisTest extends OcisPhpSdkTestCase
         $token = $this->getAccessToken('einstein', 'relativity');
         $ocis = new Ocis($this->ocisUrl, $token, ['verify' => false]);
         $this->expectException(ForbiddenException::class);
-        $countDrivesAtStart = count($ocis->listMyDrives());
+        $countDrivesAtStart = count($ocis->getMyDrives());
         $ocis->createDrive('first test drive');
         // no new drive should have been created
-        $this->assertCount($countDrivesAtStart, $ocis->listMyDrives());
+        $this->assertCount($countDrivesAtStart, $ocis->getMyDrives());
     }
 
     /**
@@ -64,10 +64,10 @@ class OcisTest extends OcisPhpSdkTestCase
         $token = $this->getAccessToken('admin', 'admin');
         $ocis = new Ocis($this->ocisUrl, $token, ['verify' => false]);
         $this->expectException(\InvalidArgumentException::class);
-        $countDrivesAtStart = count($ocis->listMyDrives());
+        $countDrivesAtStart = count($ocis->getMyDrives());
         $ocis->createDrive('drive with quota', $quota);
         // no new drive should have been created
-        $this->assertCount($countDrivesAtStart, $ocis->listMyDrives());
+        $this->assertCount($countDrivesAtStart, $ocis->getMyDrives());
     }
 
     public function testGetGroups(): void

--- a/tests/integration/Owncloud/OcisPhpSdk/UsersTest.php
+++ b/tests/integration/Owncloud/OcisPhpSdk/UsersTest.php
@@ -17,7 +17,7 @@ class UsersTest extends OcisPhpSdkTestCase
     {
         $token = $this->getAccessToken($name, $password);
         $ocis = new Ocis($this->ocisUrl, $token, ['verify' => false]);
-        $ocis->listMyDrives();
+        $ocis->getMyDrives();
     }
 
     public function testGetAllUsers(): void

--- a/tests/unit/Owncloud/OcisPhpSdk/OcisTest.php
+++ b/tests/unit/Owncloud/OcisPhpSdk/OcisTest.php
@@ -114,7 +114,7 @@ class OcisTest extends TestCase
         $drivesGetDrivesApi->method('listAllDrives')
             ->willReturn($driveCollectionMock);
         $ocis->setDrivesGetDrivesApiInstance($drivesGetDrivesApi);
-        $drives = $ocis->listAllDrives();
+        $drives = $ocis->getAllDrives();
         foreach ($drives as $drive) {
             $this->assertEquals('tokenWhenCreated', $drive->getAccessToken());
         }


### PR DESCRIPTION
Fix the naming of functions to the agreed conventions in #62

Fixes #62
