### PR TITLE
create OcisResource object from file-id

### DIFF
--- a/src/Ocis.php
+++ b/src/Ocis.php
@@ -130,6 +130,17 @@ class Ocis
     }
 
     /**
+     * Helper function to check if the variable is a DrivesApi
+     * we need this because we want to call the check with call_user_func
+     *
+     * @phpstan-ignore-next-line phpstan does not understand that this method was called via call_user_func
+     */
+    private static function isDrivesApi(mixed $api): bool
+    {
+        return $api instanceof DrivesApi;
+    }
+
+    /**
      * @param array<mixed> $connectionConfig
      * @ignore This function is used for internal purposes only and should not be shown in the documentation.
      *         The function is public to make it testable and because its also used from other classes.
@@ -141,7 +152,8 @@ class Ocis
             'verify' => 'is_bool',
             'webfinger' => 'is_bool',
             'guzzle' => 'self::isGuzzleClient',
-            'drivesPermissionsApi' => 'self::isDrivesPermissionsApi'
+            'drivesPermissionsApi' => 'self::isDrivesPermissionsApi',
+            'drivesApi' => 'self::isDrivesApi'
         ];
         foreach ($connectionConfig as $key => $check) {
             if (!array_key_exists($key, $validConnectionConfigKeys)) {
@@ -572,7 +584,7 @@ class Ocis
             $responses = $webDavClient->propFind(rawurlencode($fileId), $properties);
             $resource = new OcisResource(
                 $responses,
-                '', // ToDo find a way to get the drive-id here, is it the 'spaceid'? see https://matrix.to/#/!QxIasTYvslDCVqoPzC:matrix.org/$hZUW8b6YKbAM-rGVEl-OI0OQI7hjfcD-rQNi_OIOkjQ?via=matrix.org&via=openproject.org&via=element.io
+                null,
                 $this->connectionConfig,
                 $this->serviceUrl,
                 $this->accessToken

--- a/src/OcisResource.php
+++ b/src/OcisResource.php
@@ -19,6 +19,7 @@ use Owncloud\OcisPhpSdk\Exception\InvalidResponseException;
 use Owncloud\OcisPhpSdk\Exception\NotFoundException;
 use Owncloud\OcisPhpSdk\Exception\UnauthorizedException;
 use Sabre\DAV\Xml\Property\ResourceType;
+use Sabre\HTTP\ResponseInterface;
 
 /**
  * Class representing a file or folder inside a Drive in ownCloud Infinite Scale
@@ -497,5 +498,52 @@ class OcisResource
             );
         }
         return rawurldecode($privateLink);
+    }
+
+    /*
+     * returns the content of this resource
+     *
+     * @throws UnauthorizedException
+     * @throws ForbiddenException
+     * @throws InvalidResponseException
+     * @throws HttpException
+     * @throws BadRequestException
+     * @throws NotFoundException
+     */
+    public function getContent(): string
+    {
+        $response = $this->getFileResponseInterface($this->getId());
+        return $response->getBodyAsString();
+    }
+
+    /**
+     * returns a stream to get the content of this resource
+     *
+     * @return resource
+     * @throws UnauthorizedException
+     * @throws ForbiddenException
+     * @throws BadRequestException
+     * @throws HttpException
+     * @throws InvalidResponseException
+     * @throws NotFoundException
+     */
+    public function getContentStream()
+    {
+        $response = $this->getFileResponseInterface($this->getId());
+        return $response->getBodyAsStream();
+    }
+
+    /**
+     * @throws BadRequestException
+     * @throws ForbiddenException
+     * @throws NotFoundException
+     * @throws UnauthorizedException
+     * @throws HttpException
+     */
+    private function getFileResponseInterface(string $fileId): ResponseInterface
+    {
+        $webDavClient = new WebDavClient(['baseUri' => $this->serviceUrl . '/dav/spaces/']);
+        $webDavClient->setCustomSetting($this->connectionConfig, $this->accessToken);
+        return $webDavClient->sendRequest("GET", $fileId);
     }
 }

