### PR TITLE
use spaceid from PROPFIND in OcisResource

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,3 +1,3 @@
 # The version of OCIS to use in pipelines that test against OCIS
-OCIS_COMMITID=55f3ef0aff4c2ee58e4cf7b8a38391b43c0c576f
-OCIS_BRANCH=master
+OCIS_COMMITID=0c68af5369aed5fe74a5952ed48a06e3cb335b17
+OCIS_BRANCH=fix-ocdav-spaceid

--- a/.drone.env
+++ b/.drone.env
@@ -1,3 +1,3 @@
 # The version of OCIS to use in pipelines that test against OCIS
-OCIS_COMMITID=0c68af5369aed5fe74a5952ed48a06e3cb335b17
-OCIS_BRANCH=fix-ocdav-spaceid
+OCIS_COMMITID=39b6fe17500b707d2e9db9e696db648a95893cdf
+OCIS_BRANCH=master

--- a/src/Drive.php
+++ b/src/Drive.php
@@ -386,7 +386,6 @@ class Drive
             foreach ($responses as $response) {
                 $resources[] = new OcisResource(
                     $response,
-                    $this->getId(),
                     $this->connectionConfig,
                     $this->serviceUrl,
                     $this->accessToken

--- a/src/Ocis.php
+++ b/src/Ocis.php
@@ -585,7 +585,6 @@ class Ocis
             $responses = $webDavClient->propFindUnfiltered(rawurlencode($fileId), $properties);
             $resource = new OcisResource(
                 $responses,
-                null,
                 $this->connectionConfig,
                 $this->serviceUrl,
                 $this->accessToken

--- a/src/OcisResource.php
+++ b/src/OcisResource.php
@@ -558,11 +558,6 @@ class OcisResource
         return $response->getBodyAsStream();
     }
 
-    public function getDriveId(): string
-    {
-        return $this->driveId;
-    }
-
     /**
      * @throws BadRequestException
      * @throws ForbiddenException

--- a/src/OcisResource.php
+++ b/src/OcisResource.php
@@ -3,7 +3,6 @@
 namespace Owncloud\OcisPhpSdk;
 
 use GuzzleHttp\Client;
-use OpenAPI\Client\Api\DrivesApi;
 use OpenAPI\Client\Api\DrivesPermissionsApi;
 use OpenAPI\Client\ApiException;
 use OpenAPI\Client\Configuration;

--- a/src/OcisResource.php
+++ b/src/OcisResource.php
@@ -3,6 +3,7 @@
 namespace Owncloud\OcisPhpSdk;
 
 use GuzzleHttp\Client;
+use OpenAPI\Client\Api\DrivesApi; // @phan-suppress-current-line PhanUnreferencedUseNormal it's used in a comment
 use OpenAPI\Client\Api\DrivesPermissionsApi;
 use OpenAPI\Client\ApiException;
 use OpenAPI\Client\Configuration;

--- a/src/OcisResource.php
+++ b/src/OcisResource.php
@@ -47,14 +47,12 @@ class OcisResource
 
     private array $connectionConfig;
     private Configuration $graphApiConfig;
-    private string $driveId;
 
     /**
      * @param array<int, array<mixed>> $metadata of the resource
      *        the format of the array is directly taken from the PROPFIND response
      *        returned by Sabre\DAV\Client
      *        for details about accepted metadata see: ResourceMetadata
-     * @param string|null $driveId if null the driveId will be fetched from the server using the space-id
      * @param array $connectionConfig
      * @param string $serviceUrl
      * @param string $accessToken
@@ -79,7 +77,6 @@ class OcisResource
      */
     public function __construct(
         array $metadata,
-        ?string $driveId,
         array $connectionConfig,
         string $serviceUrl,
         string &$accessToken
@@ -94,35 +91,6 @@ class OcisResource
             ->setHost($this->serviceUrl . '/graph');
 
         $this->connectionConfig = $connectionConfig;
-        if ($driveId === null) {
-            $guzzle = new Client(
-                Ocis::createGuzzleConfig($this->connectionConfig, $this->accessToken)
-            );
-
-            if (array_key_exists('drivesApi', $this->connectionConfig)) {
-                $apiInstance = $this->connectionConfig['drivesApi'];
-            } else {
-                $apiInstance = new DrivesApi(
-                    $guzzle,
-                    $this->graphApiConfig
-                );
-            }
-            try {
-                $drive = $apiInstance->getDrive($this->getSpaceId());
-            } catch (ApiException $e) {
-                throw ExceptionHelper::getHttpErrorException($e);
-            }
-            if ($drive instanceof OdataError) {
-                throw new InvalidResponseException(
-                    "getDrive returned an OdataError - " . $drive->getError()
-                );
-            }
-            $driveId = $drive->getId();
-            if ($driveId === null) {
-                throw new InvalidResponseException('Could not get drive id');
-            }
-        }
-        $this->driveId = $driveId;
     }
 
     /**
@@ -189,7 +157,7 @@ class OcisResource
             );
         }
         try {
-            $collectionOfPermissions = $apiInstance->listPermissions($this->driveId, $this->getId());
+            $collectionOfPermissions = $apiInstance->listPermissions($this->getSpaceId(), $this->getId());
         } catch (ApiException $e) {
             throw ExceptionHelper::getHttpErrorException($e);
         }
@@ -254,7 +222,7 @@ class OcisResource
 
         $inviteData = new DriveItemInvite($driveItemInviteData);
         try {
-            $permissions = $apiInstance->invite($this->driveId, $this->getId(), $inviteData);
+            $permissions = $apiInstance->invite($this->getSpaceId(), $this->getId(), $inviteData);
         } catch (ApiException $e) {
             throw ExceptionHelper::getHttpErrorException($e);
         }
@@ -277,7 +245,7 @@ class OcisResource
             $shares[] = new ShareCreated(
                 $permission,
                 $this->getId(),
-                $this->driveId,
+                $this->getSpaceId(),
                 $this->connectionConfig,
                 $this->serviceUrl,
                 $this->accessToken
@@ -327,7 +295,7 @@ class OcisResource
             'display_name' => $displayName
         ]);
         try {
-            $permission = $apiInstance->createLink($this->driveId, $this->getId(), $createLinkData);
+            $permission = $apiInstance->createLink($this->getSpaceId(), $this->getId(), $createLinkData);
         } catch (ApiException $e) {
             throw ExceptionHelper::getHttpErrorException($e);
         }
@@ -340,7 +308,7 @@ class OcisResource
         return new ShareLink(
             $permission,
             $this->getId(),
-            $this->driveId,
+            $this->getSpaceId(),
             $this->connectionConfig,
             $this->serviceUrl,
             $this->accessToken

--- a/tests/integration/Owncloud/OcisPhpSdk/OcisPhpSdkTestCase.php
+++ b/tests/integration/Owncloud/OcisPhpSdk/OcisPhpSdkTestCase.php
@@ -128,6 +128,11 @@ class OcisPhpSdkTestCase extends TestCase
         return $this->getUUIDv4Regex() . '\\$' . $this->getUUIDv4Regex() . '!' . $this->getUUIDv4Regex();
     }
 
+
+    protected function getspaceIdRegex(): string
+    {
+        return $this->getUUIDv4Regex() . '\\$' . $this->getUUIDv4Regex();
+    }
     /**
      * init a user
      * ocis is only aware of users after the first login, because we are using keycloak

--- a/tests/integration/Owncloud/OcisPhpSdk/OcisResourceTest.php
+++ b/tests/integration/Owncloud/OcisPhpSdk/OcisResourceTest.php
@@ -105,7 +105,7 @@ class OcisResourceTest extends OcisPhpSdkTestCase
             );
 
             $this->assertMatchesRegularExpression(
-                "/^" . $this->getUUIDv4Regex() . "$/i",
+                "/^" . $this->getspaceIdRegex() . "$/i",
                 $resource->getSpaceId()
             );
             $this->assertMatchesRegularExpression(

--- a/tests/integration/Owncloud/OcisPhpSdk/OcisTest.php
+++ b/tests/integration/Owncloud/OcisPhpSdk/OcisTest.php
@@ -475,7 +475,7 @@ class OcisTest extends OcisPhpSdkTestCase
         $this->assertSame(12, $resource->getSize());
         $content = $this->getContentOfResource425Save($resource);
         $this->assertSame('some content', $content);
-        $this->assertSame($personalDrive->getId(), $resource->getDriveId());
+        $this->assertSame($personalDrive->getId(), $resource->getSpaceId());
     }
 
     public function testGetResourceByIdEmptyFolder(): void
@@ -491,7 +491,7 @@ class OcisTest extends OcisPhpSdkTestCase
         $this->assertSame('folder', $resource->getType());
         $this->assertSame(0, $resource->getSize());
         $this->assertSame('', $resource->getContent()); // getting a folder does not return any content
-        $this->assertSame($personalDrive->getId(), $resource->getDriveId());
+        $this->assertSame($personalDrive->getId(), $resource->getSpaceId());
     }
 
     public function testGetResourceByIdFolderWithContent(): void
@@ -508,7 +508,7 @@ class OcisTest extends OcisPhpSdkTestCase
         $this->assertSame('folder', $resource->getType());
         $this->assertSame(12, $resource->getSize());
         $this->assertSame('', $resource->getContent()); // getting a folder does not return any content
-        $this->assertSame($personalDrive->getId(), $resource->getDriveId());
+        $this->assertSame($personalDrive->getId(), $resource->getSpaceId());
     }
 
     public function testGetResourceByIdFileInAFolder(): void
@@ -526,7 +526,7 @@ class OcisTest extends OcisPhpSdkTestCase
         $this->assertSame(12, $resource->getSize());
         $content = $this->getContentOfResource425Save($resource);
         $this->assertSame('some content', $content);
-        $this->assertSame($personalDrive->getId(), $resource->getDriveId());
+        $this->assertSame($personalDrive->getId(), $resource->getSpaceId());
     }
 
     public function testGetResourceInvalidId(): void

--- a/tests/integration/Owncloud/OcisPhpSdk/ResourceInviteTest.php
+++ b/tests/integration/Owncloud/OcisPhpSdk/ResourceInviteTest.php
@@ -11,8 +11,7 @@ use Owncloud\OcisPhpSdk\Exception\ForbiddenException;
 use Owncloud\OcisPhpSdk\Ocis;
 use Owncloud\OcisPhpSdk\OcisResource;
 use Owncloud\OcisPhpSdk\OrderDirection;
-use Owncloud\OcisPhpSdk\ShareCreated;
-use Owncloud\OcisPhpSdk\ShareReceived;
+use Owncloud\OcisPhpSdk\ShareReceived; // @phan-suppress-current-line PhanUnreferencedUseNormal it's used in a comment
 use Owncloud\OcisPhpSdk\SharingRole;
 use Owncloud\OcisPhpSdk\User;
 

--- a/tests/integration/Owncloud/OcisPhpSdk/ResourceInviteTest.php
+++ b/tests/integration/Owncloud/OcisPhpSdk/ResourceInviteTest.php
@@ -11,6 +11,8 @@ use Owncloud\OcisPhpSdk\Exception\ForbiddenException;
 use Owncloud\OcisPhpSdk\Ocis;
 use Owncloud\OcisPhpSdk\OcisResource;
 use Owncloud\OcisPhpSdk\OrderDirection;
+use Owncloud\OcisPhpSdk\ShareCreated;
+use Owncloud\OcisPhpSdk\ShareReceived;
 use Owncloud\OcisPhpSdk\SharingRole;
 use Owncloud\OcisPhpSdk\User;
 
@@ -264,5 +266,25 @@ class ResourceInviteTest extends OcisPhpSdkTestCase
                 )
             );
         }
+    }
+
+    public function testInviteUserToAReceivedShare(): void
+    {
+        $this->fileToShare->invite([$this->einstein], $this->managerRole);
+        /**
+         * @var ShareReceived $receivedShare
+         */
+        $receivedShare = $this->einsteinOcis->getSharedWithMe()[0];
+        $resource = $this->einsteinOcis->getResourceById($receivedShare->getRemoteItemId());
+        $resource->invite([$this->marie], $this->viewerRole);
+        /**
+         * @var ShareReceived $receivedShare
+         */
+        $receivedShare = $this->marieOcis->getSharedWithMe()[0];
+        $this->assertSame('to-share-test.txt', $receivedShare->getName());
+        $this->assertSame(
+            'some content',
+            $this->marieOcis->getResourceById($receivedShare->getRemoteItemId())->getContent()
+        );
     }
 }

