### PR TITLE
tests to set expiration date when creating shares and links

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,3 +1,3 @@
 # The version of OCIS to use in pipelines that test against OCIS
-OCIS_COMMITID=d5598188ca3cc45f104f2a192d8fdd556aa86d3d
+OCIS_COMMITID=48fd95aec7131bcbafa9430c2e791ea1ca55954e
 OCIS_BRANCH=master

--- a/.drone.env
+++ b/.drone.env
@@ -1,3 +1,3 @@
 # The version of OCIS to use in pipelines that test against OCIS
-OCIS_COMMITID=eed474bec8b77b98a789b4d588c34ca0c9db2ea7
+OCIS_COMMITID=48fd95aec7131bcbafa9430c2e791ea1ca55954e
 OCIS_BRANCH=master

--- a/.drone.env
+++ b/.drone.env
@@ -1,3 +1,3 @@
 # The version of OCIS to use in pipelines that test against OCIS
-OCIS_COMMITID=48fd95aec7131bcbafa9430c2e791ea1ca55954e
+OCIS_COMMITID=d5598188ca3cc45f104f2a192d8fdd556aa86d3d
 OCIS_BRANCH=master

--- a/.drone.star
+++ b/.drone.star
@@ -566,7 +566,7 @@ def composerInstall():
             "COMPOSER_HOME": "%s/.cache/composer" % dir["base"],
         },
         "commands": [
-            "composer clear",
+            "composer update owncloud/libre-graph-api-php",
             "composer install",
         ],
     }]

--- a/.drone.star
+++ b/.drone.star
@@ -566,8 +566,7 @@ def composerInstall():
             "COMPOSER_HOME": "%s/.cache/composer" % dir["base"],
         },
         "commands": [
-            "composer update owncloud/libre-graph-api-php",
-            "composer install",
+            "composer install --prefer-dist",
         ],
     }]
 

--- a/.drone.star
+++ b/.drone.star
@@ -566,6 +566,7 @@ def composerInstall():
             "COMPOSER_HOME": "%s/.cache/composer" % dir["base"],
         },
         "commands": [
+            "composer clear",
             "composer install",
         ],
     }]

--- a/.drone.star
+++ b/.drone.star
@@ -566,7 +566,7 @@ def composerInstall():
             "COMPOSER_HOME": "%s/.cache/composer" % dir["base"],
         },
         "commands": [
-            "composer install --prefer-dist",
+            "composer install",
         ],
     }]
 

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "require": {
         "php": "^8.1",
         "sabre/dav": "^4.4",
-        "owncloud/libre-graph-api-php": "dev-main#3139375c566a21d63d9e81a9bcff19410368a6fd",
+        "owncloud/libre-graph-api-php": "dev-main#eaa85a34b43ecad81908c189556c437ac18f7d19",
         "ext-json": "*",
         "ext-curl": "*"
     },

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "require": {
         "php": "^8.1",
         "sabre/dav": "^4.4",
-        "owncloud/libre-graph-api-php": "dev-main#73c46add374372d419043df93f9d19a1c3b72976",
+        "owncloud/libre-graph-api-php": "dev-main#3139375c566a21d63d9e81a9bcff19410368a6fd",
         "ext-json": "*",
         "ext-curl": "*"
     },

