### PR TITLE
upload tests & catch 425 responses

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,18 +11,21 @@
         {
             "type": "vcs",
             "url": "https://github.com/owncloud/libre-graph-api-php.git"
+        },
+        {
+            "type": "vcs",
+            "url": "https://github.com/phil-davis/dav.git"
         }
     ],
     "require": {
         "php": "^8.1",
-        "sabre/dav": "^4.4",
+        "sabre/dav": "dev-issue-1041-alternate-a",
         "owncloud/libre-graph-api-php": "dev-main#eaa85a34b43ecad81908c189556c437ac18f7d19",
         "ext-json": "*",
         "ext-curl": "*"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.26",
-        "phan/phan": "^5.4",
         "phpunit/phpunit": "^9.6",
         "phpstan/phpstan": "^1.10"
     }

--- a/composer.json
+++ b/composer.json
@@ -11,21 +11,18 @@
         {
             "type": "vcs",
             "url": "https://github.com/owncloud/libre-graph-api-php.git"
-        },
-        {
-            "type": "vcs",
-            "url": "https://github.com/phil-davis/dav.git"
         }
     ],
     "require": {
         "php": "^8.1",
-        "sabre/dav": "dev-issue-1041-alternate-a",
+        "sabre/dav": "^4.6",
         "owncloud/libre-graph-api-php": "dev-main#eaa85a34b43ecad81908c189556c437ac18f7d19",
         "ext-json": "*",
         "ext-curl": "*"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.26",
+        "phan/phan": "^5.4",
         "phpunit/phpunit": "^9.6",
         "phpstan/phpstan": "^1.10"
     }

--- a/src/Drive.php
+++ b/src/Drive.php
@@ -368,7 +368,7 @@ class Drive
             foreach (ResourceMetadata::cases() as $property) {
                 $properties[] = $property->value;
             }
