### PR TITLE
fix: spelling of ShareReceived class

### DIFF
--- a/src/Ocis.php
+++ b/src/Ocis.php
@@ -822,7 +822,7 @@ class Ocis
     }
 
     /**
-     * @return array<ShareRecieved>
+     * @return array<ShareReceived>
      * @throws BadRequestException
      * @throws ForbiddenException
      * @throws HttpException
@@ -849,7 +849,7 @@ class Ocis
         $apiShares = $shareList->getValue() ?? [];
         $shares = [];
         foreach ($apiShares as $share) {
-            $shares[] = new ShareRecieved(
+            $shares[] = new ShareReceived(
                 $share
             );
         }

--- a/src/Ocis.php
+++ b/src/Ocis.php
@@ -28,7 +28,7 @@ use Sabre\HTTP\ClientException as SabreClientException;
 use Sabre\HTTP\ClientHttpException as SabreClientHttpException;
 use stdClass;
 use OpenAPI\Client\Api\GroupsApi;
-use OpenAPI\Client\Model\Group as OpenAPIGrop;
+use OpenAPI\Client\Model\Group as OpenAPIGroup;
 
 /**
  * Basic class to establish the connection to an ownCloud Infinite Scale instance
@@ -780,7 +780,7 @@ class Ocis
     public function createGroup(string $groupName, string $description = ""): Group
     {
         $apiInstance = new GroupsApi($this->guzzle, $this->graphApiConfig);
-        $group = new OpenAPIGrop(["display_name" => $groupName, "description" => $description]);
+        $group = new OpenAPIGroup(["display_name" => $groupName, "description" => $description]);
         try {
             $newlyCreatedGroup = $apiInstance->createGroup($group);
         } catch (ApiException $e) {

--- a/src/OcisResource.php
+++ b/src/OcisResource.php
@@ -51,7 +51,7 @@ class OcisResource
      * @param array<mixed> $metadata of the resource
      *        the format of the array is directly taken from the PROPFIND response
      *        returned by Sabre\DAV\Client
-     *        for details about accepted metadate see: ResourceMetadata
+     *        for details about accepted metadata see: ResourceMetadata
      * @param string|null $driveId if null the driveId will be fetched from the server using the space-id
      * @param array $connectionConfig
      * @param string $serviceUrl

--- a/src/ShareReceived.php
+++ b/src/ShareReceived.php
@@ -13,7 +13,7 @@ use Owncloud\OcisPhpSdk\Exception\NotImplementedException;
  * Ensures that the return type is correct, but Phan does not recognize it.
  * @phan-file-suppress PhanTypeMismatchReturnNullable
  */
-class ShareRecieved
+class ShareReceived
 {
     private DriveItem $shareReceived;
 

--- a/tests/unit/Owncloud/OcisPhpSdk/GroupTest.php
+++ b/tests/unit/Owncloud/OcisPhpSdk/GroupTest.php
@@ -40,8 +40,8 @@ class GroupTest extends TestCase
     public function testListGroup(array $data)
     {
         $libGroup = new Group($data);
-        $accessTocken = "acstok";
-        $group = new SdkGroup($libGroup, "url", [], $accessTocken);
+        $accessToken = "acstok";
+        $group = new SdkGroup($libGroup, "url", [], $accessToken);
         $this->assertInstanceOf(SdkGroup::class, $group);
         $this->assertEquals($data["id"], $group->getId());
         $this->assertEquals($data["description"], $group->getDescription());
@@ -57,7 +57,7 @@ class GroupTest extends TestCase
      *              "id" => 'id', // id of the group
      *              "description" => "description", // description of the group
      *              "display_name" => "display name", // display name of the group
-     *              "group_types" => ["type"], // group type of a grpup
+     *              "group_types" => ["type"], // group type of a group
      *              "members" => [$user1,$user2], // list of members in the group
      *          ], "id" // key of the id of the mock data
      *          , "id" // key in the error message
@@ -111,7 +111,7 @@ class GroupTest extends TestCase
         $this->expectException(InvalidResponseException::class);
         $this->expectExceptionMessage("Invalid $errorMsg returned for group '" . print_r($data[$key], true));
         $libGroup = new Group($data);
-        $accessTocken = "acstok";
-        $group = new SdkGroup($libGroup, "url", [], $accessTocken);
+        $accessToken = "acstok";
+        $group = new SdkGroup($libGroup, "url", [], $accessToken);
     }
 }

