### PR TITLE
removing '-' from group names

### DIFF
--- a/tests/integration/Owncloud/OcisPhpSdk/GroupsTest.php
+++ b/tests/integration/Owncloud/OcisPhpSdk/GroupsTest.php
@@ -21,7 +21,7 @@ class GroupsTest extends OcisPhpSdkTestCase
         $users = $ocis->getUsers('admin');
         $userName = $users[0]->getDisplayName();
         $philosophyHatersGroup =  $ocis->createGroup(
-            "philosophy-haters",
+            "philosophyhaters",
             "philosophy haters group"
         );
         $this->createdGroups = [$philosophyHatersGroup];
@@ -41,7 +41,7 @@ class GroupsTest extends OcisPhpSdkTestCase
         $einsteinUserOcis = $this->initUser('einstein', 'relativity');
         $users = $ocis->getUsers();
         $philosophyHatersGroup =  $ocis->createGroup(
-            "philosophy-haters",
+            "philosophyhaters",
             "philosophy haters group"
         );
         $this->createdGroups = [$philosophyHatersGroup];
@@ -69,7 +69,7 @@ class GroupsTest extends OcisPhpSdkTestCase
         $ocis = $this->getOcis('admin', 'admin');
         $users = $ocis->getUsers('admin');
         $philosophyHatersGroup =  $ocis->createGroup(
-            "philosophy-haters",
+            "philosophyhaters",
             "philosophy haters group"
         );
         $this->createdGroups = [$philosophyHatersGroup];
@@ -84,7 +84,7 @@ class GroupsTest extends OcisPhpSdkTestCase
         $this->expectException(NotFoundException::class);
         $ocis = $this->getOcis('admin', 'admin');
         $philosophyHatersGroup =  $ocis->createGroup(
-            "philosophy-haters",
+            "philosophyhaters",
             "philosophy haters group"
         );
         $this->createdGroups = [$philosophyHatersGroup];
@@ -97,7 +97,7 @@ class GroupsTest extends OcisPhpSdkTestCase
             ]
         );
         $sdkUser = new \Owncloud\OcisPhpSdk\User($user);
-        $groups = $ocis->getGroups(search:"philosophy");
+        $groups = $ocis->getGroups(search:"philosophyhaters");
         $this->assertGreaterThanOrEqual(1, $groups);
         $groups[0]->addUser($sdkUser);
     }