-            $responses = $webDavClient->propFind(rawurlencode(ltrim($path, "/")), $properties, 1);
+            $responses = $webDavClient->propFindUnfiltered(rawurlencode(ltrim($path, "/")), $properties, 1);
             foreach ($responses as $response) {
                 $resources[] = new OcisResource(
                     $response,

--- a/src/Exception/ConflictException.php
+++ b/src/Exception/ConflictException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Owncloud\OcisPhpSdk\Exception;
+
+/**
+ * Exception for HTTP 409 errors
+ */
+class ConflictException extends \Exception
+{
+}

--- a/src/Exception/ExceptionHelper.php
+++ b/src/Exception/ExceptionHelper.php
@@ -19,7 +19,13 @@ class ExceptionHelper
      */
     public static function getHttpErrorException(
         GuzzleException|ApiException|SabreClientHttpException|SabreClientException $e
-    ): BadRequestException|NotFoundException|ForbiddenException|UnauthorizedException|HttpException|ConflictException {
+    ): BadRequestException|
+    NotFoundException|
+    ForbiddenException|
+    UnauthorizedException|
+    HttpException|
+    ConflictException|
+    TooEarlyException {
         $message = "";
         if ($e instanceof ApiException) {
             $rawResponseBody = $e->getResponseBody();
@@ -64,6 +70,10 @@ class ExceptionHelper
             ),
             409 => new ConflictException(
                 $message,
+                $e->getCode(),
+                $e
+            ),
+            425 => new TooEarlyException(
                 $e->getCode(),
                 $e
             ),

--- a/src/Exception/ExceptionHelper.php
+++ b/src/Exception/ExceptionHelper.php
@@ -19,7 +19,7 @@ class ExceptionHelper
      */
     public static function getHttpErrorException(
         GuzzleException|ApiException|SabreClientHttpException|SabreClientException $e
-    ): BadRequestException|NotFoundException|ForbiddenException|UnauthorizedException|HttpException {
+    ): BadRequestException|NotFoundException|ForbiddenException|UnauthorizedException|HttpException|ConflictException {
         $message = "";
         if ($e instanceof ApiException) {
             $rawResponseBody = $e->getResponseBody();
@@ -58,6 +58,11 @@ class ExceptionHelper
                 $e
             ),
             404 => new NotFoundException(
+                $message,
+                $e->getCode(),
+                $e
+            ),
+            409 => new ConflictException(
                 $message,
                 $e->getCode(),
                 $e

--- a/src/Exception/TooEarlyException.php
+++ b/src/Exception/TooEarlyException.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Owncloud\OcisPhpSdk\Exception;
+
+/**
+ * Exception for HTTP 425 errors
+ */
+class TooEarlyException extends \Exception
+{
+    public function __construct(int $code = 0, \Throwable $previous = null)
+    {
+        // set default message, otherwise it will be 'Unknown' because guzzle/http does not know the 425 code
+        parent::__construct(
+            'Too early',
+            $code,
+            $previous
+        );
+    }
+}

--- a/src/Ocis.php
+++ b/src/Ocis.php
@@ -573,7 +573,7 @@ class Ocis
             foreach (ResourceMetadata::cases() as $property) {
                 $properties[] = $property->value;
             }
-            $responses = $webDavClient->propFind(rawurlencode($fileId), $properties);
+            $responses = $webDavClient->propFindUnfiltered(rawurlencode($fileId), $properties);
             $resource = new OcisResource(
                 $responses,
                 null,

--- a/src/OcisResource.php
+++ b/src/OcisResource.php
@@ -29,7 +29,7 @@ use Sabre\HTTP\ResponseInterface;
 class OcisResource
 {
     /**
-     * @var array<mixed>
+     * @var array<int, array<mixed>>
      */
     private array $metadata;
     private string $accessToken;
@@ -49,7 +49,7 @@ class OcisResource
     private string $driveId;
 
     /**
-     * @param array<mixed> $metadata of the resource
+     * @param array<int, array<mixed>> $metadata of the resource
      *        the format of the array is directly taken from the PROPFIND response
      *        returned by Sabre\DAV\Client
      *        for details about accepted metadata see: ResourceMetadata
@@ -575,6 +575,7 @@ class OcisResource
      * @throws HttpException
      * @throws InvalidResponseException
      * @throws NotFoundException
+     * @throws TooEarlyException
      */
     public function getContentStream()
     {

--- a/tests/integration/Owncloud/OcisPhpSdk/OcisPhpSdkTestCase.php
+++ b/tests/integration/Owncloud/OcisPhpSdk/OcisPhpSdkTestCase.php
@@ -153,11 +153,15 @@ class OcisPhpSdkTestCase extends TestCase
     protected function getContentOfResource425Save(OcisResource $resource): string
     {
         $content = null;
+        $timeout = 10;
+        $count = 0;
         while ($content === null) {
             try {
                 $content = $resource->getContent();
             } catch (TooEarlyException) {
+                $this->assertLessThan($timeout, $count);
                 sleep(1);
+                $count++;
             }
         }
         // check for null is done above

--- a/tests/integration/Owncloud/OcisPhpSdk/OcisPhpSdkTestCase.php
+++ b/tests/integration/Owncloud/OcisPhpSdk/OcisPhpSdkTestCase.php
@@ -5,6 +5,8 @@ namespace integration\Owncloud\OcisPhpSdk;
 use GuzzleHttp\Client;
 use Owncloud\OcisPhpSdk\Exception\NotFoundException;
 use Owncloud\OcisPhpSdk\Ocis;
+use Owncloud\OcisPhpSdk\OcisResource;
+use Owncloud\OcisPhpSdk\SharingRole;
 use PHPUnit\Framework\TestCase;
 
 class OcisPhpSdkTestCase extends TestCase
@@ -58,7 +60,7 @@ class OcisPhpSdkTestCase extends TestCase
             }
 
         }
-        foreach($this->createdGroups as $group) {
+        foreach ($this->createdGroups as $group) {
             $group->delete();
         }
         $this->createdGroups = [];
@@ -135,5 +137,15 @@ class OcisPhpSdkTestCase extends TestCase
         $ocis = new Ocis($this->ocisUrl, $token, ['verify' => false]);
         $ocis->getMyDrives();
         return $ocis;
+    }
+
+    protected function getRoleByName(OcisResource $resource, string $roleName): SharingRole
+    {
+        foreach ($resource->getRoles() as $role) {
+            if ($role->getDisplayName() === $roleName) {
+                return $role;
+            }
+        }
+        throw new \Exception('Role not found');
     }
 }

--- a/tests/integration/Owncloud/OcisPhpSdk/OcisPhpSdkTestCase.php
+++ b/tests/integration/Owncloud/OcisPhpSdk/OcisPhpSdkTestCase.php
@@ -4,6 +4,7 @@ namespace integration\Owncloud\OcisPhpSdk;
 
 use GuzzleHttp\Client;
 use Owncloud\OcisPhpSdk\Exception\NotFoundException;
+use Owncloud\OcisPhpSdk\Exception\TooEarlyException;
 use Owncloud\OcisPhpSdk\Ocis;
 use Owncloud\OcisPhpSdk\OcisResource;
 use Owncloud\OcisPhpSdk\SharingRole;
@@ -147,5 +148,18 @@ class OcisPhpSdkTestCase extends TestCase
             }
         }
         throw new \Exception('Role not found');
+    }
+
+    protected function getContentOfResource425Save(OcisResource $resource): string
+    {
+        $content = null;
+        while ($content === null) {
+            try {
+                $content = $resource->getContent();
+            } catch (TooEarlyException) {
+                sleep(1);
+            }
+        }
+        return $content;
     }
 }

--- a/tests/integration/Owncloud/OcisPhpSdk/OcisPhpSdkTestCase.php
+++ b/tests/integration/Owncloud/OcisPhpSdk/OcisPhpSdkTestCase.php
@@ -160,6 +160,8 @@ class OcisPhpSdkTestCase extends TestCase
                 sleep(1);
             }
         }
