### PR TITLE
add script to check ocis cache

### DIFF
--- a/tests/check-oCIS-cache.sh
+++ b/tests/check-oCIS-cache.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+. .drone.env
+
+ocis_cache=$(mc find s3/$CACHE_BUCKET/ocis-build/$OCIS_COMMITID/ocis 2>&1 | grep 'Object does not exist')
+
+if [[ "$ocis_cache" != "" ]]
+then
+    echo "$OCIS_COMMITID doesn't exist"
+    exit 0
+fi
+exit 78


### PR DESCRIPTION
This PR adds a script to check if ocis cache already exist in a bucket or not.