### PR TITLE
Use valid licence name

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "owncloud/ocis-php-sdk",
     "type": "library",
-    "license": "Apache 2.0",
+    "license": "Apache-2.0",
     "autoload": {
         "psr-4": {
             "Owncloud\\OcisPhpSdk\\": "src/"


### PR DESCRIPTION
This PR just uses a valid license name `Apache-2.0`