+        // check for null is done above
+        // @phan-suppress-next-line PhanTypeMismatchReturnNullable
         return $content;
     }
 }

--- a/tests/integration/Owncloud/OcisPhpSdk/OcisResourceTest.php
+++ b/tests/integration/Owncloud/OcisPhpSdk/OcisResourceTest.php
@@ -7,6 +7,8 @@ require_once __DIR__ . '/OcisPhpSdkTestCase.php';
 use Owncloud\OcisPhpSdk\Drive;
 use Owncloud\OcisPhpSdk\DriveOrder;
 use Owncloud\OcisPhpSdk\DriveType;
+use Owncloud\OcisPhpSdk\Exception\ConflictException;
+use Owncloud\OcisPhpSdk\Exception\ForbiddenException;
 use Owncloud\OcisPhpSdk\Exception\NotFoundException;
 use Owncloud\OcisPhpSdk\Ocis;
 use Owncloud\OcisPhpSdk\OcisResource; // @phan-suppress-current-line PhanUnreferencedUseNormal it's used in a comment
@@ -15,12 +17,13 @@ use Owncloud\OcisPhpSdk\OrderDirection;
 class OcisResourceTest extends OcisPhpSdkTestCase
 {
     private Drive $personalDrive;
+    private Ocis $ocis;
     public function setUp(): void
     {
         parent::setUp();
         $token = $this->getAccessToken('admin', 'admin');
-        $ocis = new Ocis($this->ocisUrl, $token, ['verify' => false]);
-        $this->personalDrive = $ocis->getMyDrives(
+        $this->ocis = new Ocis($this->ocisUrl, $token, ['verify' => false]);
+        $this->personalDrive = $this->ocis->getMyDrives(
             DriveOrder::NAME,
             OrderDirection::ASC,
             DriveType::PERSONAL
@@ -32,6 +35,43 @@ class OcisResourceTest extends OcisPhpSdkTestCase
         $this->createdResources[$this->personalDrive->getId()][] = '/somefile.txt';
         $this->createdResources[$this->personalDrive->getId()][] = '/secondfile.txt';
         $this->createdResources[$this->personalDrive->getId()][] = '/subfolder';
+    }
+
+    /**
+     * @param Ocis $ocis
+     * @return array<Drive>
+     */
+    private function getMountpoints(Ocis $ocis): array
+    {
+        // we need to wait till the mountpoint appears
+        $retryCounter = 0;
+        do {
+            $mountpoints = $ocis->getMyDrives(
+                DriveOrder::NAME,
+                OrderDirection::ASC,
+                DriveType::MOUNTPOINT
+            );
+            if (count($mountpoints) === 0) {
+                sleep(1);
+            }
+            $retryCounter++;
+            $this->assertLessThan(10, $retryCounter);
+        } while (count($mountpoints) === 0);
+        return $mountpoints;
+    }
+
+    private function share(string $receiverName, string $roleName, string $resourceName): void
+    {
+        $receiver = $this->ocis->getUsers($receiverName)[0];
+        $resources = $this->personalDrive->getResources();
+
+        foreach ($resources as $resource) {
+            if ($resource->getName() === $resourceName) {
+                $role = $this->getRoleByName($resource, $roleName);
+                $resource->invite([$receiver], $role);
+                break;
+            }
+        }
     }
 
     public function testGetResources(): void
@@ -152,5 +192,82 @@ class OcisResourceTest extends OcisPhpSdkTestCase
                     break;
             }
         }
+    }
+
+    public function testUploadFile(): void
+    {
+        $this->personalDrive->uploadFile('/subfolder/uploaded.txt', 'some content');
+        $resources = $this->personalDrive->getResources('/subfolder');
+        $this->assertCount(1, $resources);
+        $this->assertEquals('uploaded.txt', $resources[0]->getName());
+        $this->assertEquals('some content', $resources[0]->getContent());
+    }
+
+    public function testUploadFileOverwritingExisting(): void
+    {
+        $this->personalDrive->uploadFile('/subfolder/uploaded.txt', 'some content');
+        $this->personalDrive->uploadFile('/subfolder/uploaded.txt', 'new content');
+        $resources = $this->personalDrive->getResources('/subfolder');
+        $this->assertCount(1, $resources);
+        $this->assertEquals('uploaded.txt', $resources[0]->getName());
+        $this->assertEquals('new content', $resources[0]->getContent());
+    }
+
+    public function testUploadFileNotExistingFolder(): void
+    {
+        $this->expectException(ConflictException::class);
+        $this->personalDrive->uploadFile('/folder-not-existing/uploaded.txt', 'some content');
+    }
+
+    public function testUploadFileToReceivedFolderShare(): void
+    {
+        $einsteinOcis = $this->initUser('einstein', 'relativity');
+        $this->share('einstein', 'Editor', 'subfolder');
+
+        $sharesReceivedByEinstein = $this->getMountpoints($einsteinOcis);
+
+        $sharesReceivedByEinstein[0]->uploadFile('/uploaded.txt', 'some content');
+
+        $resources = $this->personalDrive->getResources('/subfolder');
+        $this->assertCount(1, $resources);
+        $this->assertEquals('uploaded.txt', $resources[0]->getName());
+        $this->assertEquals('some content', $resources[0]->getContent());
+    }
+
+    public function testUploadFileNoPermission(): void
+    {
+        $einsteinOcis = $this->initUser('einstein', 'relativity');
+        $einstein = $this->ocis->getUsers('einstein')[0];
+        $resources = $this->personalDrive->getResources();
+
+        foreach ($resources as $resource) {
+            if ($resource->getName() === 'subfolder') {
+                $role = $this->getRoleByName($resource, 'Viewer');
+                $resource->invite([$einstein], $role);
+                break;
+            }
+        }
+
+        $sharesReceivedByEinstein = $this->getMountpoints($einsteinOcis);
+
+        $this->expectException(ForbiddenException::class);
+        $sharesReceivedByEinstein[0]->uploadFile('/uploaded.txt', 'some content');
+    }
+
+    public function testUploadFileStream(): void
+    {
+        $localFileName = tempnam(sys_get_temp_dir(), "FOO");
+        $this->assertNotFalse($localFileName, 'could not create temp file');
+        $fp = fopen($localFileName, "w");
+        $this->assertNotFalse($fp, 'could not open temp file');
+        $this->assertSame(12, fwrite($fp, 'some content'));
+        fclose($fp);
+        $fp = fopen($localFileName, "r");
+        $this->assertNotFalse($fp, 'could not open temp file');
+        $this->personalDrive->uploadFileStream('/subfolder/uploaded.txt', $fp);
+        $resources = $this->personalDrive->getResources('/subfolder');
+        $this->assertCount(1, $resources);
+        $this->assertEquals('uploaded.txt', $resources[0]->getName());
+        $this->assertEquals('some content', $resources[0]->getContent());
     }
 }

