### PR TITLE
get private link

### DIFF
--- a/src/Drive.php
+++ b/src/Drive.php
@@ -290,7 +290,25 @@ class Drive
         $resources = [];
         $webDavClient = $this->createWebDavClient();
         try {
-            $responses = $webDavClient->propFind(rawurlencode(ltrim($path, "/")), [], 1);
+            $properties = [
+                '{http://owncloud.org/ns}id',
+                '{http://owncloud.org/ns}fileid',
+                '{http://owncloud.org/ns}spaceid',
+                '{http://owncloud.org/ns}file-parent',
+                '{http://owncloud.org/ns}name',
+                '{DAV:}getetag',
+                '{http://owncloud.org/ns}permissions',
+                '{DAV:}resourcetype',
+                '{http://owncloud.org/ns}size',
+                '{DAV:}getcontentlength',
+                '{DAV:}getlastmodified',
+                '{http://owncloud.org/ns}tags',
+                '{http://owncloud.org/ns}favorite',
+                '{http://owncloud.org/ns}privatelink',
+                '{DAV:}getcontenttype',
+                '{http://owncloud.org/ns}checksums'
+            ];
+            $responses = $webDavClient->propFind(rawurlencode(ltrim($path, "/")), $properties, 1);
             foreach ($responses as $response) {
                 $resources[] = new OcisResource(
                     $response,
@@ -305,7 +323,8 @@ class Drive
             throw ExceptionHelper::getHttpErrorException($e);
         }
 
-        return $resources;
+        // make sure there is again an element with index 0
+        return array_values($resources);
     }
 
     /**

--- a/src/Drive.php
+++ b/src/Drive.php
@@ -290,24 +290,10 @@ class Drive
         $resources = [];
         $webDavClient = $this->createWebDavClient();
         try {
-            $properties = [
-                '{http://owncloud.org/ns}id',
-                '{http://owncloud.org/ns}fileid',
-                '{http://owncloud.org/ns}spaceid',
-                '{http://owncloud.org/ns}file-parent',
-                '{http://owncloud.org/ns}name',
-                '{DAV:}getetag',
-                '{http://owncloud.org/ns}permissions',
-                '{DAV:}resourcetype',
-                '{http://owncloud.org/ns}size',
-                '{DAV:}getcontentlength',
-                '{DAV:}getlastmodified',
-                '{http://owncloud.org/ns}tags',
-                '{http://owncloud.org/ns}favorite',
-                '{http://owncloud.org/ns}privatelink',
-                '{DAV:}getcontenttype',
-                '{http://owncloud.org/ns}checksums'
-            ];
+            $properties = [];
+            foreach (ResourceMetadata::cases() as $property) {
+                $properties[] = $property->value;
+            }
             $responses = $webDavClient->propFind(rawurlencode(ltrim($path, "/")), $properties, 1);
             foreach ($responses as $response) {
                 $resources[] = new OcisResource(
@@ -318,7 +304,7 @@ class Drive
                     $this->accessToken
                 );
             }
-            unset($resources[0]);
+            unset($resources[0]); // skip first propfind response, because its the parent folder
         } catch (SabreClientHttpException|SabreClientException $e) {
             throw ExceptionHelper::getHttpErrorException($e);
         }

--- a/src/OcisResource.php
+++ b/src/OcisResource.php
@@ -48,21 +48,7 @@ class OcisResource
      * @param array<mixed> $metadata of the resource
      *        the format of the array is directly taken from the PROPFIND response
      *        returned by Sabre\DAV\Client
-     *        e.g:
-     *        array (
-     *          '{http://owncloud.org/ns}id' => <string>,
-     *          '{http://owncloud.org/ns}fileid' => <string>,
-     *          '{http://owncloud.org/ns}spaceid' => <string>,
-     *          '{http://owncloud.org/ns}file-parent' => <string>,
-     *          '{http://owncloud.org/ns}name' => <string>,
-     *          '{DAV:}getetag' => <string>,
-     *          '{http://owncloud.org/ns}permissions' => <string>,
-     *          '{DAV:}resourcetype' => <ResourceType>,
-     *          '{http://owncloud.org/ns}size' => <string>,
-     *          '{DAV:}getlastmodified' => <string>,
-     *          '{http://owncloud.org/ns}tags' => <null|string>,
-     *          '{http://owncloud.org/ns}favorite' => <string>,
-     *        )
+     *        for details about accepted metadate see: ResourceMetadata
      * @phpstan-param array{
      *              'headers'?:array<string, mixed>,
      *              'verify'?:bool,
@@ -467,5 +453,21 @@ class OcisResource
             }
         }
         return [];
+    }
+
+    /**
+     * Returns the private link to the resource.
+     * This link can be used by any user with the correct permissions to navigate to the resource in the web UI.
+     * The link is urldecoded.
+     * @return string
+     * @throws InvalidResponseException
+     */
+    public function getPrivatelink(): string
+    {
+        $privateLink = $this->getMetadata(ResourceMetadata::PRIVATELINK);
+        if (is_array($privateLink)) {
+            return "";
+        }
+        return rawurldecode($privateLink);
     }
 }

