### PR TITLE
allow a share to be updated

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "require": {
         "php": "^8.1",
         "sabre/dav": "^4.4",
-        "owncloud/libre-graph-api-php": "dev-main#0d0a921e70cb41358c9273cb0a6930072691c842",
+        "owncloud/libre-graph-api-php": "dev-main#451de8f909ae27c025bcd41503515dd6e3600858",
         "ext-json": "*",
         "ext-curl": "*"
     },

--- a/src/OcisResource.php
+++ b/src/OcisResource.php
@@ -219,7 +219,7 @@ class OcisResource
         }
         if ($permissions->getValue() === null) {
             throw new InvalidResponseException(
-                "invite returned an 'null' where an array of permissions were expected"
+                "invite returned 'null' where an array of permissions were expected"
             );
         }
 

--- a/src/OcisResource.php
+++ b/src/OcisResource.php
@@ -123,7 +123,7 @@ class OcisResource
     }
 
     /**
-     * gets all possible permissions for the resource
+     * Gets all possible Roles for the resource
      * @return array<SharingRole>
      * @throws BadRequestException
      * @throws ForbiddenException
@@ -165,6 +165,9 @@ class OcisResource
     }
 
     /**
+     * Invite one or multiple people(user/group) to the resource.
+     * Every recipient will result in an own ShareCreated object in the returned array.
+     *
      * @param array<int, User|Group> $recipients
      * @param SharingRole $role
      * @param \DateTime|null $expiration

--- a/src/OcisResource.php
+++ b/src/OcisResource.php
@@ -168,7 +168,7 @@ class OcisResource
      * @param array<int, User|Group> $recipients
      * @param SharingRole $role
      * @param \DateTime|null $expiration
-     * @return bool
+     * @return ShareCreated
      * @throws BadRequestException
      * @throws ForbiddenException
      * @throws HttpException
@@ -176,7 +176,7 @@ class OcisResource
      * @throws NotFoundException
      * @throws UnauthorizedException
      */
-    public function invite($recipients, SharingRole $role, ?\DateTime $expiration = null): bool
+    public function invite($recipients, SharingRole $role, ?\DateTime $expiration = null): ShareCreated
     {
         $driveItemInviteData = [];
         $driveItemInviteData['recipients'] = [];
@@ -217,7 +217,14 @@ class OcisResource
                 "invite returned an OdataError - " . $permission->getError()
             );
         }