--- a/src/OcisResource.php
+++ b/src/OcisResource.php
@@ -224,7 +224,7 @@ class OcisResource
         $driveItemInviteData['roles'] = [$role->getId()];
         if ($expiration !== null) {
             $expiration->setTimezone(new \DateTimeZone('Z'));
-            $driveItemInviteData['expiration_date_time'] = $expiration->format('Y-m-d\TH:i:s:up');
+            $driveItemInviteData['expiration_date_time'] = $expiration;
         }
 
         if (array_key_exists('drivesPermissionsApi', $this->connectionConfig)) {

--- a/src/OcisResource.php
+++ b/src/OcisResource.php
@@ -224,7 +224,6 @@ class OcisResource
         $driveItemInviteData['roles'] = [$role->getId()];
         if ($expiration !== null) {
             $expirationMutable = \DateTime::createFromImmutable($expiration);
-            $expirationMutable->setTimezone(new \DateTimeZone('Z'));
             $driveItemInviteData['expiration_date_time'] = $expirationMutable;
         }
 

--- a/src/OcisResource.php
+++ b/src/OcisResource.php
@@ -200,7 +200,7 @@ class OcisResource
      *
      * @param array<int, User|Group> $recipients
      * @param SharingRole $role
-     * @param \DateTime|null $expiration
+     * @param \DateTimeImmutable|null $expiration
      * @return array<ShareCreated>
      * @throws BadRequestException
      * @throws ForbiddenException
@@ -209,7 +209,7 @@ class OcisResource
      * @throws NotFoundException
      * @throws UnauthorizedException
      */
-    public function invite($recipients, SharingRole $role, ?\DateTime $expiration = null): array
+    public function invite($recipients, SharingRole $role, ?\DateTimeImmutable $expiration = null): array
     {
         $driveItemInviteData = [];
         $driveItemInviteData['recipients'] = [];
@@ -223,8 +223,9 @@ class OcisResource
         }
         $driveItemInviteData['roles'] = [$role->getId()];
         if ($expiration !== null) {
-            $expiration->setTimezone(new \DateTimeZone('Z'));
-            $driveItemInviteData['expiration_date_time'] = $expiration;
+            $expirationMutable = \DateTime::createFromImmutable($expiration);
+            $expirationMutable->setTimezone(new \DateTimeZone('Z'));
+            $driveItemInviteData['expiration_date_time'] = $expirationMutable;
         }
 
         if (array_key_exists('drivesPermissionsApi', $this->connectionConfig)) {

--- a/src/OcisResource.php
+++ b/src/OcisResource.php
@@ -285,7 +285,7 @@ class OcisResource
      */
     public function createSharingLink(
         SharingLinkType $type = SharingLinkType::VIEW,
-        ?\DateTime $expiration = null,
+        ?\DateTimeImmutable $expiration = null,
         ?string $password = null,
         ?string $displayName = null
     ): ShareLink {
@@ -301,16 +301,15 @@ class OcisResource
             );
         }
         if ($expiration !== null) {
-            $expiration->setTimezone(new \DateTimeZone('Z'));
-            $expirationString = $expiration->format('Y-m-d\TH:i:s:up');
+            $expirationMutable = \DateTime::createFromImmutable($expiration);
         } else {
-            $expirationString = null;
+            $expirationMutable = null;
         }
 
         $createLinkData = new DriveItemCreateLink([
-            'type' => $type->value,
+            'type' => $type,
             'password' => $password,
-            'expiration_date_time' => $expirationString,
+            'expiration_date_time' => $expirationMutable,
             'display_name' => $displayName
         ]);
         try {

--- a/src/Share.php
+++ b/src/Share.php
@@ -148,9 +148,14 @@ class Share
      * @throws HttpException
      * @throws NotFoundException
      */
-    public function setExpiration(?\DateTime $expiration): bool
+    public function setExpiration(?\DateTimeImmutable $expiration): bool
     {
-        $this->apiPermission->setExpirationDateTime($expiration);
+        if ($expiration !== null) {
+            $expirationMutable = \DateTime::createFromImmutable($expiration);
+        } else {
+            $expirationMutable = null;
+        }
+        $this->apiPermission->setExpirationDateTime($expirationMutable);
 
         try {
             $apiPermission = $this->getDrivesPermissionsApi()->updatePermission(

--- a/src/Share.php
+++ b/src/Share.php
@@ -102,9 +102,15 @@ class Share
         return (string)$this->apiPermission->getId();
     }
 
-    public function getExpiry(): ?\DateTime
+    public function getExpiry(): ?\DateTimeImmutable
     {
-        return $this->apiPermission->getExpirationDateTime();
+        $expiry = $this->apiPermission->getExpirationDateTime();
+        if ($expiry === null) {
+            return null;
+        } else {
+            return \DateTimeImmutable::createFromMutable($expiry);
+        }
+
     }
 
     /**

--- a/src/Share.php
+++ b/src/Share.php
@@ -102,7 +102,7 @@ class Share
         return (string)$this->apiPermission->getId();
     }
 
-    public function getExpiry(): ?\DateTimeImmutable
+    public function getExpiration(): ?\DateTimeImmutable
     {
         $expiry = $this->apiPermission->getExpirationDateTime();
         if ($expiry === null) {

--- a/tests/integration/Owncloud/OcisPhpSdk/ResourceInviteTest.php
+++ b/tests/integration/Owncloud/OcisPhpSdk/ResourceInviteTest.php
@@ -179,6 +179,16 @@ class ResourceInviteTest extends OcisPhpSdkTestCase
         $this->fileToShare->invite([$this->einstein], $this->managerRole);
     }
 
+    public function testInviteWithExpiry(): void
+    {
+        $tomorrow = new \DateTime('tomorrow');
+        $shares = $this->fileToShare->invite([$this->einstein], $this->viewerRole, $tomorrow);
+        $this->assertCount(1, $shares);
+        $createdShares = $this->ocis->getSharedByMe();
+        $this->assertCount(1, $createdShares);
+        $this->assertSame($tomorrow->getTimestamp(), $createdShares[0]->getExpiry()->getTimestamp());
+    }
+
     public function testGetReceiversOfShareCreatedByInvite(): void
     {
         $philosophyHatersGroup =  $this->ocis->createGroup(

--- a/tests/integration/Owncloud/OcisPhpSdk/ResourceInviteTest.php
+++ b/tests/integration/Owncloud/OcisPhpSdk/ResourceInviteTest.php
@@ -76,7 +76,7 @@ class ResourceInviteTest extends OcisPhpSdkTestCase
     {
         $shares = $this->fileToShare->invite([$this->einstein], $this->viewerRole);
         $this->assertCount(1, $shares);
-        $this->assertNull($shares[0]->getExpiry());
+        $this->assertNull($shares[0]->getExpiration());
         $receivedShares = $this->einsteinOcis->getSharedWithMe();
         $this->assertCount(1, $receivedShares);
         $this->assertSame($this->fileToShare->getName(), $receivedShares[0]->getName());
@@ -187,8 +187,8 @@ class ResourceInviteTest extends OcisPhpSdkTestCase
         $this->assertCount(1, $shares);
         $createdShares = $this->ocis->getSharedByMe();
         $this->assertCount(1, $createdShares);
-        $this->assertInstanceOf(\DateTimeImmutable::class, $createdShares[0]->getExpiry());
-        $this->assertSame($tomorrow->getTimestamp(), $createdShares[0]->getExpiry()->getTimestamp());
+        $this->assertInstanceOf(\DateTimeImmutable::class, $createdShares[0]->getExpiration());
+        $this->assertSame($tomorrow->getTimestamp(), $createdShares[0]->getExpiration()->getTimestamp());
     }
 
     public function testInviteWithPastExpiry(): void
@@ -205,10 +205,10 @@ class ResourceInviteTest extends OcisPhpSdkTestCase
         $this->assertCount(1, $shares);
         $createdShares = $this->ocis->getSharedByMe();
         $this->assertCount(1, $createdShares);
-        $this->assertInstanceOf(\DateTimeImmutable::class, $createdShares[0]->getExpiry());
+        $this->assertInstanceOf(\DateTimeImmutable::class, $createdShares[0]->getExpiration());
         // The returned expiry is in UTC timezone (2 hours earlier than the expiry time in Kyiv)
-        $this->assertSame("Thu, 01 Jan 2060 10:00:00 +0000", $createdShares[0]->getExpiry()->format('r'));
-        $this->assertSame("Z", $createdShares[0]->getExpiry()->getTimezone()->getName());
+        $this->assertSame("Thu, 01 Jan 2060 10:00:00 +0000", $createdShares[0]->getExpiration()->format('r'));
+        $this->assertSame("Z", $createdShares[0]->getExpiration()->getTimezone()->getName());
     }
 
     public function testGetReceiversOfShareCreatedByInvite(): void

--- a/tests/integration/Owncloud/OcisPhpSdk/ResourceShareLinkTest.php
+++ b/tests/integration/Owncloud/OcisPhpSdk/ResourceShareLinkTest.php
@@ -8,12 +8,9 @@ use OpenAPI\Client\Model\SharingLinkType;
 use Owncloud\OcisPhpSdk\DriveOrder;
 use Owncloud\OcisPhpSdk\DriveType;
 use Owncloud\OcisPhpSdk\Exception\BadRequestException;
-use Owncloud\OcisPhpSdk\Exception\ForbiddenException;
 use Owncloud\OcisPhpSdk\Ocis;
 use Owncloud\OcisPhpSdk\OcisResource;
 use Owncloud\OcisPhpSdk\OrderDirection;
-use Owncloud\OcisPhpSdk\SharingRole;
-use Owncloud\OcisPhpSdk\User;
 
 class ResourceShareLinkTest extends OcisPhpSdkTestCase
 {
@@ -51,7 +48,7 @@ class ResourceShareLinkTest extends OcisPhpSdkTestCase
     }
 
     /**
-     * @return array<int,array<int,SharingLinkType>>
+     * @return array<int,array<int,SharingLinkType|bool|string>>
      */
     public function sharingLinkTypeDataProvider(): array
     {
@@ -97,8 +94,10 @@ class ResourceShareLinkTest extends OcisPhpSdkTestCase
     {
         $tomorrow = new \DateTimeImmutable('tomorrow');
         $link = $this->fileToShare->createSharingLink(SharingLinkType::VIEW, $tomorrow);
+        $this->assertInstanceOf(\DateTimeImmutable::class, $link->getExpiration());
         $this->assertSame($tomorrow->getTimestamp(), $link->getExpiration()->getTimestamp());
         $createdShares = $this->ocis->getSharedByMe();
+        $this->assertInstanceOf(\DateTimeImmutable::class, $createdShares[0]->getExpiration());
         $this->assertSame($tomorrow->getTimestamp(), $createdShares[0]->getExpiration()->getTimestamp());
     }
 

--- a/tests/integration/Owncloud/OcisPhpSdk/ResourceShareLinkTest.php
+++ b/tests/integration/Owncloud/OcisPhpSdk/ResourceShareLinkTest.php
@@ -1,0 +1,130 @@
+<?php
+
+namespace integration\Owncloud\OcisPhpSdk;
+
+require_once __DIR__ . '/OcisPhpSdkTestCase.php';
+
+use OpenAPI\Client\Model\SharingLinkType;
+use Owncloud\OcisPhpSdk\DriveOrder;
+use Owncloud\OcisPhpSdk\DriveType;
+use Owncloud\OcisPhpSdk\Exception\BadRequestException;
+use Owncloud\OcisPhpSdk\Exception\ForbiddenException;
+use Owncloud\OcisPhpSdk\Ocis;
+use Owncloud\OcisPhpSdk\OcisResource;
+use Owncloud\OcisPhpSdk\OrderDirection;
+use Owncloud\OcisPhpSdk\SharingRole;
+use Owncloud\OcisPhpSdk\User;
+
+class ResourceShareLinkTest extends OcisPhpSdkTestCase
+{
+    private OcisResource $fileToShare;
+    private OcisResource $folderToShare;
+    private Ocis $ocis;
+    public function setUp(): void
+    {
+        parent::setUp();
+        $token = $this->getAccessToken('admin', 'admin');
+        $this->ocis = new Ocis($this->ocisUrl, $token, ['verify' => false]);
+        $personalDrive = $this->ocis->getMyDrives(
+            DriveOrder::NAME,
+            OrderDirection::ASC,
+            DriveType::PERSONAL
+        )[0];
+
+
+        $personalDrive->uploadFile('to-share-test.txt', 'some content');
+        $this->createdResources[$personalDrive->getId()][] = 'to-share-test.txt';
+        $personalDrive->createFolder('folder-to-share');
+        $this->createdResources[$personalDrive->getId()][] = 'folder-to-share';
+        $resources = $personalDrive->getResources();
+        /**
+         * @var OcisResource $resource
+         */
+        foreach ($resources as $resource) {
+            if ($resource->getName() === 'to-share-test.txt') {
+                $this->fileToShare = $resource;
+            }
+            if ($resource->getName() === 'folder-to-share') {
+                $this->folderToShare = $resource;
+            }
+        }
+    }
+
+    /**
+     * @return array<int,array<int,SharingLinkType>>
+     */
+    public function sharingLinkTypeDataProvider(): array
+    {
+        return [
+            [SharingLinkType::INTERNAL, true, true, ''],
+            [SharingLinkType::VIEW, true, true, ''],
+            [SharingLinkType::UPLOAD, false, true, ''],
+            [SharingLinkType::EDIT, false, true, ''],
+            [SharingLinkType::CREATE_ONLY, false, true, ''],
+            [SharingLinkType::BLOCKS_DOWNLOAD, true, false, 'https://github.com/owncloud/ocis/issues/7879'],
+        ];
+    }
+
+    /**
+     * @dataProvider sharingLinkTypeDataProvider
+     */
+    public function testCreateLink(
+        SharingLinkType $type,
+        bool $validForFile,
+        bool $validForFolder,
+        string $issue
+    ): void {
+        if ($issue !== '') {
+            $this->markTestSkipped($issue);
+        }
+        $expectedCountShares = 0;
+        if ($validForFile) {
+            $link = $this->fileToShare->createSharingLink($type);
+            $this->assertSame($type, $link->getType());
+            $expectedCountShares++;
+        }
+        if ($validForFolder) {
+            $link = $this->folderToShare->createSharingLink($type);
+            $this->assertSame($type, $link->getType());
+            $expectedCountShares++;
+        }
+
+        $createdShares = $this->ocis->getSharedByMe();
+        $this->assertCount($expectedCountShares, $createdShares);
+    }
+
+    public function testCreateLinkWithExpiry(): void
+    {
+        $tomorrow = new \DateTimeImmutable('tomorrow');
+        $link = $this->fileToShare->createSharingLink(SharingLinkType::VIEW, $tomorrow);
+        $this->assertSame($tomorrow->getTimestamp(), $link->getExpiration()->getTimestamp());
+        $createdShares = $this->ocis->getSharedByMe();
+        $this->assertSame($tomorrow->getTimestamp(), $createdShares[0]->getExpiration()->getTimestamp());
+    }
+
+    public function testCreateLinkPastExpiry(): void
+    {
+        $this->markTestSkipped('https://github.com/owncloud/ocis/issues/7880');
+        // @phpstan-ignore-next-line because the test is skipped
+        $this->expectException(BadRequestException::class);
+        $yesterday = new \DateTimeImmutable('yesterday');
+        $this->fileToShare->createSharingLink(SharingLinkType::VIEW, $yesterday);
+    }
+
+    public function testCreateLinkWithExpiryTimezone(): void
+    {
+        $expiry = new \DateTimeImmutable('2060-01-01 12:00:00', new \DateTimeZone('Europe/Kyiv'));
+        $link = $this->fileToShare->createSharingLink(SharingLinkType::VIEW, $expiry);
+        $this->assertInstanceOf(\DateTimeImmutable::class, $link->getExpiration());
+        // The returned expiry is in UTC timezone (2 hours earlier than the expiry time in Kyiv)
+        $this->assertSame("Thu, 01 Jan 2060 10:00:00 +0000", $link->getExpiration()->format('r'));
+        $this->assertSame("Z", $link->getExpiration()->getTimezone()->getName());
+
+        $createdShares = $this->ocis->getSharedByMe();
+        $this->assertCount(1, $createdShares);
+        $this->assertInstanceOf(\DateTimeImmutable::class, $createdShares[0]->getExpiration());
+        // The returned expiry is in UTC timezone (2 hours earlier than the expiry time in Kyiv)
+        $this->assertSame("Thu, 01 Jan 2060 10:00:00 +0000", $createdShares[0]->getExpiration()->format('r'));
+        $this->assertSame("Z", $createdShares[0]->getExpiration()->getTimezone()->getName());
+    }
+}

--- a/tests/integration/Owncloud/OcisPhpSdk/ShareCreatedModifyTest.php
+++ b/tests/integration/Owncloud/OcisPhpSdk/ShareCreatedModifyTest.php
@@ -123,4 +123,34 @@ class ShareCreatedModifyTest extends OcisPhpSdkTestCase
         );
         $share->delete();
     }
+
+    public function testSetExpirationDateOnObjectFromInvite(): void
+    {
+        $this->markTestSkipped('Not implemented yet in oCIS, see https://github.com/owncloud/ocis/issues/6993');
+        // @phpstan-ignore-next-line because the test is skipped
+        $this->expectException(NotFoundException::class);
+        $sharesFromInvite = $this->fileToShare->invite([$this->einstein], $this->viewerRole);
+        $tomorrow = new \DateTime('tomorrow');
+        $sharesFromInvite[0]->setExpiration($tomorrow);
+        $sharedByMeShares = $this->ocis->getSharedByMe();
+
+        $this->assertInstanceOf(\DateTimeImmutable::class, $sharesFromInvite[0]->getExpiry());
+        $this->assertSame($tomorrow->getTimestamp(), $sharesFromInvite[0]->getExpiry()->getTimestamp());
+        $this->assertInstanceOf(\DateTimeImmutable::class, $sharedByMeShares[0]->getExpiry());
+        $this->assertSame($tomorrow->getTimestamp(), $sharedByMeShares[0]->getExpiry()->getTimestamp());
+    }
+
+    public function testSetExpirationDateOnObjectFromSharedByMe(): void
+    {
+        $this->markTestSkipped('Not implemented yet in oCIS, see https://github.com/owncloud/ocis/issues/6993');
+        // @phpstan-ignore-next-line because the test is skipped
+        $this->expectException(NotFoundException::class);
+        $this->fileToShare->invite([$this->einstein], $this->viewerRole);
+        $tomorrow = new \DateTime('tomorrow');
+        $sharedByMeShares = $this->ocis->getSharedByMe();
+        $sharedByMeShares[0]->setExpiration($tomorrow);
+
+        $this->assertInstanceOf(\DateTimeImmutable::class, $sharedByMeShares[0]->getExpiry());
+        $this->assertSame($tomorrow->getTimestamp(), $sharedByMeShares[0]->getExpiry()->getTimestamp());
+    }
 }

--- a/tests/integration/Owncloud/OcisPhpSdk/ShareCreatedModifyTest.php
+++ b/tests/integration/Owncloud/OcisPhpSdk/ShareCreatedModifyTest.php
@@ -134,10 +134,10 @@ class ShareCreatedModifyTest extends OcisPhpSdkTestCase
         $sharesFromInvite[0]->setExpiration($tomorrow);
         $sharedByMeShares = $this->ocis->getSharedByMe();
 
-        $this->assertInstanceOf(\DateTimeImmutable::class, $sharesFromInvite[0]->getExpiry());
-        $this->assertSame($tomorrow->getTimestamp(), $sharesFromInvite[0]->getExpiry()->getTimestamp());
-        $this->assertInstanceOf(\DateTimeImmutable::class, $sharedByMeShares[0]->getExpiry());
-        $this->assertSame($tomorrow->getTimestamp(), $sharedByMeShares[0]->getExpiry()->getTimestamp());
+        $this->assertInstanceOf(\DateTimeImmutable::class, $sharesFromInvite[0]->getExpiration());
+        $this->assertSame($tomorrow->getTimestamp(), $sharesFromInvite[0]->getExpiration()->getTimestamp());
+        $this->assertInstanceOf(\DateTimeImmutable::class, $sharedByMeShares[0]->getExpiration());
+        $this->assertSame($tomorrow->getTimestamp(), $sharedByMeShares[0]->getExpiration()->getTimestamp());
     }
 
     public function testSetExpirationDateOnObjectFromSharedByMe(): void
@@ -150,7 +150,7 @@ class ShareCreatedModifyTest extends OcisPhpSdkTestCase
         $sharedByMeShares = $this->ocis->getSharedByMe();
         $sharedByMeShares[0]->setExpiration($tomorrow);
 
-        $this->assertInstanceOf(\DateTimeImmutable::class, $sharedByMeShares[0]->getExpiry());
-        $this->assertSame($tomorrow->getTimestamp(), $sharedByMeShares[0]->getExpiry()->getTimestamp());
+        $this->assertInstanceOf(\DateTimeImmutable::class, $sharedByMeShares[0]->getExpiration());
+        $this->assertSame($tomorrow->getTimestamp(), $sharedByMeShares[0]->getExpiration()->getTimestamp());
     }
 }