--- a/src/OcisResource.php
+++ b/src/OcisResource.php
@@ -465,8 +465,10 @@ class OcisResource
     public function getPrivatelink(): string
     {
         $privateLink = $this->getMetadata(ResourceMetadata::PRIVATELINK);
-        if (is_array($privateLink)) {
-            return "";
+        if (!is_string($privateLink)) {
+            throw new InvalidResponseException(
+                'Invalid private link in response from server: ' . print_r($privateLink, true)
+            );
         }
         return rawurldecode($privateLink);
     }

--- a/src/ResourceMetadata.php
+++ b/src/ResourceMetadata.php
@@ -21,6 +21,7 @@ enum ResourceMetadata: string
     case TAGS = "{http://owncloud.org/ns}tags";
     case FAVORITE = "{http://owncloud.org/ns}favorite";
     case CHECKSUMS = "{http://owncloud.org/ns}checksums";
+    case PRIVATELINK = '{http://owncloud.org/ns}privatelink';
 
 
 
@@ -41,6 +42,7 @@ enum ResourceMetadata: string
             self::TAGS => 'tags',
             self::FAVORITE => 'favorite',
             self::CHECKSUMS => 'checksums',
+            self::PRIVATELINK => 'privatelink',
         };
     }
 }

--- a/tests/integration/Owncloud/OcisPhpSdk/OcisResourceTest.php
+++ b/tests/integration/Owncloud/OcisPhpSdk/OcisResourceTest.php
@@ -51,11 +51,13 @@ class OcisResourceTest extends OcisPhpSdkTestCase
                 "?^" . $this->ocisUrl . '/f/'. $this->getFileIdRegex() . "$?i",
                 $resource->getPrivatelink()
             );
-            try {
-                $this->assertEquals('file', $resource->getType());
-            } catch (\Exception $e) {
-                $this->assertEquals('folder', $resource->getType());
-            }
+            $this->assertThat(
+                $resource->getType(),
+                $this->logicalOr(
+                    $this->equalTo("file"),
+                    $this->equalTo("folder")
+                )
+            );
 
             $this->assertMatchesRegularExpression(
                 "/^" . $this->getUUIDv4Regex() . "$/i",
@@ -65,11 +67,14 @@ class OcisResourceTest extends OcisPhpSdkTestCase
                 "/^" . $this->getFileIdRegex() . "$/i",
                 $resource->getParent()
             );
