### PR TITLE
rearranged group related integration tests

### DIFF
--- a/tests/integration/Owncloud/OcisPhpSdk/GroupsTest.php
+++ b/tests/integration/Owncloud/OcisPhpSdk/GroupsTest.php
@@ -1,0 +1,147 @@
+<?php
+
+namespace integration\Owncloud\OcisPhpSdk;
+
+require_once __DIR__ . '/OcisPhpSdkTestCase.php';
+
+use OpenAPI\Client\Model\User;
+use Owncloud\OcisPhpSdk\Exception\NotFoundException;
+use Owncloud\OcisPhpSdk\Exception\UnauthorizedException;
+use Owncloud\OcisPhpSdk\Ocis;
+
+class GroupsTest extends OcisPhpSdkTestCase
+{
+    /**
+     * @return void
+     */
+    public function testAddUserToGroup(): void
+    {
+        $token = $this->getAccessToken('admin', 'admin');
+        $ocis = new Ocis($this->ocisUrl, $token, ['verify' => false]);
+        $users = $ocis->getUsers('admin');
+        $userName = $users[0]->getDisplayName();
+        $philosophyHatersGroup =  $ocis->createGroup(
+            "philosophy-haters",
+            "philosophy haters group"
+        );
+        $this->createdGroups = [$philosophyHatersGroup];
+        $philosophyHatersGroup->addUser($users[0]);
+        foreach ($ocis->getGroups(expandMembers: true) as $group) {
+            $this->assertGreaterThan(0, count($group->getMembers()));
+            $this->assertEquals($userName, $group->getMembers()[0]->getDisplayName());
+        }
+    }
+
+    /**
+     * @return void
+     */
+    public function testRemoveExistingUserFromGroup(): void
+    {
+        $token = $this->getAccessToken('admin', 'admin');
+        $ocis = new Ocis($this->ocisUrl, $token, ['verify' => false]);
+        $einsteinUserToken = $this->getAccessToken('einstein', 'relativity');
+        $einsteinUserOcis = new Ocis($this->ocisUrl, $einsteinUserToken, ["verify" => false]);
+        $users = $ocis->getUsers();
+        $philosophyHatersGroup =  $ocis->createGroup(
+            "philosophy-haters",
+            "philosophy haters group"
+        );
+        $this->createdGroups = [$philosophyHatersGroup];
+        foreach($users as $user) {
+            $philosophyHatersGroup->addUser($user);
+        }
+        $initialMemberCount = count($philosophyHatersGroup->getMembers());
+        foreach ($users as $user) {
+            if($user->getDisplayName() === "Albert Einstein") {
+                $philosophyHatersGroup->removeUser($user);
+            }
+        }
+        $adminUserName = $users[0]->getDisplayName();
+        $createdGroup = $ocis->getGroups(expandMembers: true);
+        $this->assertEquals($initialMemberCount - 1, count($createdGroup[0]->getMembers()));
+        $this->assertEquals($adminUserName, $createdGroup[0]->getMembers()[0]->getDisplayName());
+    }
+
+    /**
+     * @return void
+     */
+    public function testRemoveUserNotAddedToGroup(): void
+    {
+        $this->expectException(NotFoundException::class);
+        $token = $this->getAccessToken('admin', 'admin');
+        $ocis = new Ocis($this->ocisUrl, $token, ['verify' => false]);
+        $users = $ocis->getUsers('admin');
+        $philosophyHatersGroup =  $ocis->createGroup(
+            "philosophy-haters",
+            "philosophy haters group"
+        );
+        $this->createdGroups = [$philosophyHatersGroup];
+        $philosophyHatersGroup->removeUser($users[0]);
+    }
+
+    /**
+    * @return void
+    */
+    public function testAddUserToGroupInvalid(): void
+    {
+        $this->expectException(NotFoundException::class);
+        $ocis = $this->getOcis('admin', 'admin');
+        $philosophyHatersGroup =  $ocis->createGroup(
+            "philosophy-haters",
+            "philosophy haters group"
+        );
+        $this->createdGroups = [$philosophyHatersGroup];
+        $user = new User(
+            [
+                "id" => "id",
+                "display_name" => "displayname",
+                "mail" => "mail@mail.com",
+                "on_premises_sam_account_name" => "sd",
+            ]
+        );
+        $sdkUser = new \Owncloud\OcisPhpSdk\User($user);
+        $groups = $ocis->getGroups(search:"philosophy");
+        $this->assertGreaterThanOrEqual(1, $groups);
+        $groups[0]->addUser($sdkUser);
+    }
+
+    /**
+     * @return void
+     */
+    public function testAddUserToGroupUnauthorizedUser(): void
+    {
+        $this->expectException(UnauthorizedException::class);
+        $ocis = $this->getOcis('marie', 'radioactivity');
+        $physicsLoversGroup =  $ocis->createGroup(
+            "physics-lovers",
+            "physics lovers group"
+        );
+        $this->createdGroups = [$physicsLoversGroup];
+        $users = $ocis->getUsers('marie');
+        $groups = $ocis->getGroups(search:"physics");
+        $this->assertGreaterThanOrEqual(1, $groups);
+        $groups[0]->addUser($users[0]);
+    }
+
+
+    /**
+     * @return void
+     */
+    public function testDeleteGroup(): void
+    {
+        $token = $this->getAccessToken("admin", "admin");
+        $ocis = new Ocis($this->ocisUrl, $token, ["verify" => false]);
+        $philosophyHatersGroup =  $ocis->createGroup(
+            "philosophy-haters",
+            "philosophy haters group"
+        );
+        $physicsLoversGroup = $ocis->createGroup(
+            "physics-lovers",
+            "physics lover group"
+        );
+        $philosophyHatersGroup->delete();
+        $this->assertCount(1, $ocis->getGroups());
+        $this->assertEquals("physics-lovers", $ocis->getGroups()[0]->getDisplayName());
+        $this->createdGroups = [$physicsLoversGroup];
+    }
+}