--- a/tests/integration/Owncloud/OcisPhpSdk/ShareCreatedModifyTest.php
+++ b/tests/integration/Owncloud/OcisPhpSdk/ShareCreatedModifyTest.php
@@ -130,7 +130,7 @@ class ShareCreatedModifyTest extends OcisPhpSdkTestCase
         // @phpstan-ignore-next-line because the test is skipped
         $this->expectException(NotFoundException::class);
         $sharesFromInvite = $this->fileToShare->invite([$this->einstein], $this->viewerRole);
-        $tomorrow = new \DateTime('tomorrow');
+        $tomorrow = new \DateTimeImmutable('tomorrow');
         $sharesFromInvite[0]->setExpiration($tomorrow);
         $sharedByMeShares = $this->ocis->getSharedByMe();
 
@@ -146,7 +146,7 @@ class ShareCreatedModifyTest extends OcisPhpSdkTestCase
         // @phpstan-ignore-next-line because the test is skipped
         $this->expectException(NotFoundException::class);
         $this->fileToShare->invite([$this->einstein], $this->viewerRole);
-        $tomorrow = new \DateTime('tomorrow');
+        $tomorrow = new \DateTimeImmutable('tomorrow');
         $sharedByMeShares = $this->ocis->getSharedByMe();
         $sharedByMeShares[0]->setExpiration($tomorrow);
 