-        return true;
+        return new ShareCreated(
+            $permission,
+            $this->getId(),
+            $this->driveId,
+            $this->connectionConfig,
+            $this->serviceUrl,
+            $this->accessToken
+        );
     }
 
     /**
@@ -273,7 +280,7 @@ class OcisResource
 
         return new ShareLink(
             $permission,
-            $this,
+            $this->getId(),
             $this->driveId,
             $this->connectionConfig,
             $this->serviceUrl,

--- a/src/Share.php
+++ b/src/Share.php
@@ -105,7 +105,7 @@ class Share
     }
 
     /**
-     * permanently delete the current share or share link
+     * Permanently delete the current share or share link
      *
      * @throws BadRequestException
      * @throws ForbiddenException
@@ -129,6 +129,8 @@ class Share
     }
 
     /**
+     * Change the Expiration date for the current share or share link
+     *
      * @throws UnauthorizedException
      * @throws ForbiddenException
      * @throws InvalidResponseException

--- a/src/Share.php
+++ b/src/Share.php
@@ -1,0 +1,161 @@
+<?php
+
+namespace Owncloud\OcisPhpSdk;
+
+use GuzzleHttp\Client;
+use OpenAPI\Client\Api\DrivesPermissionsApi;
+use OpenAPI\Client\ApiException;
+use OpenAPI\Client\Configuration;
+use OpenAPI\Client\Model\OdataError;
+use OpenAPI\Client\Model\Permission as ApiPermission;
+use Owncloud\OcisPhpSdk\Exception\BadRequestException;
+use Owncloud\OcisPhpSdk\Exception\ExceptionHelper;
+use Owncloud\OcisPhpSdk\Exception\ForbiddenException;
+use Owncloud\OcisPhpSdk\Exception\HttpException;
+use Owncloud\OcisPhpSdk\Exception\InvalidResponseException;
+use Owncloud\OcisPhpSdk\Exception\NotFoundException;
+use Owncloud\OcisPhpSdk\Exception\UnauthorizedException;
+
+/**
+ * Parent class representing different types of share objects
+ */
+class Share
+{
+    private string $accessToken;
+    /**
+     * @phpstan-var array{
+     *                      'headers'?:array<string, mixed>,
+     *                      'verify'?:bool,
+     *                      'webfinger'?:bool,
+     *                      'guzzle'?:\GuzzleHttp\Client,
+     *                      'drivesPermissionsApi'?:\OpenAPI\Client\Api\DrivesPermissionsApi,
+     *                    }
+     */
+    protected array $connectionConfig;
+    protected string $serviceUrl;
+    protected Configuration $graphApiConfig;
+    protected ApiPermission $apiPermission;
+    protected string $driveId;
+    protected string $resourceId;
+
+
+    /**
+     * @throws InvalidResponseException
+     * @phpstan-param array{
+     *                       'headers'?:array<string, mixed>,
+     *                       'verify'?:bool,
+     *                       'webfinger'?:bool,
+     *                       'guzzle'?:\GuzzleHttp\Client,
+     *                       'drivesPermissionsApi'?:\OpenAPI\Client\Api\DrivesPermissionsApi,
+     *                     } $connectionConfig
+     */
+    public function __construct(
+        ApiPermission $apiPermission,
+        string        $resourceId,
+        string        $driveId,
+        array         $connectionConfig,
+        string        $serviceUrl,
+        string        &$accessToken
+    ) {
+        $this->apiPermission = $apiPermission;
+        $this->driveId = $driveId;
+        if (!is_string($apiPermission->getId())) {
+            throw new InvalidResponseException(
+                "Invalid id returned for permission '" . print_r($apiPermission->getId(), true) . "'"
+            );
+        }
+
+        $this->resourceId = $resourceId;
+        $this->accessToken = &$accessToken;
+        $this->serviceUrl = $serviceUrl;
+        if (!Ocis::isConnectionConfigValid($connectionConfig)) {
+            throw new \InvalidArgumentException('connection configuration not valid');
+        }
+        $this->graphApiConfig = Configuration::getDefaultConfiguration()
+            ->setHost($this->serviceUrl . '/graph');
+
+        $this->connectionConfig = $connectionConfig;
+    }
+
+    protected function getDrivesPermissionsApi(): DrivesPermissionsApi
+    {
+        $guzzle = new Client(
+            Ocis::createGuzzleConfig($this->connectionConfig, $this->accessToken)
+        );
+        if (array_key_exists('drivesPermissionsApi', $this->connectionConfig)) {
+            return $this->connectionConfig['drivesPermissionsApi'];
+        } else {
+            return new DrivesPermissionsApi(
+                $guzzle,
+                $this->graphApiConfig
+            );
+        }
+    }
+
+    public function getPermissionId(): string
+    {
+        // in the constructor the value is checked for being the right type, but phan does not know
+        // so simply cast to string
+        return (string)$this->apiPermission->getId();
+    }
+
+    public function getExpiry(): ?\DateTime
+    {
+        return $this->apiPermission->getExpirationDateTime();
+    }
+
+    /**
+     * permanently delete the current share or share link
+     *
+     * @throws BadRequestException
+     * @throws ForbiddenException
+     * @throws HttpException
+     * @throws NotFoundException
+     * @throws UnauthorizedException
+     * @throws InvalidResponseException
+     */
+    public function delete(): bool
+    {
+        try {
+            $this->getDrivesPermissionsApi()->deletePermission(
+                $this->driveId,
+                $this->resourceId,
+                $this->getPermissionId()
+            );
+        } catch (ApiException $e) {
+            throw ExceptionHelper::getHttpErrorException($e);
+        }
+        return true;
+    }
+
+    /**
+     * @throws UnauthorizedException
+     * @throws ForbiddenException
+     * @throws InvalidResponseException
+     * @throws BadRequestException
+     * @throws HttpException
+     * @throws NotFoundException
+     */
+    public function setExpiration(\DateTime $expiration): bool
+    {
+        $this->apiPermission->setExpirationDateTime($expiration);
+
+        try {
+            $apiPermission = $this->getDrivesPermissionsApi()->updatePermission(
+                $this->driveId,
+                $this->resourceId,
+                $this->getPermissionId(),
+                $this->apiPermission
+            );
+        } catch (ApiException $e) {
+            throw ExceptionHelper::getHttpErrorException($e);
+        }
+        if ($apiPermission instanceof OdataError) {
+            throw new InvalidResponseException(
+                "updatePermission returned an OdataError - " . $apiPermission->getError()
+            );
+        }
+        $this->apiPermission = $apiPermission;
+        return true;
+    }
+}

