### PR TITLE
use driveId instead or itemId as first argument in API calls

### DIFF
--- a/src/Drive.php
+++ b/src/Drive.php
@@ -294,6 +294,7 @@ class Drive
             foreach ($responses as $response) {
                 $resources[] = new OcisResource(
                     $response,
+                    $this->getId(),
                     $this->connectionConfig,
                     $this->serviceUrl,
                     $this->accessToken

--- a/src/OcisResource.php
+++ b/src/OcisResource.php
@@ -40,6 +40,7 @@ class OcisResource
      */
     private array $connectionConfig;
     private Configuration $graphApiConfig;
+    private string $driveId;
 
     /**
      * @param array<mixed> $metadata of the resource
@@ -71,11 +72,13 @@ class OcisResource
      */
     public function __construct(
         array $metadata,
+        string $driveId,
         array $connectionConfig,
         string $serviceUrl,
         string &$accessToken
     ) {
         $this->metadata = $metadata;
+        $this->driveId = $driveId;
         $this->accessToken = &$accessToken;
         $this->serviceUrl = $serviceUrl;
         if (!Ocis::isConnectionConfigValid($connectionConfig)) {
@@ -142,7 +145,7 @@ class OcisResource
             );
         }
         try {
-            $collectionOfPermissions = $apiInstance->listPermissions($this->getId(), $this->getId());
+            $collectionOfPermissions = $apiInstance->listPermissions($this->driveId, $this->getId());
         } catch (ApiException $e) {
             throw ExceptionHelper::getHttpErrorException($e);
         }
@@ -203,7 +206,7 @@ class OcisResource
 
         $inviteData = new DriveItemInvite($driveItemInviteData);
         try {
-            $permission = $apiInstance->invite($this->getId(), $this->getId(), $inviteData);
+            $permission = $apiInstance->invite($this->driveId, $this->getId(), $inviteData);
         } catch (ApiException $e) {
             throw ExceptionHelper::getHttpErrorException($e);
         }

--- a/tests/unit/Owncloud/OcisPhpSdk/ResourceInviteTest.php
+++ b/tests/unit/Owncloud/OcisPhpSdk/ResourceInviteTest.php
@@ -130,7 +130,7 @@ class ResourceInviteTest extends TestCase
         $drivesPermissionsApi = $this->createMock(DrivesPermissionsApi::class);
         $drivesPermissionsApi->method('invite')
             /** @phan-suppress-next-line PhanTypeMismatchArgumentProbablyReal */
-            ->with('uuid-of-the-resource', 'uuid-of-the-resource', $expectedInviteData)
+            ->with('uuid-of-the-drive', 'uuid-of-the-resource', $expectedInviteData)
             ->willReturn($this->createMock(Permission::class));
         $accessToken = 'an-access-token';
         $connectionConfig = [
@@ -142,6 +142,7 @@ class ResourceInviteTest extends TestCase
 
         $resource = new OcisResource(
             $resourceMetadata,
+            'uuid-of-the-drive',
             $connectionConfig,
             'http://ocis',
             $accessToken

--- a/tests/unit/Owncloud/OcisPhpSdk/ResourceTest.php
+++ b/tests/unit/Owncloud/OcisPhpSdk/ResourceTest.php
@@ -42,6 +42,7 @@ class ResourceTest extends TestCase
         $accessToken = 'aaa';
         return new OcisResource(
             $metadata,
+            'uuid-of-the-drive',
             [],
             '',
             $accessToken


### PR DESCRIPTION
in these API calls we actually need the `driveId` not the `itemId` as the first argument see https://owncloud.dev/libre-graph-api/#/drives.permissions/Invite

So forwarding the driveId from the drive class down to the resource and using it there