--- a/tests/unit/Owncloud/OcisPhpSdk/ResourceInviteTest.php
+++ b/tests/unit/Owncloud/OcisPhpSdk/ResourceInviteTest.php
@@ -87,7 +87,7 @@ class ResourceInviteTest extends TestCase
             // set expiry time
             [
                 [$smartPeopleGroup],
-                new \DateTime('2022-12-31 01:02:03.456789'),
+                new \DateTimeImmutable('2022-12-31 01:02:03.456789'),
                 new DriveItemInvite(
                     [
                         'recipients' => [
@@ -99,14 +99,14 @@ class ResourceInviteTest extends TestCase
                             ),
                         ],
                         'roles' => ['uuid-of-the-role'],
-                        'expiration_date_time' => new \DateTime('2022-12-31 01:02:03.456789Z')
+                        'expiration_date_time' => new \DateTimeImmutable('2022-12-31 01:02:03.456789Z')
                     ]
                 )
             ],
             // set expiry time, with conversion to UTC/Z timezone
             [
                 [$einstein],
-                new \DateTime('2021-01-01 17:45:43.123456', new \DateTimeZone('Asia/Kathmandu')),
+                new \DateTimeImmutable('2021-01-01 17:45:43.123456', new \DateTimeZone('Asia/Kathmandu')),
                 new DriveItemInvite(
                     [
                         'recipients' => [
@@ -117,7 +117,7 @@ class ResourceInviteTest extends TestCase
                             ),
                         ],
                         'roles' => ['uuid-of-the-role'],
-                        'expiration_date_time' => new \DateTime('2021-01-01 12:00:43.123456Z')
+                        'expiration_date_time' => new \DateTimeImmutable('2021-01-01 12:00:43.123456Z')
                     ]
                 )
             ],