--- a/tests/integration/Owncloud/OcisPhpSdk/OcisResourceTest.php
+++ b/tests/integration/Owncloud/OcisPhpSdk/OcisResourceTest.php
@@ -187,6 +187,8 @@ class OcisResourceTest extends OcisPhpSdkTestCase
                     sleep(1);
                 }
             }
+            // check for null is done above
+            // @phan-suppress-next-line PhanTypeMismatchArgumentNullableInternal
             $content = fread($stream, 1024);
             switch ($resource->getName()) {
                 case 'somefile.txt':

--- a/tests/integration/Owncloud/OcisPhpSdk/OcisTest.php
+++ b/tests/integration/Owncloud/OcisPhpSdk/OcisTest.php
@@ -242,7 +242,8 @@ class OcisTest extends OcisPhpSdkTestCase
         $this->assertSame('somefile.txt', $resource->getName());
         $this->assertSame('file', $resource->getType());
         $this->assertSame(12, $resource->getSize());
-        $this->assertSame('some content', $resource->getContent());
+        $content = $this->getContentOfResource425Save($resource);
+        $this->assertSame('some content', $content);
         $this->assertSame($personalDrive->getId(), $resource->getDriveId());
     }
 
@@ -292,7 +293,8 @@ class OcisTest extends OcisPhpSdkTestCase
         $this->assertSame('somefile.txt', $resource->getName());
         $this->assertSame('file', $resource->getType());
         $this->assertSame(12, $resource->getSize());