--- a/src/ShareCreated.php
+++ b/src/ShareCreated.php
@@ -22,6 +22,10 @@ class ShareCreated extends Share
     }
 
     /**
+     * Change the Role of the particular Share.
+     * Possible roles are defined by the resource and have to be queried using OcisResource::getRoles()
+     * Roles for shares are not to be confused with the types of share links!
+     * @see OcisResource::getRoles()
      * @throws UnauthorizedException
      * @throws ForbiddenException
      * @throws InvalidResponseException

--- a/src/ShareCreated.php
+++ b/src/ShareCreated.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Owncloud\OcisPhpSdk;
+
+use OpenAPI\Client\ApiException;
+use OpenAPI\Client\Model\OdataError;
+use Owncloud\OcisPhpSdk\Exception\BadRequestException;
+use Owncloud\OcisPhpSdk\Exception\ExceptionHelper;
+use Owncloud\OcisPhpSdk\Exception\ForbiddenException;
+use Owncloud\OcisPhpSdk\Exception\HttpException;
+use Owncloud\OcisPhpSdk\Exception\InvalidResponseException;
+use Owncloud\OcisPhpSdk\Exception\NotFoundException;
+use Owncloud\OcisPhpSdk\Exception\UnauthorizedException;
+
+class ShareCreated extends Share
+{
+    public function getPermissionId(): string
+    {
+        // in the constructor the value is checked for being the right type, but phan does not know
+        // so simply cast to string
+        return (string)$this->apiPermission->getId();
+    }
+
+    /**
+     * @throws UnauthorizedException
+     * @throws ForbiddenException
+     * @throws InvalidResponseException
+     * @throws BadRequestException
+     * @throws HttpException
+     * @throws NotFoundException
+     */
+    public function setRole(SharingRole $role): bool
+    {
+        $this->apiPermission->setRoles([$role->getId()]);
+
+        try {
+            $apiPermission = $this->getDrivesPermissionsApi()->updatePermission(
+                $this->driveId,
+                $this->resourceId,
+                $this->getPermissionId(),
+                $this->apiPermission
+            );
+        } catch (ApiException $e) {
+            throw ExceptionHelper::getHttpErrorException($e);
+        }
+        if ($apiPermission instanceof OdataError) {
+            throw new InvalidResponseException(
+                "updatePermission returned an OdataError - " . $apiPermission->getError()
+            );
+        }
+        $this->apiPermission = $apiPermission;
+        return true;
+    }
+}