--- a/tests/integration/Owncloud/OcisPhpSdk/OcisPhpSdkTestCase.php
+++ b/tests/integration/Owncloud/OcisPhpSdk/OcisPhpSdkTestCase.php
@@ -6,6 +6,7 @@ use GuzzleHttp\Client;
 use Owncloud\OcisPhpSdk\Drive; // @phan-suppress-current-line PhanUnreferencedUseNormal it's used in a comment
 use Owncloud\OcisPhpSdk\DriveOrder;
 use Owncloud\OcisPhpSdk\DriveType;
+use Owncloud\OcisPhpSdk\Exception\NotFoundException;
 use Owncloud\OcisPhpSdk\Ocis;
 use Owncloud\OcisPhpSdk\OrderDirection;
 use PHPUnit\Framework\TestCase;
@@ -69,7 +70,11 @@ class OcisPhpSdkTestCase extends TestCase
                 OrderDirection::ASC,
                 DriveType::PERSONAL
             )[0];
-            $personalDrive->deleteResource($resource);
+            try {
+                $personalDrive->deleteResource($resource);
+            } catch (NotFoundException $e) {
+                // ignore, we don't care if the resource was already deleted
+            }
         }
     }
 

--- a/tests/integration/Owncloud/OcisPhpSdk/OcisTest.php
+++ b/tests/integration/Owncloud/OcisPhpSdk/OcisTest.php
@@ -320,6 +320,7 @@ class OcisTest extends OcisPhpSdkTestCase
         $this->assertSame('file', $resource->getType());
         $this->assertSame(12, $resource->getSize());
         $this->assertSame('some content', $resource->getContent());
+        $this->assertSame($personalDrive->getId(), $resource->getDriveId());
     }
 
     public function testGetResourceByIdEmptyFolder(): void
@@ -335,6 +336,7 @@ class OcisTest extends OcisPhpSdkTestCase
         $this->assertSame('folder', $resource->getType());
         $this->assertSame(0, $resource->getSize());
         $this->assertSame('', $resource->getContent()); // getting a folder does not return any content
+        $this->assertSame($personalDrive->getId(), $resource->getDriveId());
     }
 
     public function testGetResourceByIdFolderWithContent(): void
@@ -351,6 +353,7 @@ class OcisTest extends OcisPhpSdkTestCase
         $this->assertSame('folder', $resource->getType());
         $this->assertSame(12, $resource->getSize());
         $this->assertSame('', $resource->getContent()); // getting a folder does not return any content
+        $this->assertSame($personalDrive->getId(), $resource->getDriveId());
     }
 
     public function testGetResourceByIdFileInAFolder(): void
@@ -367,6 +370,7 @@ class OcisTest extends OcisPhpSdkTestCase
         $this->assertSame('file', $resource->getType());
         $this->assertSame(12, $resource->getSize());
         $this->assertSame('some content', $resource->getContent());
+        $this->assertSame($personalDrive->getId(), $resource->getDriveId());
     }
 
     public function testGetResourceInvalidId(): void

--- a/tests/integration/Owncloud/OcisPhpSdk/OcisTest.php
+++ b/tests/integration/Owncloud/OcisPhpSdk/OcisTest.php
@@ -4,6 +4,9 @@ namespace integration\Owncloud\OcisPhpSdk;
 
 require_once __DIR__ . '/OcisPhpSdkTestCase.php';
 
+use Owncloud\OcisPhpSdk\Drive;
+use Owncloud\OcisPhpSdk\DriveOrder;
+use Owncloud\OcisPhpSdk\DriveType;
 use Owncloud\OcisPhpSdk\Exception\ForbiddenException;
 use Owncloud\OcisPhpSdk\Group;
 use Owncloud\OcisPhpSdk\Ocis;