-        $this->assertSame('some content', $resource->getContent());
+        $content = $this->getContentOfResource425Save($resource);
+        $this->assertSame('some content', $content);
         $this->assertSame($personalDrive->getId(), $resource->getDriveId());
     }
 

--- a/tests/integration/compose.yaml
+++ b/tests/integration/compose.yaml
@@ -74,6 +74,7 @@ services:
       GRAPH_ASSIGN_DEFAULT_USER_ROLE: false
       GRAPH_USERNAME_MATCH: "none"
       OCIS_LOG_LEVEL: "debug"
+      POSTPROCESSING_DELAY: "15s"
     restart: unless-stopped
     labels:
       - "traefik.enable=true"

--- a/tests/integration/compose.yaml
+++ b/tests/integration/compose.yaml
@@ -74,7 +74,6 @@ services:
       GRAPH_ASSIGN_DEFAULT_USER_ROLE: false
       GRAPH_USERNAME_MATCH: "none"
       OCIS_LOG_LEVEL: "debug"
-      POSTPROCESSING_DELAY: "15s"
     restart: unless-stopped
     labels:
       - "traefik.enable=true"

--- a/tests/unit/Owncloud/OcisPhpSdk/ResourceInviteTest.php
+++ b/tests/unit/Owncloud/OcisPhpSdk/ResourceInviteTest.php
@@ -146,7 +146,9 @@ class ResourceInviteTest extends TestCase
             'drivesPermissionsApi' => $drivesPermissionsApi,
         ];
         $resourceMetadata = [
-            '{http://owncloud.org/ns}id' => 'uuid-of-the-resource',
+            200 => [
+                '{http://owncloud.org/ns}id' => 'uuid-of-the-resource',
+            ]
         ];
 
         $resource = new OcisResource(

--- a/tests/unit/Owncloud/OcisPhpSdk/ResourceLinkTest.php
+++ b/tests/unit/Owncloud/OcisPhpSdk/ResourceLinkTest.php
@@ -74,9 +74,9 @@ class ResourceLinkTest extends TestCase
         $connectionConfig = [
             'drivesPermissionsApi' => $drivesPermissionsApi,
         ];
-        $resourceMetadata = [
+        $resourceMetadata = [200 => [
             '{http://owncloud.org/ns}id' => 'uuid-of-the-resource',
-        ];
+        ]];
         return new OcisResource(
             $resourceMetadata,
             'uuid-of-the-drive',

--- a/tests/unit/Owncloud/OcisPhpSdk/ResourceTest.php
+++ b/tests/unit/Owncloud/OcisPhpSdk/ResourceTest.php
@@ -58,7 +58,7 @@ class ResourceTest extends TestCase
     public function testGetFileTypeValid(string|null $resourceType, string $expectedResult): void
     {
         $metadata = [];
-        $metadata['{DAV:}resourcetype'] = new ResourceType($resourceType);
+        $metadata[200]['{DAV:}resourcetype'] = new ResourceType($resourceType);
         $resource = $this->createOcisResource($metadata);
         $result = $resource->getType();
         $this->assertSame($expectedResult, $result);
@@ -88,7 +88,7 @@ class ResourceTest extends TestCase
         $metadata = [];
         $this->expectException(InvalidResponseException::class);
         $this->expectExceptionMessage("Received invalid data for the key \"resourcetype\" in the response array");
-        $metadata['{DAV:}resourcetype'] = new ResourceType($resourceType);
+        $metadata[200]['{DAV:}resourcetype'] = new ResourceType($resourceType);
         $resource = $this->createOcisResource($metadata);
         $result = $resource->getType();
     }
@@ -128,8 +128,8 @@ class ResourceTest extends TestCase
         string $sizeKey
     ): void {
         $metadata = [];
-        $metadata['{DAV:}resourcetype'] = new ResourceType($data);
-        $metadata[$sizeKey] = $actualSize;
+        $metadata[200]['{DAV:}resourcetype'] = new ResourceType($data);
+        $metadata[200][$sizeKey] = $actualSize;
         $resource = $this->createOcisResource($metadata);
         $result = $resource->getSize();
         $this->assertSame($expectedSize, $result);
@@ -154,8 +154,8 @@ class ResourceTest extends TestCase
         $metadata = [];
         $this->expectException(InvalidResponseException::class);
         $this->expectExceptionMessage("Received an invalid value for size in the response");
-        $metadata['{DAV:}resourcetype'] = new ResourceType($data);
-        $metadata[$sizeKey] = $actualSize;
+        $metadata[200]['{DAV:}resourcetype'] = new ResourceType($data);
+        $metadata[200][$sizeKey] = $actualSize;
         $resource = $this->createOcisResource($metadata);
         $result = $resource->getSize();
     }
@@ -183,8 +183,8 @@ class ResourceTest extends TestCase
     public function testGetContentType(string $expectedResult, null|string $fileType): void
     {
         $metadata = [];
-        $metadata['{DAV:}resourcetype'] = new ResourceType($fileType);
-        $metadata['{DAV:}getcontenttype'] = $expectedResult;
+        $metadata[200]['{DAV:}resourcetype'] = new ResourceType($fileType);
+        $metadata[200]['{DAV:}getcontenttype'] = $expectedResult;
         $resource = $this->createOcisResource($metadata);
         $result = $resource->getContentType();
         $this->assertSame($expectedResult, $result);
@@ -198,7 +198,7 @@ class ResourceTest extends TestCase
         $metadata = [];
         $tags = [["mytag"], ["asd", "asd"], [''], [null]];
         foreach ($tags as $tag) {
-            $metadata['{http://owncloud.org/ns}tags'] = implode(',', $tag);
+            $metadata[200]['{http://owncloud.org/ns}tags'] = implode(',', $tag);
             $resource = $this->createOcisResource($metadata);
             $result = $resource->getTags();
             if ($tag === [null] || $tag === ['']) {
@@ -226,7 +226,7 @@ class ResourceTest extends TestCase
     public function testGetFavorite(string|int $value): void
     {
         $metadata = [];
-        $metadata['{http://owncloud.org/ns}favorite'] = $value;
+        $metadata[200]['{http://owncloud.org/ns}favorite'] = $value;
         $resource = $this->createOcisResource($metadata);
         $result = $resource->isFavorited();
         $this->assertIsBool($result);
@@ -252,7 +252,7 @@ class ResourceTest extends TestCase
         $metadata = [];
         $this->expectException(InvalidResponseException::class);
         $this->expectExceptionMessage("Value of property \"favorite\" invalid in the server response");
-        $metadata['{http://owncloud.org/ns}favorite'] = $value;
+        $metadata[200]['{http://owncloud.org/ns}favorite'] = $value;
         $resource = $this->createOcisResource($metadata);
         $resource->isFavorited();
     }
@@ -279,9 +279,9 @@ class ResourceTest extends TestCase
     public function testGetCheckSum(array $value, string|null $fileType): void
     {
         $metadata = [];
-        $metadata['{DAV:}resourcetype'] = new ResourceType($fileType);
-        $metadata['{DAV:}getcontentlength'] = 1;
-        $metadata['{http://owncloud.org/ns}checksums'] = $value;
+        $metadata[200]['{DAV:}resourcetype'] = new ResourceType($fileType);
+        $metadata[200]['{DAV:}getcontentlength'] = 1;
+        $metadata[200]['{http://owncloud.org/ns}checksums'] = $value;
         $resource = $this->createOcisResource($metadata);
         $result = $resource->getCheckSums();
         $this->assertEquals($value, $result);
@@ -295,9 +295,9 @@ class ResourceTest extends TestCase
         $metadata = [];
         foreach ($this->properties as ['property' => $property, "function" => $propertyFunc]) {
             if (in_array($property, ['etag', 'lastmodified'])) {
-                $metadata['{DAV:}get' . $property] = $property;
+                $metadata[200]['{DAV:}get' . $property] = $property;
             } else {
-                $metadata['{http://owncloud.org/ns}' . $property] = $property;
+                $metadata[200]['{http://owncloud.org/ns}' . $property] = $property;
             }
             $resource = $this->createOcisResource($metadata);
             $result = $resource->$propertyFunc();
@@ -312,7 +312,7 @@ class ResourceTest extends TestCase
     {
         $metadata = [];
         foreach ($this->properties as ['property' => $property, "function" => $propertyFunc]) {
-            $metadata[''] = $property;
+            $metadata[200][''] = $property;
             $resource = $this->createOcisResource($metadata);
             $result = null;
             try {
@@ -332,9 +332,9 @@ class ResourceTest extends TestCase
         $metadata = [];
         foreach ($this->properties as ['property' => $property, "function" => $propertyFunc]) {
             if (in_array($property, ["etag", "lastmodified"])) {
-                $metadata['{DAV:}get' . $property] = null;
+                $metadata[200]['{DAV:}get' . $property] = null;
             } else {
-                $metadata['{http://owncloud.org/ns}' . $property] = null;
+                $metadata[200]['{http://owncloud.org/ns}' . $property] = null;
             }
             $resource = $this->createOcisResource($metadata);
             $result = null;
@@ -354,7 +354,7 @@ class ResourceTest extends TestCase
         $driveApiMock->method('getDrive')
             ->willReturn($driveMock);
         $accessToken = 'aaa';
-        $metadata = ['{http://owncloud.org/ns}spaceid' => 'spaceid'];
+        $metadata[200] = ['{http://owncloud.org/ns}spaceid' => 'spaceid'];
         $this->expectException(InvalidResponseException::class);
         $this->expectExceptionMessage('Could not get drive id');
         // @phan-suppress-next-line PhanNoopNew we are expecting an exception
@@ -374,7 +374,7 @@ class ResourceTest extends TestCase
         $driveApiMock->method('getDrive')
             ->willReturn($errorMock);
         $accessToken = 'aaa';
-        $metadata = ['{http://owncloud.org/ns}spaceid' => 'spaceid'];
+        $metadata[200] = ['{http://owncloud.org/ns}spaceid' => 'spaceid'];
         $this->expectException(InvalidResponseException::class);
         $this->expectExceptionMessage('getDrive returned an OdataError - ');
         // @phan-suppress-next-line PhanNoopNew we are expecting an exception

--- a/tests/unit/Owncloud/OcisPhpSdk/ResourceTest.php
+++ b/tests/unit/Owncloud/OcisPhpSdk/ResourceTest.php
@@ -37,7 +37,7 @@ class ResourceTest extends TestCase
     }
 
     /**
-     * @param array<mixed> $metadata
+     * @param array<int, array<mixed>> $metadata
      * @return OcisResource
      */
     private function createOcisResource(array $metadata): OcisResource
@@ -354,7 +354,7 @@ class ResourceTest extends TestCase
         $driveApiMock->method('getDrive')
             ->willReturn($driveMock);
         $accessToken = 'aaa';
-        $metadata[200] = ['{http://owncloud.org/ns}spaceid' => 'spaceid'];
+        $metadata = [200 => ['{http://owncloud.org/ns}spaceid' => 'spaceid']];
         $this->expectException(InvalidResponseException::class);
         $this->expectExceptionMessage('Could not get drive id');
         // @phan-suppress-next-line PhanNoopNew we are expecting an exception
@@ -374,7 +374,7 @@ class ResourceTest extends TestCase
         $driveApiMock->method('getDrive')
             ->willReturn($errorMock);
         $accessToken = 'aaa';
-        $metadata[200] = ['{http://owncloud.org/ns}spaceid' => 'spaceid'];
+        $metadata = [200 => ['{http://owncloud.org/ns}spaceid' => 'spaceid']];
         $this->expectException(InvalidResponseException::class);
         $this->expectExceptionMessage('getDrive returned an OdataError - ');
         // @phan-suppress-next-line PhanNoopNew we are expecting an exception


### PR DESCRIPTION
The main purpose of this PR is to create upload tests, but to make them (basically the downloads) reliably I had to implement catching 425(too early) issues.

This is based on https://github.com/sabre-io/dav/pull/1519

should fix #75