### PR TITLE
restrict invite requests to a single receiver

### DIFF
--- a/tests/integration/Owncloud/OcisPhpSdk/OcisResourceTest.php
+++ b/tests/integration/Owncloud/OcisPhpSdk/OcisResourceTest.php
@@ -72,7 +72,7 @@ class OcisResourceTest extends OcisPhpSdkTestCase
         foreach ($resources as $resource) {
             if ($resource->getName() === $resourceName) {
                 $role = $this->getRoleByName($resource, $roleName);
-                $resource->invite([$receiver], $role);
+                $resource->invite($receiver, $role);
                 break;
             }
         }
@@ -265,7 +265,7 @@ class OcisResourceTest extends OcisPhpSdkTestCase
         foreach ($resources as $resource) {
             if ($resource->getName() === 'subfolder') {
                 $role = $this->getRoleByName($resource, 'Viewer');
-                $resource->invite([$einstein], $role);
+                $resource->invite($einstein, $role);
                 break;
             }
         }

--- a/tests/integration/Owncloud/OcisPhpSdk/OcisTest.php
+++ b/tests/integration/Owncloud/OcisPhpSdk/OcisTest.php
@@ -66,7 +66,7 @@ class OcisTest extends OcisPhpSdkTestCase
                 "manager role not found "
             );
         }
-        $sharedResource->invite([$marie], $managerRole);
+        $sharedResource->invite($marie, $managerRole);
 
         $marieDrive = $marieOcis->getMyDrives();
         $this->assertContainsOnlyInstancesOf(Drive::class, $marieDrive);
@@ -125,7 +125,7 @@ class OcisTest extends OcisPhpSdkTestCase
                 "manager role not found "
             );
         }
-        $sharedResource->invite([$katherine], $managerRole);
+        $sharedResource->invite($katherine, $managerRole);
 
         $drives = $adminOcis->getAllDrives();
         foreach ($drives as $drive) {
@@ -220,7 +220,7 @@ class OcisTest extends OcisPhpSdkTestCase
                 );
             }
 