@@ -128,7 +128,7 @@ class ResourceInviteTest extends TestCase
      * @dataProvider inviteDataProvider
      * @param array<int, User|Group> $recipients
      */
-    public function testInvite($recipients, ?\DateTime $expiration, DriveItemInvite $expectedInviteData): void
+    public function testInvite($recipients, ?\DateTimeImmutable $expiration, DriveItemInvite $expectedInviteData): void
     {
         $permission = $this->createMock(Permission::class);
         $permission->method('getId')

--- a/tests/unit/Owncloud/OcisPhpSdk/ResourceInviteTest.php
+++ b/tests/unit/Owncloud/OcisPhpSdk/ResourceInviteTest.php
@@ -99,7 +99,7 @@ class ResourceInviteTest extends TestCase
                             ),
                         ],
                         'roles' => ['uuid-of-the-role'],
-                        'expiration_date_time' => '2022-12-31T01:02:03:456789Z'
+                        'expiration_date_time' => new \DateTime('2022-12-31 01:02:03.456789Z')
                     ]
                 )
             ],
@@ -117,7 +117,7 @@ class ResourceInviteTest extends TestCase
                             ),
                         ],
                         'roles' => ['uuid-of-the-role'],
-                        'expiration_date_time' => '2021-01-01T12:00:43:123456Z'
+                        'expiration_date_time' => new \DateTime('2021-01-01 12:00:43.123456Z')
                     ]
                 )
             ],