--- a/tests/unit/Owncloud/OcisPhpSdk/ResourceInviteTest.php
+++ b/tests/unit/Owncloud/OcisPhpSdk/ResourceInviteTest.php
@@ -40,8 +40,8 @@ class ResourceInviteTest extends TestCase
                 'display_name' => 'smart-people',
             ]
         );
-        $accessTocken = "acstok";
-        $smartPeopleGroup = new Group($openAPIGroup, "url", [], $accessTocken);
+        $accessToken = "acstok";
+        $smartPeopleGroup = new Group($openAPIGroup, "url", [], $accessToken);
 
         return [
             // invite for a single recipient

--- a/tests/unit/Owncloud/OcisPhpSdk/ResourceTest.php
+++ b/tests/unit/Owncloud/OcisPhpSdk/ResourceTest.php
@@ -40,7 +40,7 @@ class ResourceTest extends TestCase
      * @param array<mixed> $metadata
      * @return OcisResource
      */
-    private function createOcisResouce(array $metadata): OcisResource
+    private function createOcisResource(array $metadata): OcisResource
     {
         $accessToken = 'aaa';
         return new OcisResource(
@@ -59,7 +59,7 @@ class ResourceTest extends TestCase
     {
         $metadata = [];
         $metadata['{DAV:}resourcetype'] = new ResourceType($resourceType);
-        $resource = $this->createOcisResouce($metadata);
+        $resource = $this->createOcisResource($metadata);
         $result = $resource->getType();
         $this->assertSame($expectedResult, $result);
     }
@@ -89,7 +89,7 @@ class ResourceTest extends TestCase
         $this->expectException(InvalidResponseException::class);
         $this->expectExceptionMessage("Received invalid data for the key \"resourcetype\" in the response array");
         $metadata['{DAV:}resourcetype'] = new ResourceType($resourceType);
-        $resource = $this->createOcisResouce($metadata);
+        $resource = $this->createOcisResource($metadata);
         $result = $resource->getType();
     }
 
@@ -130,7 +130,7 @@ class ResourceTest extends TestCase
         $metadata = [];
         $metadata['{DAV:}resourcetype'] = new ResourceType($data);
         $metadata[$sizeKey] = $actualSize;
-        $resource = $this->createOcisResouce($metadata);
+        $resource = $this->createOcisResource($metadata);
         $result = $resource->getSize();
         $this->assertSame($expectedSize, $result);
     }
@@ -156,7 +156,7 @@ class ResourceTest extends TestCase
         $this->expectExceptionMessage("Received an invalid value for size in the response");
         $metadata['{DAV:}resourcetype'] = new ResourceType($data);
         $metadata[$sizeKey] = $actualSize;
-        $resource = $this->createOcisResouce($metadata);
+        $resource = $this->createOcisResource($metadata);
         $result = $resource->getSize();
     }
 
@@ -185,7 +185,7 @@ class ResourceTest extends TestCase
         $metadata = [];
         $metadata['{DAV:}resourcetype'] = new ResourceType($fileType);
         $metadata['{DAV:}getcontenttype'] = $expectedResult;
-        $resource = $this->createOcisResouce($metadata);
+        $resource = $this->createOcisResource($metadata);
         $result = $resource->getContentType();
         $this->assertSame($expectedResult, $result);
     }
