### PR TITLE
Improve autogenerated documentation

### DIFF
--- a/phpdoc.dist.xml
+++ b/phpdoc.dist.xml
@@ -13,7 +13,8 @@
         <api>
             <source dsn=".">
                 <path>src</path>
-                <path>vendor/owncloud/libre-graph-api-php/lib/Model/Quota.php</path>
+                <path>vendor/owncloud/libre-graph-api-php/src/Model/Quota.php</path>
+                <path>vendor/owncloud/libre-graph-api-php/src/Model/SharingLinkType.php</path>
             </source>
             <visibility>public</visibility>
             <include-source>true</include-source>

--- a/src/Group.php
+++ b/src/Group.php
@@ -41,6 +41,8 @@ class Group
      *                      'webfinger'?:bool,
      *                      'guzzle'?:\GuzzleHttp\Client
      *                      } $connectionConfig
+     * @ignore The developer using the SDK does not need to create Group objects manually,
+     *         but should use the Ocis class to query the server for groups
      */
     private array $connectionConfig; /** @phpstan-ignore-line */
 

--- a/src/OcisResource.php
+++ b/src/OcisResource.php
@@ -40,6 +40,7 @@ class OcisResource
      *                      'drivesPermissionsApi'?:\OpenAPI\Client\Api\DrivesPermissionsApi,
      *                    }
      */
+
     private array $connectionConfig;
     private Configuration $graphApiConfig;
     private string $driveId;
@@ -57,6 +58,8 @@ class OcisResource
      *              'drivesPermissionsApi'?:DrivesPermissionsApi
      *             } $connectionConfig
      * @return void
+     * @ignore The developer using the SDK does not need to create OcisResource objects manually,
+     *         but should use the Drive class to query the server for resources
      */
     public function __construct(
         array $metadata,

--- a/src/Share.php
+++ b/src/Share.php
@@ -48,6 +48,9 @@ class Share
      *                       'guzzle'?:\GuzzleHttp\Client,
      *                       'drivesPermissionsApi'?:\OpenAPI\Client\Api\DrivesPermissionsApi,
      *                     } $connectionConfig
+     * @ignore The developer using the SDK does not need to create share objects manually,
+     *         but should use the OcisResource class to invite people to a resource and
+     *         that will create ShareCreated objects
      */
     public function __construct(
         ApiPermission $apiPermission,

--- a/src/ShareLink.php
+++ b/src/ShareLink.php
@@ -32,6 +32,9 @@ class ShareLink extends Share
      *                       'guzzle'?:\GuzzleHttp\Client,
      *                       'drivesPermissionsApi'?:\OpenAPI\Client\Api\DrivesPermissionsApi,
      *                     } $connectionConfig
+     * @ignore The developer using the SDK does not need to create ShareLink objects manually,
+     *         but should use the OcisResource class to share resources using a link
+     *         and that will create ShareLink objects
      */
     public function __construct(
         ApiPermission $apiPermission,

--- a/src/SharingRole.php
+++ b/src/SharingRole.php
@@ -17,6 +17,8 @@ class SharingRole
     private int $weight;
 
     /**
+     * @ignore The developer using the SDK does not need to create SharingRole objects manually,
+     *         but should use OcisResource::getRoles() to query for possible roles for the given resource
      */
     public function __construct(UnifiedRoleDefinition $apiRole)
     {

--- a/src/User.php
+++ b/src/User.php
@@ -13,6 +13,8 @@ class User
     private string $onPremisesSamAccountName;
     /**
      * @param OpenAPIUser $openApiUser
+     * @ignore The developer using the SDK does not need to create User objects manually,
+     *         but should use the Ocis class to query the server for users
      */
     public function __construct(
         OpenAPIUser $openApiUser


### PR DESCRIPTION
1. ignore some constructors in the docs, because a developer using this library should never use them
2. add/fix path to classes from the dependency that we want to see in the docs