--- a/tests/unit/Owncloud/OcisPhpSdk/ResourceLinkTest.php
+++ b/tests/unit/Owncloud/OcisPhpSdk/ResourceLinkTest.php
@@ -28,7 +28,7 @@ class ResourceLinkTest extends TestCase
                 null,
                 new DriveItemCreateLink(
                     [
-                        'type' => 'view',
+                        'type' => SharingLinkType::VIEW,
                         'password' => null,
                         'expiration_date_time' => null,
                         'display_name' => null
@@ -43,7 +43,7 @@ class ResourceLinkTest extends TestCase
                 'the name of the link',
                 new DriveItemCreateLink(
                     [
-                        'type' => 'edit',
+                        'type' => SharingLinkType::EDIT,
                         'password' => 'a-password',
                         'expiration_date_time' => new \DateTime('2022-12-31 01:02:03.456789Z'),
                         'display_name' => 'the name of the link'
@@ -58,7 +58,7 @@ class ResourceLinkTest extends TestCase
                 null,
                 new DriveItemCreateLink(
                     [
-                        'type' => 'edit',
+                        'type' => SharingLinkType::EDIT,
                         'password' => null,
                         'expiration_date_time' => new \DateTime('2020-12-31 23:00:43.123456Z'),
                         'display_name' => null

--- a/tests/unit/Owncloud/OcisPhpSdk/ResourceLinkTest.php
+++ b/tests/unit/Owncloud/OcisPhpSdk/ResourceLinkTest.php
@@ -38,14 +38,14 @@ class ResourceLinkTest extends TestCase
             // create a link setting all data
             [
                 SharingLinkType::EDIT,
-                new \DateTime('2022-12-31 01:02:03.456789'),
+                new \DateTimeImmutable('2022-12-31 01:02:03.456789'),
                 'a-password',
                 'the name of the link',
                 new DriveItemCreateLink(
                     [
                         'type' => 'edit',
                         'password' => 'a-password',
-                        'expiration_date_time' => '2022-12-31T01:02:03:456789Z',
+                        'expiration_date_time' => new \DateTime('2022-12-31 01:02:03.456789Z'),
                         'display_name' => 'the name of the link'
                     ]
                 ),
@@ -53,14 +53,14 @@ class ResourceLinkTest extends TestCase
             // set expiry time, with conversion to UTC/Z timezone
             [
                 SharingLinkType::EDIT,
-                new \DateTime('2021-01-01 04:45:43.123456', new \DateTimeZone('Asia/Kathmandu')),
+                new \DateTimeImmutable('2021-01-01 04:45:43.123456', new \DateTimeZone('Asia/Kathmandu')),
                 null,
                 null,
                 new DriveItemCreateLink(
                     [
                         'type' => 'edit',
                         'password' => null,
-                        'expiration_date_time' => '2020-12-31T23:00:43:123456Z',
+                        'expiration_date_time' => new \DateTime('2020-12-31 23:00:43.123456Z'),
                         'display_name' => null
                     ]
                 ),
@@ -90,7 +90,7 @@ class ResourceLinkTest extends TestCase
      */
     public function testCreateLink(
         SharingLinkType $type,
-        ?\DateTime $expiration,
+        ?\DateTimeImmutable $expiration,
         ?string $password,
         ?string $displayName,
         DriveItemCreateLink $expectedCreateLinkData


### PR DESCRIPTION
This PR adds test to set the expiration date during creation of shares and links.
The tests revealed some issues that have been fixed:

- makes all date variables immutable, so that the passed in objects are not changed
- delete the timezone conversion, its not needed
- set the link type as object and not string