### PR TITLE
refactoring the code so gives its own errors instead of libregraph's error 

### DIFF
--- a/src/Exception/ExceptionHelper.php
+++ b/src/Exception/ExceptionHelper.php
@@ -45,27 +45,22 @@ class ExceptionHelper
             400 => new BadRequestException(
                 $message,
                 $e->getCode(),
-                $e
             ),
             401 => new UnauthorizedException(
                 $message,
                 $e->getCode(),
-                $e
             ),
             403 => new ForbiddenException(
                 $message,
                 $e->getCode(),
-                $e
             ),
             404 => new NotFoundException(
                 $message,
                 $e->getCode(),
-                $e
             ),
             default => new HttpException(
                 $message,
                 $e->getCode(),
-                $e
             ),
         };
     }


### PR DESCRIPTION
previous
```bash
PHP Fatal error:  Uncaught OpenAPI\Client\ApiException: [401] Client error: `GET https://localhost:9200/graph/v1.0/users` resulted in a `401 Unauthorized` response in /home/neer/www/ocis-php-sdk/vendor/owncloud/libre-graph-api-php/src/Api/UsersApi.php:509
Stack trace:
#0 /home/neer/www/ocis-php-sdk/vendor/owncloud/libre-graph-api-php/src/Api/UsersApi.php(473): OpenAPI\Client\Api\UsersApi->listUsersWithHttpInfo()
#1 /home/neer/www/ocis-php-sdk/src/Ocis.php(620): OpenAPI\Client\Api\UsersApi->listUsers()
#2 /home/neer/www/ocis-php-sdk/src/example.php(55): Owncloud\OcisPhpSdk\Ocis->getUsers()
#3 {main}

Next Owncloud\OcisPhpSdk\Exception\UnauthorizedException: [401] Client error: `GET https://localhost:9200/graph/v1.0/users` resulted in a `401 Unauthorized` response in /home/neer/www/ocis-php-sdk/src/Exception/ExceptionHelper.php:52
Stack trace:
#0 /home/neer/www/ocis-php-sdk/src/Ocis.php(622): Owncloud\OcisPhpSdk\Exception\ExceptionHelper::getHttpErrorException()
#1 /home/neer/www/ocis-php-sdk/src/example.php(55): Owncloud\OcisPhpSdk\Ocis->getUsers()
#2 {main}
  thrown in /home/neer/www/ocis-php-sdk/src/Exception/ExceptionHelper.php on line 52

```
now
```bash
PHP Fatal error:  Uncaught Owncloud\OcisPhpSdk\Exception\UnauthorizedException: [401] Client error: `GET https://localhost:9200/graph/v1.0/users` resulted in a `401 Unauthorized` response in /home/neer/www/ocis-php-sdk/src/Exception/ExceptionHelper.php:49
Stack trace:
#0 /home/neer/www/ocis-php-sdk/src/Ocis.php(621): Owncloud\OcisPhpSdk\Exception\ExceptionHelper::getHttpErrorException()
#1 /home/neer/www/ocis-php-sdk/src/example.php(55): Owncloud\OcisPhpSdk\Ocis->getUsers()
#2 {main}
  thrown in /home/neer/www/ocis-php-sdk/src/Exception/ExceptionHelper.php on line 49

```










fixes: https://github.com/owncloud/ocis-php-sdk/issues/85