@@ -199,7 +199,7 @@ class ResourceTest extends TestCase
         $tags = [["mytag"], ["asd", "asd"], [''], [null]];
         foreach ($tags as $tag) {
             $metadata['{http://owncloud.org/ns}tags'] = implode(',', $tag);
-            $resource = $this->createOcisResouce($metadata);
+            $resource = $this->createOcisResource($metadata);
             $result = $resource->getTags();
             if ($tag === [null] || $tag === ['']) {
                 $tag = [];
@@ -227,7 +227,7 @@ class ResourceTest extends TestCase
     {
         $metadata = [];
         $metadata['{http://owncloud.org/ns}favorite'] = $value;
-        $resource = $this->createOcisResouce($metadata);
+        $resource = $this->createOcisResource($metadata);
         $result = $resource->isFavorited();
         $this->assertIsBool($result);
         $this->assertSame($result, (bool)$value);
@@ -253,7 +253,7 @@ class ResourceTest extends TestCase
         $this->expectException(InvalidResponseException::class);
         $this->expectExceptionMessage("Value of property \"favorite\" invalid in the server response");
         $metadata['{http://owncloud.org/ns}favorite'] = $value;
-        $resource = $this->createOcisResouce($metadata);
+        $resource = $this->createOcisResource($metadata);
         $resource->isFavorited();
     }
 
@@ -282,7 +282,7 @@ class ResourceTest extends TestCase
         $metadata['{DAV:}resourcetype'] = new ResourceType($fileType);
         $metadata['{DAV:}getcontentlength'] = 1;
         $metadata['{http://owncloud.org/ns}checksums'] = $value;
-        $resource = $this->createOcisResouce($metadata);
+        $resource = $this->createOcisResource($metadata);
         $result = $resource->getCheckSums();
         $this->assertEquals($value, $result);
     }
@@ -293,14 +293,14 @@ class ResourceTest extends TestCase
     public function testGettersCorrectResponse(): void
     {
         $metadata = [];
-        foreach ($this->properties as ['property' => $property, "function" => $properytFunc]) {
+        foreach ($this->properties as ['property' => $property, "function" => $propertyFunc]) {
             if (in_array($property, ['etag', 'lastmodified'])) {
                 $metadata['{DAV:}get' . $property] = $property;
             } else {
                 $metadata['{http://owncloud.org/ns}' . $property] = $property;
             }
-            $resource = $this->createOcisResouce($metadata);
-            $result = $resource->$properytFunc();
+            $resource = $this->createOcisResource($metadata);
+            $result = $resource->$propertyFunc();
             $this->assertSame($property, $result);
         }
     }
@@ -311,12 +311,12 @@ class ResourceTest extends TestCase
     public function testGettersEmptyResponseKey(): void
     {
         $metadata = [];
-        foreach ($this->properties as ['property' => $property, "function" => $properytFunc]) {
+        foreach ($this->properties as ['property' => $property, "function" => $propertyFunc]) {
             $metadata[''] = $property;
-            $resource = $this->createOcisResouce($metadata);
+            $resource = $this->createOcisResource($metadata);
             $result = null;
             try {
-                $result = $resource->$properytFunc();
+                $result = $resource->$propertyFunc();
             } catch (InvalidResponseException $e) {
                 $this->assertSame('Could not find property "' . $property . '" in response', $e->getMessage());
             }
@@ -330,16 +330,16 @@ class ResourceTest extends TestCase
     public function testGettersValuesAreNull(): void
     {
         $metadata = [];
-        foreach ($this->properties as ['property' => $property, "function" => $properytFunc]) {
+        foreach ($this->properties as ['property' => $property, "function" => $propertyFunc]) {
             if (in_array($property, ["etag", "lastmodified"])) {
                 $metadata['{DAV:}get' . $property] = null;
             } else {
                 $metadata['{http://owncloud.org/ns}' . $property] = null;
             }
-            $resource = $this->createOcisResouce($metadata);
+            $resource = $this->createOcisResource($metadata);
             $result = null;
             try {
-                $result = $resource->$properytFunc();
+                $result = $resource->$propertyFunc();
             } catch (InvalidResponseException $e) {
                 $this->assertSame('Invalid response from server', $e->getMessage());
             }


### PR DESCRIPTION
and other minor typos - silly English.

This will break any consumer that uses `ShareReceived` directly.