### PR TITLE
add mountpoit drivetype

### DIFF
--- a/src/DriveType.php
+++ b/src/DriveType.php
@@ -10,4 +10,5 @@ enum DriveType: string
     case PERSONAL = "personal";
     case PROJECT = "project";
     case VIRTUAL = "virtual";
+    case MOUNTPOINT = "mountpoint";
 }


### PR DESCRIPTION
received shares are listed as 'mountpoint' drivetype when getting my drives (`/v1.0/me/drives`), so add this type to the list