-            $sharedResource->invite([$katherine], $managerRole);
+            $sharedResource->invite($katherine, $managerRole);
         }
 
         $drives = $adminOcis->getAllDrives(

--- a/tests/integration/Owncloud/OcisPhpSdk/ShareCreatedModifyTest.php
+++ b/tests/integration/Owncloud/OcisPhpSdk/ShareCreatedModifyTest.php
@@ -58,7 +58,8 @@ class ShareCreatedModifyTest extends OcisPhpSdkTestCase
 
     public function testDeleteIndividualShare(): void
     {
-        $this->fileToShare->invite([$this->einstein, $this->marie], $this->viewerRole);
+        $this->fileToShare->invite($this->einstein, $this->viewerRole);
+        $this->fileToShare->invite($this->marie, $this->viewerRole);
         $shares = $this->ocis->getSharedByMe();
         foreach ($shares as $share) {
             $this->assertInstanceOf(ShareCreated::class, $share);
@@ -76,17 +77,19 @@ class ShareCreatedModifyTest extends OcisPhpSdkTestCase
     public function testDeleteGroupShare(): void
     {
         $philosophyHatersGroup =  $this->ocis->createGroup(
-            'philosophyhaters',
+            'philosophy-haters',
             'philosophy haters group'
         );
         $this->createdGroups = [$philosophyHatersGroup];
         $philosophyHatersGroup->addUser($this->einstein);
 
-        $this->fileToShare->invite([$this->einstein, $philosophyHatersGroup, $this->marie], $this->viewerRole);
+        $this->fileToShare->invite($this->einstein, $this->viewerRole);
+        $this->fileToShare->invite($philosophyHatersGroup, $this->viewerRole);
+        $this->fileToShare->invite($this->marie, $this->viewerRole);
         $shares = $this->ocis->getSharedByMe();
         foreach ($shares as $share) {
             $this->assertInstanceOf(ShareCreated::class, $share);
-            if ($share->getReceiver()->getDisplayName() === 'philosophyhaters') {
+            if ($share->getReceiver()->getDisplayName() === 'philosophy-haters') {
                 $share->delete();
                 break;
             }
@@ -101,7 +104,8 @@ class ShareCreatedModifyTest extends OcisPhpSdkTestCase
         $this->markTestSkipped('https://github.com/owncloud/ocis/issues/7872');
         // @phpstan-ignore-next-line because the test is skipped
         $this->expectException(NotFoundException::class);
-        $this->fileToShare->invite([$this->einstein, $this->marie], $this->viewerRole);
+        $this->fileToShare->invite($this->einstein, $this->viewerRole);
+        $this->fileToShare->invite($this->marie, $this->viewerRole);
         $shares = $this->ocis->getSharedByMe();
         $shares[0]->delete();
         $shares[0]->delete();
@@ -132,15 +136,15 @@ class ShareCreatedModifyTest extends OcisPhpSdkTestCase
         $this->markTestSkipped('Not implemented yet in oCIS, see https://github.com/owncloud/ocis/issues/6993');
         // @phpstan-ignore-next-line because the test is skipped
         $this->expectException(NotFoundException::class);
-        $sharesFromInvite = $this->fileToShare->invite([$this->einstein], $this->viewerRole);
+        $shareFromInvite = $this->fileToShare->invite($this->einstein, $this->viewerRole);
         $tomorrow = new \DateTimeImmutable('tomorrow');
-        $sharesFromInvite[0]->setExpiration($tomorrow);
+        $shareFromInvite->setExpiration($tomorrow);
         $sharedByMeShares = $this->ocis->getSharedByMe();
 
-        $this->assertInstanceOf(\DateTimeImmutable::class, $sharesFromInvite[0]->getExpiration());
-        $this->assertSame($tomorrow->getTimestamp(), $sharesFromInvite[0]->getExpiration()->getTimestamp());
-        $this->assertInstanceOf(\DateTimeImmutable::class, $sharedByMeShares[0]->getExpiration());
-        $this->assertSame($tomorrow->getTimestamp(), $sharedByMeShares[0]->getExpiration()->getTimestamp());
+        $this->assertInstanceOf(\DateTimeImmutable::class, $shareFromInvite->getExpiration());
+        $this->assertSame($tomorrow->getTimestamp(), $shareFromInvite->getExpiration()->getTimestamp());
+        $this->assertInstanceOf(\DateTimeImmutable::class, $shareFromInvite->getExpiration());
+        $this->assertSame($tomorrow->getTimestamp(), $shareFromInvite->getExpiration()->getTimestamp());
     }
 
     public function testSetExpirationDateOnObjectFromSharedByMe(): void
@@ -148,7 +152,7 @@ class ShareCreatedModifyTest extends OcisPhpSdkTestCase
         $this->markTestSkipped('Not implemented yet in oCIS, see https://github.com/owncloud/ocis/issues/6993');
         // @phpstan-ignore-next-line because the test is skipped
         $this->expectException(NotFoundException::class);
-        $this->fileToShare->invite([$this->einstein], $this->viewerRole);
+        $this->fileToShare->invite($this->einstein, $this->viewerRole);
         $tomorrow = new \DateTimeImmutable('tomorrow');
         $sharedByMeShares = $this->ocis->getSharedByMe();
         $sharedByMeShares[0]->setExpiration($tomorrow);

--- a/tests/integration/Owncloud/OcisPhpSdk/ShareGetShareByMeTest.php
+++ b/tests/integration/Owncloud/OcisPhpSdk/ShareGetShareByMeTest.php
@@ -62,7 +62,7 @@ class ShareGetShareByMeTest extends OcisPhpSdkTestCase
 
     public function testGetShareByMe(): void
     {
-        $this->sharedResource->invite([$this->einstein], $this->editorRole);
+        $this->sharedResource->invite($this->einstein, $this->editorRole);
         $myShare = $this->ocis->getSharedByMe();
         $this->assertInstanceOf(ShareCreated::class, $myShare[0]);
         $this->assertEquals('Albert Einstein', $myShare[0]->getReceiver()->getDisplayName());
@@ -86,7 +86,7 @@ class ShareGetShareByMeTest extends OcisPhpSdkTestCase
 
     public function testGetShareAndShareLinkByMe(): void
     {
-        $this->sharedResource->invite([$this->einstein], $this->editorRole);
+        $this->sharedResource->invite($this->einstein, $this->editorRole);
         $this->sharedResource->createSharingLink(
             SharingLinkType::VIEW,
             new \DateTimeImmutable('2023-12-31 01:02:03.456789'),

--- a/tests/unit/Owncloud/OcisPhpSdk/ResourceInviteTest.php
+++ b/tests/unit/Owncloud/OcisPhpSdk/ResourceInviteTest.php
@@ -46,7 +46,7 @@ class ResourceInviteTest extends TestCase
         return [
             // invite for a single recipient
             [
-                [$einstein],
+                $einstein,
                 null,
                 new DriveItemInvite(
                     [
@@ -54,29 +54,6 @@ class ResourceInviteTest extends TestCase
                             new DriveRecipient(
                                 [
                                     'object_id' => 'uuid-of-einstein',
-                                ]
-                            ),
-                        ],
-                        'roles' => ['uuid-of-the-role'],
-                    ]
-                )
-            ],
-            // invite a user and a group
-            [
-                [$einstein, $smartPeopleGroup],
-                null,
-                new DriveItemInvite(
-                    [
-                        'recipients' => [
-                            new DriveRecipient(
-                                [
-                                    'object_id' => 'uuid-of-einstein',
-                                ]
-                            ),
-                            new DriveRecipient(
-                                [
-                                    'object_id' => 'uuid-of-smart-people-group',
-                                    'at_libre_graph_recipient_type' => 'group',
                                 ]
                             ),
                         ],
@@ -86,7 +63,7 @@ class ResourceInviteTest extends TestCase
             ],
             // set expiry time
             [
-                [$smartPeopleGroup],
+                $smartPeopleGroup,
                 new \DateTimeImmutable('2022-12-31 01:02:03.456789'),
                 new DriveItemInvite(
                     [
@@ -105,7 +82,7 @@ class ResourceInviteTest extends TestCase
             ],
             // set expiry time, with conversion to UTC/Z timezone
             [
-                [$einstein],
+                $einstein,
                 new \DateTimeImmutable('2021-01-01 17:45:43.123456', new \DateTimeZone('Asia/Kathmandu')),
                 new DriveItemInvite(
                     [
@@ -126,10 +103,12 @@ class ResourceInviteTest extends TestCase
 
     /**
      * @dataProvider inviteDataProvider
-     * @param array<int, User|Group> $recipients
      */
-    public function testInvite($recipients, ?\DateTimeImmutable $expiration, DriveItemInvite $expectedInviteData): void
-    {
+    public function testInvite(
+        User|Group $recipient,
+        ?\DateTimeImmutable $expiration,
+        DriveItemInvite $expectedInviteData
+    ): void {
         $permission = $this->createMock(Permission::class);
         $permission->method('getId')
             ->willReturn('uuid-of-the-permission');
@@ -167,7 +146,7 @@ class ResourceInviteTest extends TestCase
         );
         $role = new SharingRole($openAPIRole);
 
-        $result = $resource->invite($recipients, $role, $expiration);
-        $this->assertContainsOnly(ShareCreated::class, $result);
+        $result = $resource->invite($recipient, $role, $expiration);
+        $this->assertInstanceOf(ShareCreated::class, $result);
     }
 }


### PR DESCRIPTION
fixes #138

oCIS will allow a maximum of one invite at a time after https://github.com/owncloud/ocis/pull/8019
We can make the change here already now
