### PR TITLE
ability to check if drive is disabled

### DIFF
--- a/tests/integration/Owncloud/OcisPhpSdk/DriveTest.php
+++ b/tests/integration/Owncloud/OcisPhpSdk/DriveTest.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace integration\Owncloud\OcisPhpSdk;
+
+require_once __DIR__ . '/OcisPhpSdkTestCase.php';
+
+class DriveTest extends OcisPhpSdkTestCase
+{
+    public function testDisableDrive(): void
+    {
+        $ocis = $this->getOcis('admin', 'admin');
+        $drive = $ocis->createDrive('test drive');
+        $this->createdDrives[] = $drive->getId();
+        $this->assertFalse($drive->isDisabled());
+        $drive->disable();
+        $this->assertTrue($drive->isDisabled());
+    }
+}

--- a/tests/integration/Owncloud/OcisPhpSdk/OcisPhpSdkTestCase.php
+++ b/tests/integration/Owncloud/OcisPhpSdk/OcisPhpSdkTestCase.php
@@ -112,6 +112,12 @@ class OcisPhpSdkTestCase extends TestCase
         return $accessTokenResponse['access_token'];
     }
 
+    protected function getOcis(string $username, string $password): Ocis
+    {
+        $token = $this->getAccessToken($username, $password);
+        return new Ocis($this->ocisUrl, $token, ['verify' => false]);
+    }
+
     protected function getUUIDv4Regex(): string
     {
         return '[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-4[0-9A-Fa-f]{3}-[89ABab][0-9A-Fa-f]{3}-[0-9A-Fa-f]{12}';

--- a/tests/integration/Owncloud/OcisPhpSdk/OcisTest.php
+++ b/tests/integration/Owncloud/OcisPhpSdk/OcisTest.php
@@ -17,12 +17,6 @@ use Owncloud\OcisPhpSdk\Exception\UnauthorizedException;
 
 class OcisTest extends OcisPhpSdkTestCase
 {
-    private function getOcis(string $username, string $password): Ocis
-    {
-        $token = $this->getAccessToken($username, $password);
-        return new Ocis($this->ocisUrl, $token, ['verify' => false]);
-    }
-
     public function testServiceUrlTrailingSlash(): void
     {
         $ocis = $this->getOcis('admin', 'admin');


### PR DESCRIPTION
When listing drives (spaces) it might be handy to know if a particular drive is currently disabled to be able to display it differently or not at all.