@@ -109,10 +109,10 @@ class GroupsTest extends OcisPhpSdkTestCase
     {
         $ocis = $this->getOcis('admin', 'admin');
         $marieOcis = $this->getOcis('marie', 'radioactivity');
-        $physicsLoversGroup =  $ocis->createGroup("physics-lovers", "physics lovers group");
+        $physicsLoversGroup =  $ocis->createGroup("physicslovers", "physics lovers group");
         $this->createdGroups = [$physicsLoversGroup];
         $users = $marieOcis->getUsers('marie');
-        $groups = $marieOcis->getGroups(search:"physics");
+        $groups = $marieOcis->getGroups(search:"physicslovers");
         $this->assertGreaterThanOrEqual(1, $groups);
         $this->expectException(UnauthorizedException::class);
         $groups[0]->addUser($users[0]);
@@ -126,16 +126,16 @@ class GroupsTest extends OcisPhpSdkTestCase
     {
         $ocis = $this->getOcis('admin', 'admin');
         $philosophyHatersGroup =  $ocis->createGroup(
-            "philosophy-haters",
+            "philosophyhaters",
             "philosophy haters group"
         );
         $physicsLoversGroup = $ocis->createGroup(
-            "physics-lovers",
+            "physicslovers",
             "physics lover group"
         );
         $philosophyHatersGroup->delete();
         $this->assertCount(1, $ocis->getGroups());
-        $this->assertEquals("physics-lovers", $ocis->getGroups()[0]->getDisplayName());
+        $this->assertEquals("physicslovers", $ocis->getGroups()[0]->getDisplayName());
         $this->createdGroups = [$physicsLoversGroup];
     }
 
@@ -145,10 +145,10 @@ class GroupsTest extends OcisPhpSdkTestCase
     public function testGetGroupsByNormalUser(): void
     {
         $ocis = $this->getOcis('admin', 'admin');
-        $philosophyHatersGroup =  $ocis->createGroup("philosophy-haters", "philosophy haters group");
+        $philosophyHatersGroup =  $ocis->createGroup("philosophyhaters", "philosophy haters group");
         $this->createdGroups = [$philosophyHatersGroup];
         $ocis = $this->getOcis('marie', 'radioactivity');
-        $groups = $ocis->getGroups("philosophy");
+        $groups = $ocis->getGroups("philosophyhaters");
         $this->assertCount(1, $groups);
         foreach ($groups as $group) {
             $this->assertInstanceOf(Group::class, $group);
@@ -166,7 +166,7 @@ class GroupsTest extends OcisPhpSdkTestCase
     {
         $token = $this->getAccessToken("admin", "admin");
         $ocis = new Ocis($this->ocisUrl, $token, ["verify" => false]);
-        $philosophyHatersGroup = $ocis->createGroup("philosophy-haters", "philosophy haters group");
+        $philosophyHatersGroup = $ocis->createGroup("philosophyhaters", "philosophy haters group");
         $this->createdGroups = [$philosophyHatersGroup];
         $token = $this->getAccessToken('einstein', 'relativity');
         $ocisEinstein = new Ocis($this->ocisUrl, $token, ["verify" => false]);

--- a/tests/integration/Owncloud/OcisPhpSdk/OcisTest.php
+++ b/tests/integration/Owncloud/OcisPhpSdk/OcisTest.php
@@ -324,7 +324,7 @@ class OcisTest extends OcisPhpSdkTestCase
     public function groupNameList(): array
     {
         return[
-            [["philosophy-haters", "physics-lovers"]],
+            [["philosophyhaters", "physicslovers"]],
         ];
     }
 
@@ -359,7 +359,7 @@ class OcisTest extends OcisPhpSdkTestCase
     public function testGetGroupsExpanded(): void
     {
         $ocis = $this->getOcis('admin', 'admin');
-        $physicsLoversGroup =  $ocis->createGroup("physics-lovers", "physics lovers group");
+        $physicsLoversGroup =  $ocis->createGroup("physicslovers", "physics lovers group");
         $this->createdGroups = [$physicsLoversGroup];
         $physicsLoversGroup->addUser($ocis->getUsers()[0]);
         $groups = $ocis->getGroups(expandMembers: true);
@@ -375,7 +375,7 @@ class OcisTest extends OcisPhpSdkTestCase
     public function searchText(): array
     {
         return [
-            ["ph",["philosophy-haters", "physics-lovers"]],
+            ["ph",["philosophyhaters", "physicslovers"]],
         ];
     }
 
@@ -389,8 +389,8 @@ class OcisTest extends OcisPhpSdkTestCase
     public function testGetGroupSearch(string $searchText, array $groupDisplayName): void
     {
         $ocis = $this->getOcis('admin', 'admin');
-        $philosophyHatersGroup =  $ocis->createGroup("philosophy-haters", "philosophy haters group");
-        $physicsLoversGroup = $ocis->createGroup("physics-lovers", "physics lover group");
+        $philosophyHatersGroup =  $ocis->createGroup("philosophyhaters", "philosophy haters group");
+        $physicsLoversGroup = $ocis->createGroup("physicslovers", "physics lover group");
         $this->createdGroups = [$philosophyHatersGroup,$physicsLoversGroup];
         $groups = $ocis->getGroups(search: $searchText);
         $this->assertCount(count($groupDisplayName), $groups);
@@ -405,8 +405,8 @@ class OcisTest extends OcisPhpSdkTestCase
     public function orderDirection(): array
     {
         return [
-            [OrderDirection::ASC, "ph", ["philosophy-haters", "physics-lovers"]],
-            [OrderDirection::DESC, "ph", ["physics-lovers", "philosophy-haters"]]
+            [OrderDirection::ASC, "ph", ["philosophyhaters", "physicslovers"]],
+            [OrderDirection::DESC, "ph", ["physicslovers", "philosophyhaters"]]
         ];
     }
 
@@ -421,8 +421,8 @@ class OcisTest extends OcisPhpSdkTestCase
     public function testGetGroupSort(OrderDirection $orderDirection, string $searchText, array $resultGroups): void
     {
         $ocis = $this->getOcis('admin', 'admin');
-        $philosophyHatersGroup =  $ocis->createGroup("philosophy-haters", "philosophy haters group");
-        $physicsLoversGroup = $ocis->createGroup("physics-lovers", "physics lover group");
+        $philosophyHatersGroup =  $ocis->createGroup("philosophyhaters", "philosophy haters group");
+        $physicsLoversGroup = $ocis->createGroup("physicslovers", "physics lover group");
         $this->createdGroups = [$philosophyHatersGroup,$physicsLoversGroup];
         $groups = $ocis->getGroups(search: $searchText, orderBy: $orderDirection);
         if(count($groups) <= 0) {
@@ -440,15 +440,15 @@ class OcisTest extends OcisPhpSdkTestCase
     public function testDeleteGroupById(): void
     {
         $ocis = $this->getOcis('admin', 'admin');
-        $ocis->createGroup("philosophy-haters", "philosophy haters group");
-        $physicsLoversGroup = $ocis->createGroup("physics-lovers", "physics lover group");
+        $ocis->createGroup("philosophyhaters", "philosophy haters group");
+        $physicsLoversGroup = $ocis->createGroup("physicslovers", "physics lover group");
         foreach($ocis->getGroups() as $group) {
-            if($group->getDisplayName() === "philosophy-haters") {
+            if($group->getDisplayName() === "philosophyhaters") {
                 $ocis->deleteGroupByID($group->getId());
             }
         }
         $this->assertCount(1, $ocis->getGroups());
-        $this->assertEquals("physics-lovers", $ocis->getGroups()[0]->getDisplayName());
+        $this->assertEquals("physicslovers", $ocis->getGroups()[0]->getDisplayName());
         $this->createdGroups = [$physicsLoversGroup];
     }
 

--- a/tests/integration/Owncloud/OcisPhpSdk/ResourceInviteTest.php
+++ b/tests/integration/Owncloud/OcisPhpSdk/ResourceInviteTest.php
@@ -111,7 +111,7 @@ class ResourceInviteTest extends OcisPhpSdkTestCase
     public function testInviteGroup(): void
     {
         $philosophyHatersGroup =  $this->ocis->createGroup(
-            'philosophy-haters',
+            'philosophyhaters',
             'philosophy haters group'
         );
         $this->createdGroups = [$philosophyHatersGroup];
@@ -126,7 +126,7 @@ class ResourceInviteTest extends OcisPhpSdkTestCase
     public function testInviteGroupAndUserOfTheGroup(): void
     {
         $philosophyHatersGroup =  $this->ocis->createGroup(
-            'philosophy-haters',
+            'philosophyhaters',
             'philosophy haters group'
         );
         $this->createdGroups = [$philosophyHatersGroup];
@@ -142,11 +142,11 @@ class ResourceInviteTest extends OcisPhpSdkTestCase
     public function testInviteMultipleGroups(): void
     {
         $philosophyHatersGroup =  $this->ocis->createGroup(
-            'philosophy-haters',
+            'philosophyhaters',
             'philosophy haters group'
         );
         $physicsLoversGroup =  $this->ocis->createGroup(
-            'physics-lovers',
+            'physicslovers',
             'physics lovers group'
         );
         $this->createdGroups = [$philosophyHatersGroup, $physicsLoversGroup];
@@ -217,7 +217,7 @@ class ResourceInviteTest extends OcisPhpSdkTestCase
     public function testGetReceiversOfShareCreatedByInvite(): void
     {
         $philosophyHatersGroup =  $this->ocis->createGroup(
-            'philosophy-haters',
+            'philosophyhaters',
             'philosophy haters group'
         );
         $this->createdGroups = [$philosophyHatersGroup];
@@ -231,7 +231,7 @@ class ResourceInviteTest extends OcisPhpSdkTestCase
             $this->assertThat(
                 $shares[$i]->getReceiver()->getDisplayName(),
                 $this->logicalOr(
-                    $this->equalTo("philosophy-haters"),
+                    $this->equalTo("philosophyhaters"),
                     $this->equalTo("Marie Curie"),
                     $this->equalTo("Albert Einstein")
                 )
@@ -242,7 +242,7 @@ class ResourceInviteTest extends OcisPhpSdkTestCase
     public function testGetReceiversOfShareReturnedBySharedByMe(): void
     {
         $philosophyHatersGroup =  $this->ocis->createGroup(
-            'philosophy-haters',
+            'philosophyhaters',
             'philosophy haters group'
         );
         $this->createdGroups = [$philosophyHatersGroup];
@@ -270,7 +270,7 @@ class ResourceInviteTest extends OcisPhpSdkTestCase
             $this->assertThat(
                 $shares[$i]->getReceiver()->getDisplayName(),
                 $this->logicalOr(
-                    $this->equalTo("philosophy-haters"),
+                    $this->equalTo("philosophyhaters"),
                     $this->equalTo("Marie Curie"),
                     $this->equalTo("Albert Einstein")
                 )

--- a/tests/integration/Owncloud/OcisPhpSdk/ShareCreatedModifyTest.php
+++ b/tests/integration/Owncloud/OcisPhpSdk/ShareCreatedModifyTest.php
@@ -76,7 +76,7 @@ class ShareCreatedModifyTest extends OcisPhpSdkTestCase
     public function testDeleteGroupShare(): void
     {
         $philosophyHatersGroup =  $this->ocis->createGroup(
-            'philosophy-haters',
+            'philosophyhaters',
             'philosophy haters group'
         );
         $this->createdGroups = [$philosophyHatersGroup];
@@ -86,7 +86,7 @@ class ShareCreatedModifyTest extends OcisPhpSdkTestCase
         $shares = $this->ocis->getSharedByMe();
         foreach ($shares as $share) {
             $this->assertInstanceOf(ShareCreated::class, $share);
-            if ($share->getReceiver()->getDisplayName() === 'philosophy-haters') {
+            if ($share->getReceiver()->getDisplayName() === 'philosophyhaters') {
                 $share->delete();
                 break;
             }


### PR DESCRIPTION
currently in ocis we can't search for groups if the search query contains '-'. so its better not create groups with that character in our tests