--- a/tests/integration/Owncloud/OcisPhpSdk/GroupsTest.php
+++ b/tests/integration/Owncloud/OcisPhpSdk/GroupsTest.php
@@ -7,7 +7,6 @@ require_once __DIR__ . '/OcisPhpSdkTestCase.php';
 use OpenAPI\Client\Model\User;
 use Owncloud\OcisPhpSdk\Exception\NotFoundException;
 use Owncloud\OcisPhpSdk\Exception\UnauthorizedException;
-use Owncloud\OcisPhpSdk\Ocis;
 
 class GroupsTest extends OcisPhpSdkTestCase
 {
@@ -16,8 +15,7 @@ class GroupsTest extends OcisPhpSdkTestCase
      */
     public function testAddUserToGroup(): void
     {
-        $token = $this->getAccessToken('admin', 'admin');
-        $ocis = new Ocis($this->ocisUrl, $token, ['verify' => false]);
+        $ocis = $this->getOcis('admin', 'admin');
         $users = $ocis->getUsers('admin');
         $userName = $users[0]->getDisplayName();
         $philosophyHatersGroup =  $ocis->createGroup(
@@ -37,10 +35,8 @@ class GroupsTest extends OcisPhpSdkTestCase
      */
     public function testRemoveExistingUserFromGroup(): void
     {
-        $token = $this->getAccessToken('admin', 'admin');
-        $ocis = new Ocis($this->ocisUrl, $token, ['verify' => false]);
-        $einsteinUserToken = $this->getAccessToken('einstein', 'relativity');
-        $einsteinUserOcis = new Ocis($this->ocisUrl, $einsteinUserToken, ["verify" => false]);
+        $ocis = $this->getOcis('admin', 'admin');
+        $einsteinUserOcis = $this->initUser('einstein', 'relativity');
         $users = $ocis->getUsers();
         $philosophyHatersGroup =  $ocis->createGroup(
             "philosophy-haters",
@@ -68,8 +64,7 @@ class GroupsTest extends OcisPhpSdkTestCase
     public function testRemoveUserNotAddedToGroup(): void
     {
         $this->expectException(NotFoundException::class);
-        $token = $this->getAccessToken('admin', 'admin');
-        $ocis = new Ocis($this->ocisUrl, $token, ['verify' => false]);
+        $ocis = $this->getOcis('admin', 'admin');
         $users = $ocis->getUsers('admin');
         $philosophyHatersGroup =  $ocis->createGroup(
             "philosophy-haters",
@@ -111,7 +106,7 @@ class GroupsTest extends OcisPhpSdkTestCase
     public function testAddUserToGroupUnauthorizedUser(): void
     {
         $this->expectException(UnauthorizedException::class);
-        $ocis = $this->getOcis('marie', 'radioactivity');
+        $ocis = $this->initUser('marie', 'radioactivity');
         $physicsLoversGroup =  $ocis->createGroup(
             "physics-lovers",
             "physics lovers group"
@@ -129,8 +124,7 @@ class GroupsTest extends OcisPhpSdkTestCase
      */
     public function testDeleteGroup(): void
     {
-        $token = $this->getAccessToken("admin", "admin");
-        $ocis = new Ocis($this->ocisUrl, $token, ["verify" => false]);
+        $ocis = $this->getOcis('admin', 'admin');
         $philosophyHatersGroup =  $ocis->createGroup(
             "philosophy-haters",
             "philosophy haters group"

--- a/tests/integration/Owncloud/OcisPhpSdk/OcisTest.php
+++ b/tests/integration/Owncloud/OcisPhpSdk/OcisTest.php
@@ -11,7 +11,6 @@ use Owncloud\OcisPhpSdk\Exception\ForbiddenException;
 use Owncloud\OcisPhpSdk\Group;
 use Owncloud\OcisPhpSdk\Ocis;
 use Owncloud\OcisPhpSdk\OrderDirection;
-use OpenAPI\Client\Model\User;
 use Owncloud\OcisPhpSdk\Exception\NotFoundException;
 use Owncloud\OcisPhpSdk\Exception\UnauthorizedException;
 
@@ -82,6 +81,7 @@ class OcisTest extends OcisPhpSdkTestCase
             [["philosophy-haters", "physics-lovers"]],
         ];
     }
+
     /**
      * @dataProvider groupNameList
      *
@@ -110,103 +110,6 @@ class OcisTest extends OcisPhpSdkTestCase
     /**
      * @return void
      */
-    public function testAddUserToGroup(): void
-    {
-        $token = $this->getAccessToken('admin', 'admin');
-        $ocis = new Ocis($this->ocisUrl, $token, ['verify' => false]);
-        $users = $ocis->getUsers('admin');
-        $userName = $users[0]->getDisplayName();
-        $philosophyHatersGroup =  $ocis->createGroup("philosophy-haters", "philosophy haters group");
-        $this->createdGroups = [$philosophyHatersGroup];
-        $philosophyHatersGroup->addUser($users[0]);
-        foreach ($ocis->getGroups(expandMembers: true) as $group) {
-            $this->assertGreaterThan(0, count($group->getMembers()));
-            $this->assertEquals($userName, $group->getMembers()[0]->getDisplayName());
-        }
-    }
-
-    /**
-     * @return void
-     */
-    public function testRemoveExistingUserFromGroup(): void
-    {
-        $token = $this->getAccessToken('admin', 'admin');
-        $ocis = new Ocis($this->ocisUrl, $token, ['verify' => false]);
-        $einsteinUserToken = $this->getAccessToken('einstein', 'relativity');
-        $einsteinUserOcis = new Ocis($this->ocisUrl, $einsteinUserToken, ["verify" => false]);
-        $users = $ocis->getUsers();
-        $philosophyHatersGroup =  $ocis->createGroup("philosophy-haters", "philosophy haters group");
-        $this->createdGroups = [$philosophyHatersGroup];
-        foreach($users as $user) {
-            $philosophyHatersGroup->addUser($user);
-        }
-        $initialMemberCount = count($philosophyHatersGroup->getMembers());
-        foreach ($users as $user) {
-            if($user->getDisplayName() === "Albert Einstein") {
-                $philosophyHatersGroup->removeUser($user);
-            }
-        }
-        $adminUserName = $users[0]->getDisplayName();
-        $createdGroup = $ocis->getGroups(expandMembers: true);
-        $this->assertEquals($initialMemberCount - 1, count($createdGroup[0]->getMembers()));
-        $this->assertEquals($adminUserName, $createdGroup[0]->getMembers()[0]->getDisplayName());
-    }
-
-    /**
-     * @return void
-     */
-    public function testRemoveUserNotAddedToGroup(): void
-    {
-        $this->expectException(NotFoundException::class);
-        $token = $this->getAccessToken('admin', 'admin');
-        $ocis = new Ocis($this->ocisUrl, $token, ['verify' => false]);
-        $users = $ocis->getUsers('admin');
-        $philosophyHatersGroup =  $ocis->createGroup("philosophy-haters", "philosophy haters group");
-        $this->createdGroups = [$philosophyHatersGroup];
-        $philosophyHatersGroup->removeUser($users[0]);
-    }
-
-    /**
-     * @return void
-     */
-    public function testAddUserToGroupInvalid(): void
-    {
-        $this->expectException(NotFoundException::class);
-        $ocis = $this->getOcis('admin', 'admin');
-        $philosophyHatersGroup =  $ocis->createGroup("philosophy-haters", "philosophy haters group");
-        $this->createdGroups = [$philosophyHatersGroup];
-        $user = new User(
-            [
-                "id" => "id",
-                "display_name" => "displayname",
-                "mail" => "mail@mail.com",
-                "on_premises_sam_account_name" => "sd",
-            ]
-        );
-        $sdkUser = new \Owncloud\OcisPhpSdk\User($user);
-        $groups = $ocis->getGroups(search:"philosophy");
-        $this->assertGreaterThanOrEqual(1, $groups);
-        $groups[0]->addUser($sdkUser);
-    }
-
-    /**
-     * @return void
-     */
-    public function testAddUserToGroupUnauthorizedUser(): void
-    {
-        $this->expectException(UnauthorizedException::class);
-        $ocis = $this->getOcis('marie', 'radioactivity');
-        $physicsLoversGroup =  $ocis->createGroup("physics-lovers", "physics lovers group");
-        $this->createdGroups = [$physicsLoversGroup];
-        $users = $ocis->getUsers('marie');
-        $groups = $ocis->getGroups(search:"physics");
-        $this->assertGreaterThanOrEqual(1, $groups);
-        $groups[0]->addUser($users[0]);
-    }
-
-    /**
-     * @return void
-     */
     public function testGetGroupsExpanded(): void
     {
         $ocis = $this->getOcis('admin', 'admin');
@@ -219,6 +122,7 @@ class OcisTest extends OcisPhpSdkTestCase
             $this->assertGreaterThan(0, count($group->getMembers()));
         }
     }
+
     /**
      * @return array<int, array<int, array<int, string>|int|string>>
      */
@@ -247,6 +151,7 @@ class OcisTest extends OcisPhpSdkTestCase
             $this->assertEquals($groups[$i]->getDisplayName(), $groupDisplayName[$i]);
         }
     }
+
     /**
      * @return array<int, array<int, array<int,  string>|int|OrderDirection|string>>
      */
@@ -279,21 +184,6 @@ class OcisTest extends OcisPhpSdkTestCase
         for ($i = 0; $i < count($groups); $i++) {
             $this->assertEquals($resultGroups[$i], $groups[$i]->getDisplayName());
         }
-    }
-
-    /**
-     * @return void
-     */
-    public function testDeleteGroup(): void
-    {
-        $token = $this->getAccessToken("admin", "admin");
-        $ocis = new Ocis($this->ocisUrl, $token, ["verify" => false]);
-        $philosophyHatersGroup =  $ocis->createGroup("philosophy-haters", "philosophy haters group");
-        $physicsLoversGroup = $ocis->createGroup("physics-lovers", "physics lover group");
-        $philosophyHatersGroup->delete();
-        $this->assertCount(1, $ocis->getGroups());
-        $this->assertEquals("physics-lovers", $ocis->getGroups()[0]->getDisplayName());
-        $this->createdGroups = [$physicsLoversGroup];
     }
 
     /**

--- a/tests/integration/Owncloud/OcisPhpSdk/OcisTest.php
+++ b/tests/integration/Owncloud/OcisPhpSdk/OcisTest.php
@@ -191,8 +191,7 @@ class OcisTest extends OcisPhpSdkTestCase
      */
     public function testDeleteGroupById(): void
     {
-        $token = $this->getAccessToken("admin", "admin");
-        $ocis = new Ocis($this->ocisUrl, $token, ["verify" => false]);
+        $ocis = $this->getOcis('admin', 'admin');
         $ocis->createGroup("philosophy-haters", "philosophy haters group");
         $physicsLoversGroup = $ocis->createGroup("physics-lovers", "physics lover group");
         foreach($ocis->getGroups() as $group) {
@@ -210,8 +209,7 @@ class OcisTest extends OcisPhpSdkTestCase
      */
     public function testDeleteGroupByIdNoPermission(): void
     {
-        $token = $this->getAccessToken("admin", "admin");
-        $ocis = new Ocis($this->ocisUrl, $token, ["verify" => false]);
+        $ocis = $this->getOcis('admin', 'admin');
         $philosophyHatersGroup = $ocis->createGroup("philosophy-haters", "philosophy haters group");
         //any user other than admin can't get Group ID because of bug, thus bypassing this step
         //Todo : make Einstein get Group ID after this bug is solved.


### PR DESCRIPTION
Since many tests related to group were added in OcisTest inside our integration test, this PR focus on rearranging the test code and make them seperate file.