-            try {
-                $this->assertEquals('RDNVWZP', $resource->getPermission());
-            } catch (\Exception $e) {
-                $this->assertEquals('RDNVCKZP', $resource->getPermission());
-            }
+            $this->assertThat(
+                $resource->getPermission(),
+                $this->logicalOr(
+                    $this->equalTo("RDNVWZP"),
+                    $this->equalTo("RDNVCKZP")
+                )
+            );
+
             $this->assertEqualsWithDelta(
                 strtotime("now"),
                 strtotime($resource->getLastModifiedTime()),

--- a/tests/integration/Owncloud/OcisPhpSdk/OcisResourceTest.php
+++ b/tests/integration/Owncloud/OcisPhpSdk/OcisResourceTest.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace integration\Owncloud\OcisPhpSdk;
+
+require_once __DIR__ . '/OcisPhpSdkTestCase.php';
+
+use Owncloud\OcisPhpSdk\Drive; // @phan-suppress-current-line PhanUnreferencedUseNormal it's used in a comment
+use Owncloud\OcisPhpSdk\DriveOrder;
+use Owncloud\OcisPhpSdk\DriveType;
+use Owncloud\OcisPhpSdk\Ocis;
+use Owncloud\OcisPhpSdk\OcisResource; // @phan-suppress-current-line PhanUnreferencedUseNormal it's used in a comment
+use Owncloud\OcisPhpSdk\OrderDirection;
+
+class OcisResourceTest extends OcisPhpSdkTestCase
+{
+    public function testGetResources(): void
+    {
+        $token = $this->getAccessToken('admin', 'admin');
+        $ocis = new Ocis($this->ocisUrl, $token, ['verify' => false]);
+        /**
+         * @var Drive $personalDrive
+         */
+        $personalDrive = $ocis->getMyDrives(
+            DriveOrder::NAME,
+            OrderDirection::ASC,
+            DriveType::PERSONAL
+        )[0];
+        $personalDrive->uploadFile('somefile.txt', 'some content');
+        $personalDrive->uploadFile('secondfile.txt', 'some other content');
+        $personalDrive->createFolder('subfolder');
+        $this->createdResources[] = '/somefile.txt';
+        $this->createdResources[] = '/secondfile.txt';
+        $this->createdResources[] = '/subfolder';
+
+        $resources = $personalDrive->getResources();
+        $this->assertCount(3, $resources);
+
+        /**
+         * @var OcisResource $resource
+         */
+        foreach ($resources as $resource) {
+            $this->assertMatchesRegularExpression(
+                "/^" . $this->getFileIdRegex() . "$/i",
+                $resource->getId()
+            );
+            $this->assertMatchesRegularExpression(
+                "/^\"[a-f0-9:\.]{1,32}\"$/",
+                $resource->getEtag()
+            );
+            $this->assertMatchesRegularExpression(
+                "?^" . $this->ocisUrl . '/f/'. $this->getFileIdRegex() . "$?i",
+                $resource->getPrivatelink()
+            );
+            try {
+                $this->assertEquals('file', $resource->getType());
+            } catch (\Exception $e) {
+                $this->assertEquals('folder', $resource->getType());
+            }
+
+            $this->assertMatchesRegularExpression(
+                "/^" . $this->getUUIDv4Regex() . "$/i",
+                $resource->getSpaceId()
+            );
+            $this->assertMatchesRegularExpression(
+                "/^" . $this->getFileIdRegex() . "$/i",
+                $resource->getParent()
+            );
+            try {
+                $this->assertEquals('RDNVWZP', $resource->getPermission());
+            } catch (\Exception $e) {
+                $this->assertEquals('RDNVCKZP', $resource->getPermission());
+            }
+            $this->assertEqualsWithDelta(
+                strtotime("now"),
+                strtotime($resource->getLastModifiedTime()),
+                60
+            );
+            if ($resource->getType() === 'folder') {
+                $this->assertEquals('', $resource->getContentType());
+            } else {
+                $this->assertEquals('text/plain', $resource->getContentType());
+            }
+
+            $this->assertEquals(false, $resource->isFavorited());
+            $this->assertEquals([], $resource->getTags());
+            $this->assertIsInt($resource->getSize());
+            if ($resource->getType() === 'folder') {
+                $this->assertEquals('subfolder', $resource->getName());
+            } else {
+                $this->assertStringContainsString('file.txt', $resource->getName());
+            }
+            if ($resource->getType() === 'file') {
+                $this->assertStringContainsString('SHA1', $resource->getCheckSums()[0]['value']);
+                $this->assertStringContainsString('MD5', $resource->getCheckSums()[0]['value']);
+            }
+        }
+    }
+}

--- a/tests/integration/Owncloud/OcisPhpSdk/OcisTest.php
+++ b/tests/integration/Owncloud/OcisPhpSdk/OcisTest.php
@@ -31,7 +31,10 @@ class OcisTest extends OcisPhpSdkTestCase
         );
         $drive = $ocis->createDrive('first test drive');
         $this->createdDrives[] = $drive->getId();
-        $this->assertMatchesRegularExpression(self::UUID_REGEX_PATTERN, $drive->getId());
+        $this->assertMatchesRegularExpression(
+            "/^" . $this->getUUIDv4Regex() . '\$' . $this->getUUIDv4Regex() . "$/i",
+            $drive->getId()
+        );
         // there should be one more drive
         $this->assertCount($countDrivesAtStart + 1, $ocis->getMyDrives());
     }


### PR DESCRIPTION
Functionality to get the private link for a resource.
The link is delivered using the WebDAV properties, see https://owncloud.dev/apis/http/webdav/#listing-properties
I don't believe this is a very expensive data to generate, so I've decided to get it directly with the main request, alternatively we could send a new request just when calling `getPrivatelink`, but I don't think its worth it.
