### PR TITLE
allow removal of expiration date of shares

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "require": {
         "php": "^8.1",
         "sabre/dav": "^4.4",
-        "owncloud/libre-graph-api-php": "dev-main#451de8f909ae27c025bcd41503515dd6e3600858",
+        "owncloud/libre-graph-api-php": "dev-main#73c46add374372d419043df93f9d19a1c3b72976",
         "ext-json": "*",
         "ext-curl": "*"
     },

--- a/src/Share.php
+++ b/src/Share.php
@@ -133,6 +133,7 @@ class Share
 
     /**
      * Change the Expiration date for the current share or share link
+     * Set to null to remove the expiration date
      *
      * @throws UnauthorizedException
      * @throws ForbiddenException
@@ -141,7 +142,7 @@ class Share
      * @throws HttpException
      * @throws NotFoundException
      */
-    public function setExpiration(\DateTime $expiration): bool
+    public function setExpiration(?\DateTime $expiration): bool
     {
         $this->apiPermission->setExpirationDateTime($expiration);
 


### PR DESCRIPTION
after the fix in the [libre-graph-api](https://github.com/owncloud/libre-graph-api/pull/145) we can now delete the expiration date