@@ -14,18 +17,22 @@ use Owncloud\OcisPhpSdk\Exception\UnauthorizedException;
 
 class OcisTest extends OcisPhpSdkTestCase
 {
+    private function getOcis(string $username, string $password): Ocis
+    {
+        $token = $this->getAccessToken($username, $password);
+        return new Ocis($this->ocisUrl, $token, ['verify' => false]);
+    }
+
     public function testServiceUrlTrailingSlash(): void
     {
-        $token = $this->getAccessToken('admin', 'admin');
-        $ocis = new Ocis($this->ocisUrl . '///', $token, ['verify' => false]);
+        $ocis = $this->getOcis('admin', 'admin');
         $drives = $ocis->getMyDrives();
         $this->assertTrue((is_array($drives) && count($drives) > 1));
     }
 
     public function testCreateDrive(): void
     {
-        $token = $this->getAccessToken('admin', 'admin');
-        $ocis = new Ocis($this->ocisUrl, $token, ['verify' => false]);
+        $ocis = $this->getOcis('admin', 'admin');
         $countDrivesAtStart = count(
             $ocis->getMyDrives()
         );
@@ -41,8 +48,7 @@ class OcisTest extends OcisPhpSdkTestCase
 
     public function testCreateDriveNoPermissions(): void
     {
-        $token = $this->getAccessToken('einstein', 'relativity');
-        $ocis = new Ocis($this->ocisUrl, $token, ['verify' => false]);
+        $ocis = $this->getOcis('einstein', 'relativity');
         $this->expectException(ForbiddenException::class);
         $countDrivesAtStart = count($ocis->getMyDrives());
         $ocis->createDrive('first test drive');
@@ -65,8 +71,7 @@ class OcisTest extends OcisPhpSdkTestCase
      */
     public function testCreateDriveInvalidQuota(int $quota): void
     {
-        $token = $this->getAccessToken('admin', 'admin');
-        $ocis = new Ocis($this->ocisUrl, $token, ['verify' => false]);
+        $ocis = $this->getOcis('admin', 'admin');
         $this->expectException(\InvalidArgumentException::class);
         $countDrivesAtStart = count($ocis->getMyDrives());
         $ocis->createDrive('drive with quota', $quota);
@@ -91,8 +96,7 @@ class OcisTest extends OcisPhpSdkTestCase
      */
     public function testGetGroups(array $groupName): void
     {
-        $token = $this->getAccessToken('admin', 'admin');
-        $ocis = new Ocis($this->ocisUrl, $token, ['verify' => false]);
+        $ocis = $this->getOcis('admin', 'admin');
         $philosophyHatersGroup =  $ocis->createGroup($groupName[0], "philosophy haters group");
         $physicsLoversGroup =  $ocis->createGroup($groupName[1], "physics lover group");
         $this->createdGroups = [$philosophyHatersGroup,$physicsLoversGroup];
@@ -133,8 +137,7 @@ class OcisTest extends OcisPhpSdkTestCase
     public function testAddUserToGroupInvalid(): void
     {
         $this->expectException(NotFoundException::class);
-        $token = $this->getAccessToken('admin', 'admin');
-        $ocis = new Ocis($this->ocisUrl, $token, ['verify' => false]);
+        $ocis = $this->getOcis('admin', 'admin');
         $philosophyHatersGroup =  $ocis->createGroup("philosophy-haters", "philosophy haters group");
         $this->createdGroups = [$philosophyHatersGroup];
         $user = new User(
@@ -157,8 +160,7 @@ class OcisTest extends OcisPhpSdkTestCase
     public function testAddUserToGroupUnauthorizedUser(): void
     {
         $this->expectException(UnauthorizedException::class);
-        $token = $this->getAccessToken('marie', 'radioactivity');
-        $ocis = new Ocis($this->ocisUrl, $token, ['verify' => false]);
+        $ocis = $this->getOcis('marie', 'radioactivity');
         $physicsLoversGroup =  $ocis->createGroup("physics-lovers", "physics lovers group");
         $this->createdGroups = [$physicsLoversGroup];
         $users = $ocis->getUsers('marie');
@@ -172,8 +174,7 @@ class OcisTest extends OcisPhpSdkTestCase
      */
     public function testGetGroupsExpanded(): void
     {
-        $token = $this->getAccessToken('admin', 'admin');
-        $ocis = new Ocis($this->ocisUrl, $token, ['verify' => false]);
+        $ocis = $this->getOcis('admin', 'admin');
         $physicsLoversGroup =  $ocis->createGroup("physics-lovers", "physics lovers group");
         $this->createdGroups = [$physicsLoversGroup];
         $physicsLoversGroup->addUser($ocis->getUsers()[0]);
@@ -201,8 +202,7 @@ class OcisTest extends OcisPhpSdkTestCase
      */
     public function testGetGroupSearch(string $searchText, array $groupDisplayName): void
     {
-        $token = $this->getAccessToken('admin', 'admin');
-        $ocis = new Ocis($this->ocisUrl, $token, ['verify' => false]);
+        $ocis = $this->getOcis('admin', 'admin');
         $philosophyHatersGroup =  $ocis->createGroup("philosophy-haters", "philosophy haters group");
         $physicsLoversGroup = $ocis->createGroup("physics-lovers", "physics lover group");
         $this->createdGroups = [$philosophyHatersGroup,$physicsLoversGroup];
@@ -232,8 +232,7 @@ class OcisTest extends OcisPhpSdkTestCase
      */
     public function testGetGroupSort(OrderDirection $orderDirection, string $searchText, array $resultGroups): void
     {
-        $token = $this->getAccessToken("admin", "admin");
-        $ocis = new Ocis($this->ocisUrl, $token, ["verify" => false]);
+        $ocis = $this->getOcis('admin', 'admin');
         $philosophyHatersGroup =  $ocis->createGroup("philosophy-haters", "philosophy haters group");
         $physicsLoversGroup = $ocis->createGroup("physics-lovers", "physics lover group");
         $this->createdGroups = [$philosophyHatersGroup,$physicsLoversGroup];
@@ -297,5 +296,83 @@ class OcisTest extends OcisPhpSdkTestCase
         $ocis = new Ocis($this->ocisUrl, $token, ["verify" => false]);
         $this->expectException(UnauthorizedException::class);
         $ocis->deleteGroupByID($groupId);
+    }
+
+    private function getPersonalDrive(Ocis $ocis): Drive
+    {
+        return $ocis->getMyDrives(
+            DriveOrder::NAME,
+            OrderDirection::ASC,
+            DriveType::PERSONAL
+        )[0];
+    }
+
+    public function testGetResourceById(): void
+    {
+        $ocis = $this->getOcis('admin', 'admin');
+        $personalDrive = $this->getPersonalDrive($ocis);
+        $personalDrive->uploadFile('somefile.txt', 'some content');
+        $this->createdResources[] = '/somefile.txt';
+        $expectedResource = $personalDrive->getResources()[0];
+        $resource = $ocis->getResourceById($expectedResource->getId());
+        $this->assertSame($expectedResource->getId(), $resource->getId());
+        $this->assertSame('somefile.txt', $resource->getName());
+        $this->assertSame('file', $resource->getType());
+        $this->assertSame(12, $resource->getSize());
+        $this->assertSame('some content', $resource->getContent());
+    }
+
+    public function testGetResourceByIdEmptyFolder(): void
+    {
+        $ocis = $this->getOcis('admin', 'admin');
+        $personalDrive = $this->getPersonalDrive($ocis);
+        $personalDrive->createFolder('myfolder');
+        $this->createdResources[] = '/myfolder';
+        $expectedResource = $personalDrive->getResources()[0];
+        $resource = $ocis->getResourceById($expectedResource->getId());
+        $this->assertSame($expectedResource->getId(), $resource->getId());
+        $this->assertSame('myfolder', $resource->getName());
+        $this->assertSame('folder', $resource->getType());
+        $this->assertSame(0, $resource->getSize());
+        $this->assertSame('', $resource->getContent()); // getting a folder does not return any content
+    }
+
+    public function testGetResourceByIdFolderWithContent(): void
+    {
+        $ocis = $this->getOcis('admin', 'admin');
+        $personalDrive = $this->getPersonalDrive($ocis);
+        $personalDrive->createFolder('myfolder');
+        $this->createdResources[] = '/myfolder';
+        $personalDrive->uploadFile('myfolder/somefile.txt', 'some content');
+        $expectedResource = $personalDrive->getResources()[0];
+        $resource = $ocis->getResourceById($expectedResource->getId());
+        $this->assertSame($expectedResource->getId(), $resource->getId());
+        $this->assertSame('myfolder', $resource->getName());
+        $this->assertSame('folder', $resource->getType());
+        $this->assertSame(12, $resource->getSize());
+        $this->assertSame('', $resource->getContent()); // getting a folder does not return any content
+    }
+
+    public function testGetResourceByIdFileInAFolder(): void
+    {
+        $ocis = $this->getOcis('admin', 'admin');
+        $personalDrive = $this->getPersonalDrive($ocis);
+        $personalDrive->createFolder('myfolder');
+        $this->createdResources[] = '/myfolder';
+        $personalDrive->uploadFile('myfolder/somefile.txt', 'some content');
+        $expectedResource = $personalDrive->getResources('/myfolder')[0];
+        $resource = $ocis->getResourceById($expectedResource->getId());
+        $this->assertSame($expectedResource->getId(), $resource->getId());
+        $this->assertSame('somefile.txt', $resource->getName());
+        $this->assertSame('file', $resource->getType());
+        $this->assertSame(12, $resource->getSize());
+        $this->assertSame('some content', $resource->getContent());
+    }
+
+    public function testGetResourceInvalidId(): void
+    {
+        $this->expectException(NotFoundException::class);
+        $ocis = $this->getOcis('admin', 'admin');
+        $ocis->getResourceById('not-existing-id');
     }
 }

--- a/tests/unit/Owncloud/OcisPhpSdk/ResourceTest.php
+++ b/tests/unit/Owncloud/OcisPhpSdk/ResourceTest.php
@@ -2,6 +2,9 @@
 
 namespace unit\Owncloud\OcisPhpSdk;
 
+use OpenAPI\Client\Api\DrivesApi;
+use OpenAPI\Client\Model\Drive;
+use OpenAPI\Client\Model\OdataError;
 use Owncloud\OcisPhpSdk\Exception\InvalidResponseException;
 use Owncloud\OcisPhpSdk\OcisResource;
 use PHPUnit\Framework\TestCase;
@@ -342,5 +345,45 @@ class ResourceTest extends TestCase
             }
             $this->assertNull($result);
         }
+    }
+
+    public function testDriveIdCannotBeFetchedUsingSpaceId(): void
+    {
+        $driveMock = $this->createMock(Drive::class);
+        $driveApiMock = $this->createMock(DrivesApi::class);
+        $driveApiMock->method('getDrive')
+            ->willReturn($driveMock);
+        $accessToken = 'aaa';
+        $metadata = ['{http://owncloud.org/ns}spaceid' => 'spaceid'];
+        $this->expectException(InvalidResponseException::class);
+        $this->expectExceptionMessage('Could not get drive id');
+        // @phan-suppress-next-line PhanNoopNew we are expecting an exception
+        new OcisResource(
+            $metadata,
+            null,
+            ['drivesApi' => $driveApiMock],
+            '',
+            $accessToken
+        );
+    }
+
+    public function testFetchingDriveIdByUsingSpaceIdReturnsOdataError(): void
+    {
+        $errorMock = $this->createMock(OdataError::class);
+        $driveApiMock = $this->createMock(DrivesApi::class);
+        $driveApiMock->method('getDrive')
+            ->willReturn($errorMock);
+        $accessToken = 'aaa';
+        $metadata = ['{http://owncloud.org/ns}spaceid' => 'spaceid'];
+        $this->expectException(InvalidResponseException::class);
+        $this->expectExceptionMessage('getDrive returned an OdataError - ');
+        // @phan-suppress-next-line PhanNoopNew we are expecting an exception
+        new OcisResource(
+            $metadata,
+            null,
+            ['drivesApi' => $driveApiMock],
+            '',
+            $accessToken
+        );
     }
 }


### PR DESCRIPTION
- If only a file-id is known, allow the user to create an `OcisResource` just using that. The use-case is that an application might have stored the file-id in the database and then wants to use all the abilities of `OcisResource` with it.
- move the functions to get the content of a file to the `OcisResource` class. Does that make sense? We can also keep both, but the naming might be confusing.