--- a/tests/integration/Owncloud/OcisPhpSdk/ResourceInviteTest.php
+++ b/tests/integration/Owncloud/OcisPhpSdk/ResourceInviteTest.php
@@ -21,7 +21,7 @@ class ResourceInviteTest extends OcisPhpSdkTestCase
     private User $einstein;
     private User $marie;
     private SharingRole $viewerRole;
-    private SharingRole $managerRole; // @phpstan-ignore-line the property is used, but in a skipped test
+    private SharingRole $managerRole;
     private OcisResource $fileToShare;
     private OcisResource $folderToShare;
     private Ocis $ocis;

--- a/tests/integration/Owncloud/OcisPhpSdk/ShareCreatedModifyTest.php
+++ b/tests/integration/Owncloud/OcisPhpSdk/ShareCreatedModifyTest.php
@@ -116,7 +116,7 @@ class ShareCreatedModifyTest extends OcisPhpSdkTestCase
         $share = new ShareCreated(
             $permission,
             $this->fileToShare->getId(),
-            $this->fileToShare->getDriveId(),
+            $this->fileToShare->getSpaceId(),
             ['verify' => false],
             $this->ocisUrl,
             $token

--- a/tests/integration/compose.yaml
+++ b/tests/integration/compose.yaml
@@ -52,7 +52,7 @@ services:
 
 
   ocis:
-    image: owncloud/ocis:${OCIS_VERSION:-latest}
+    image: ocis:sharing
     networks:
       ocis-net:
     entrypoint: /bin/sh

--- a/tests/integration/compose.yaml
+++ b/tests/integration/compose.yaml
@@ -52,7 +52,7 @@ services:
 
 
   ocis:
-    image: ocis:sharing
+    image: owncloud/ocis:${OCIS_VERSION:-latest}
     networks:
       ocis-net:
     entrypoint: /bin/sh

--- a/tests/unit/Owncloud/OcisPhpSdk/ResourceInviteTest.php
+++ b/tests/unit/Owncloud/OcisPhpSdk/ResourceInviteTest.php
@@ -148,12 +148,12 @@ class ResourceInviteTest extends TestCase
         $resourceMetadata = [
             200 => [
                 '{http://owncloud.org/ns}id' => 'uuid-of-the-resource',
+                '{http://owncloud.org/ns}spaceid' => 'uuid-of-the-drive',
             ]
         ];
 
         $resource = new OcisResource(
             $resourceMetadata,
-            'uuid-of-the-drive',
             $connectionConfig,
             'http://ocis',
             $accessToken

--- a/tests/unit/Owncloud/OcisPhpSdk/ResourceLinkTest.php
+++ b/tests/unit/Owncloud/OcisPhpSdk/ResourceLinkTest.php
@@ -77,10 +77,10 @@ class ResourceLinkTest extends TestCase
         ];
         $resourceMetadata = [200 => [
             '{http://owncloud.org/ns}id' => 'uuid-of-the-resource',
+            '{http://owncloud.org/ns}spaceid' => 'uuid-of-the-drive',
         ]];
         return new OcisResource(
             $resourceMetadata,
-            'uuid-of-the-drive',
             $connectionConfig, // @phpstan-ignore-line 'drivesPermissionsApi' is a MockObject
             'http://ocis',
             $accessToken

--- a/tests/unit/Owncloud/OcisPhpSdk/ResourceTest.php
+++ b/tests/unit/Owncloud/OcisPhpSdk/ResourceTest.php
@@ -2,9 +2,6 @@
 
 namespace unit\Owncloud\OcisPhpSdk;
 
-use OpenAPI\Client\Api\DrivesApi;
-use OpenAPI\Client\Model\Drive;
-use OpenAPI\Client\Model\OdataError;
 use Owncloud\OcisPhpSdk\Exception\InvalidResponseException;
 use Owncloud\OcisPhpSdk\OcisResource;
 use PHPUnit\Framework\TestCase;

--- a/tests/unit/Owncloud/OcisPhpSdk/ResourceTest.php
+++ b/tests/unit/Owncloud/OcisPhpSdk/ResourceTest.php
@@ -45,7 +45,6 @@ class ResourceTest extends TestCase
         $accessToken = 'aaa';
         return new OcisResource(
             $metadata,
-            'uuid-of-the-drive',
             [],
             '',
             $accessToken
@@ -345,45 +344,5 @@ class ResourceTest extends TestCase
             }
             $this->assertNull($result);
         }
-    }
-
-    public function testDriveIdCannotBeFetchedUsingSpaceId(): void
-    {
-        $driveMock = $this->createMock(Drive::class);
-        $driveApiMock = $this->createMock(DrivesApi::class);
-        $driveApiMock->method('getDrive')
-            ->willReturn($driveMock);
-        $accessToken = 'aaa';
-        $metadata = [200 => ['{http://owncloud.org/ns}spaceid' => 'spaceid']];
-        $this->expectException(InvalidResponseException::class);
-        $this->expectExceptionMessage('Could not get drive id');
-        // @phan-suppress-next-line PhanNoopNew we are expecting an exception
-        new OcisResource(
-            $metadata,
-            null,
-            ['drivesApi' => $driveApiMock],
-            '',
-            $accessToken
-        );
-    }
-
-    public function testFetchingDriveIdByUsingSpaceIdReturnsOdataError(): void
-    {
-        $errorMock = $this->createMock(OdataError::class);
-        $driveApiMock = $this->createMock(DrivesApi::class);
-        $driveApiMock->method('getDrive')
-            ->willReturn($errorMock);
-        $accessToken = 'aaa';
-        $metadata = [200 => ['{http://owncloud.org/ns}spaceid' => 'spaceid']];
-        $this->expectException(InvalidResponseException::class);
-        $this->expectExceptionMessage('getDrive returned an OdataError - ');
-        // @phan-suppress-next-line PhanNoopNew we are expecting an exception
-        new OcisResource(
-            $metadata,
-            null,
-            ['drivesApi' => $driveApiMock],
-            '',
-            $accessToken
-        );
     }
 }


### PR DESCRIPTION
with https://github.com/owncloud/ocis/pull/7975 we don't need to try to get the 'real' drive-id from the server, we can directly use the `spaceid` from the PROPFIND response as drive-id in the graph API.

Fixes: https://github.com/owncloud/moodle-repository_ocis/issues/49