--- a/src/ShareLink.php
+++ b/src/ShareLink.php
@@ -113,28 +113,13 @@ class ShareLink extends Share
     public function setDisplayName(string $displayName): bool
     {
         $this->sharingLink->setAtLibreGraphDisplayName($displayName);
-        $this->apiPermission->setLink($this->sharingLink);
-
-        try {
-            $apiPermission = $this->getDrivesPermissionsApi()->updatePermission(
-                $this->driveId,
-                $this->resourceId,
-                $this->getPermissionId(),
-                $this->apiPermission
-            );
-        } catch (ApiException $e) {
-            throw ExceptionHelper::getHttpErrorException($e);
-        }
-        if ($apiPermission instanceof OdataError) {
-            throw new InvalidResponseException(
-                "updatePermission returned an OdataError - " . $apiPermission->getError()
-            );
-        }
-        $this->apiPermission = $apiPermission;
-        return true;
+        return $this->updateLinkOfPermission();
     }
 
     /**
+     * Change the type of the current ShareLink.
+     * For details about the possible types see https://owncloud.dev/libre-graph-api/#/drives.permissions/CreateLink
+     * Types of share links are not to be confused with roles for shares!
      * @throws UnauthorizedException
      * @throws ForbiddenException
      * @throws InvalidResponseException
@@ -145,25 +130,7 @@ class ShareLink extends Share
     public function setType(SharingLinkType $linkType): bool
     {
         $this->sharingLink->setType($linkType);
-        $this->apiPermission->setLink($this->sharingLink);
-
-        try {
-            $apiPermission = $this->getDrivesPermissionsApi()->updatePermission(
-                $this->driveId,
-                $this->resourceId,
-                $this->getPermissionId(),
-                $this->apiPermission
-            );
-        } catch (ApiException $e) {
-            throw ExceptionHelper::getHttpErrorException($e);
-        }
-        if ($apiPermission instanceof OdataError) {
-            throw new InvalidResponseException(
-                "updatePermission returned an OdataError - " . $apiPermission->getError()
-            );
-        }
-        $this->apiPermission = $apiPermission;
-        return true;
+        return $this->updateLinkOfPermission();
     }
 
     /**
@@ -195,6 +162,38 @@ class ShareLink extends Share
         if ($apiPermission instanceof OdataError) {
             throw new InvalidResponseException(
                 "setPassword returned an OdataError - " . $apiPermission->getError()
+            );
+        }
+        $this->apiPermission = $apiPermission;
+        return true;
+    }
+
+    /**
+     * @return true
+     * @throws BadRequestException
+     * @throws ForbiddenException
+     * @throws HttpException
+     * @throws InvalidResponseException
+     * @throws NotFoundException
+     * @throws UnauthorizedException
+     */
+    public function updateLinkOfPermission(): bool
+    {
+        $this->apiPermission->setLink($this->sharingLink);
+
+        try {
+            $apiPermission = $this->getDrivesPermissionsApi()->updatePermission(
+                $this->driveId,
+                $this->resourceId,
+                $this->getPermissionId(),
+                $this->apiPermission
+            );
+        } catch (ApiException $e) {
+            throw ExceptionHelper::getHttpErrorException($e);
+        }
+        if ($apiPermission instanceof OdataError) {
+            throw new InvalidResponseException(
+                "updatePermission returned an OdataError - " . $apiPermission->getError()
             );
         }
         $this->apiPermission = $apiPermission;

--- a/tests/unit/Owncloud/OcisPhpSdk/ResourceInviteTest.php
+++ b/tests/unit/Owncloud/OcisPhpSdk/ResourceInviteTest.php
@@ -6,11 +6,13 @@ use OpenAPI\Client\Api\DrivesPermissionsApi;
 use OpenAPI\Client\Model\DriveItemInvite;
 use OpenAPI\Client\Model\DriveRecipient;
 use OpenAPI\Client\Model\Group as OpenAPIGroup;
+use OpenAPI\Client\Model\UnifiedRolePermission;
 use OpenAPI\Client\Model\User as OpenAPIUser;
 use OpenAPI\Client\Model\Permission;
 use OpenAPI\Client\Model\UnifiedRoleDefinition;
 use Owncloud\OcisPhpSdk\Group;
 use Owncloud\OcisPhpSdk\OcisResource;
+use Owncloud\OcisPhpSdk\ShareCreated;
 use Owncloud\OcisPhpSdk\SharingRole;
 use Owncloud\OcisPhpSdk\User;
 use PHPUnit\Framework\TestCase;
@@ -128,11 +130,14 @@ class ResourceInviteTest extends TestCase
      */
     public function testInvite($recipients, ?\DateTime $expiration, DriveItemInvite $expectedInviteData): void
     {
+        $permission = $this->createMock(Permission::class);
+        $permission->method('getId')
+            ->willReturn('uuid-of-the-permission');
         $drivesPermissionsApi = $this->createMock(DrivesPermissionsApi::class);
         $drivesPermissionsApi->method('invite')
             /** @phan-suppress-next-line PhanTypeMismatchArgumentProbablyReal */
             ->with('uuid-of-the-drive', 'uuid-of-the-resource', $expectedInviteData)
-            ->willReturn($this->createMock(Permission::class));
+            ->willReturn($permission);
         $accessToken = 'an-access-token';
         $connectionConfig = [
             'drivesPermissionsApi' => $drivesPermissionsApi,
@@ -158,6 +163,6 @@ class ResourceInviteTest extends TestCase
         $role = new SharingRole($openAPIRole);
 
         $result = $resource->invite($recipients, $role, $expiration);
-        $this->assertTrue($result);
+        $this->assertInstanceOf(ShareCreated::class, $result);
     }
 }

--- a/tests/unit/Owncloud/OcisPhpSdk/ResourceInviteTest.php
+++ b/tests/unit/Owncloud/OcisPhpSdk/ResourceInviteTest.php
@@ -3,10 +3,10 @@
 namespace unit\Owncloud\OcisPhpSdk;
 
 use OpenAPI\Client\Api\DrivesPermissionsApi;
+use OpenAPI\Client\Model\CollectionOfPermissions;
 use OpenAPI\Client\Model\DriveItemInvite;
 use OpenAPI\Client\Model\DriveRecipient;
 use OpenAPI\Client\Model\Group as OpenAPIGroup;
-use OpenAPI\Client\Model\UnifiedRolePermission;
 use OpenAPI\Client\Model\User as OpenAPIUser;
 use OpenAPI\Client\Model\Permission;
 use OpenAPI\Client\Model\UnifiedRoleDefinition;
@@ -133,11 +133,14 @@ class ResourceInviteTest extends TestCase
         $permission = $this->createMock(Permission::class);
         $permission->method('getId')
             ->willReturn('uuid-of-the-permission');
+        $permissions = $this->createMock(CollectionOfPermissions::class);
+        $permissions->method('getValue')
+            ->willReturn([$permission]);
         $drivesPermissionsApi = $this->createMock(DrivesPermissionsApi::class);
         $drivesPermissionsApi->method('invite')
             /** @phan-suppress-next-line PhanTypeMismatchArgumentProbablyReal */
             ->with('uuid-of-the-drive', 'uuid-of-the-resource', $expectedInviteData)
-            ->willReturn($permission);
+            ->willReturn($permissions);
         $accessToken = 'an-access-token';
         $connectionConfig = [
             'drivesPermissionsApi' => $drivesPermissionsApi,
@@ -163,6 +166,6 @@ class ResourceInviteTest extends TestCase
         $role = new SharingRole($openAPIRole);
 
         $result = $resource->invite($recipients, $role, $expiration);
-        $this->assertInstanceOf(ShareCreated::class, $result);
+        $this->assertContainsOnly(ShareCreated::class, $result);
     }
 }


### PR DESCRIPTION
1. `invite()` function returns an array of `ShareCreated` objects
2. `ShareCreated` & `ShareLink` extend the `Share` class, which combines functions/properties that are needed in both places
3. the role in `ShareCreated` can be changed (and of course anything that is extended from `Share`)