### PR TITLE
unskip test for share link with past expiry

### DIFF
--- a/tests/integration/Owncloud/OcisPhpSdk/ResourceShareLinkTest.php
+++ b/tests/integration/Owncloud/OcisPhpSdk/ResourceShareLinkTest.php
@@ -104,8 +104,6 @@ class ResourceShareLinkTest extends OcisPhpSdkTestCase
 
     public function testCreateLinkPastExpiry(): void
     {
-        $this->markTestSkipped('https://github.com/owncloud/ocis/issues/7880');
-        // @phpstan-ignore-next-line because the test is skipped
         $this->expectException(BadRequestException::class);
         $yesterday = new \DateTimeImmutable('yesterday');
         $this->fileToShare->createSharingLink(SharingLinkType::VIEW, $yesterday, self::PASSWORD);


### PR DESCRIPTION
unskip the test, because the related bug in ocis was fixed
