### PR TITLE
bump ocis for tests to the newest version

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,3 +1,3 @@
 # The version of OCIS to use in pipelines that test against OCIS
-OCIS_COMMITID=39b6fe17500b707d2e9db9e696db648a95893cdf
+OCIS_COMMITID=35c95685ba2b36bc91e6f0b05f7d968ba27cba42
 OCIS_BRANCH=master


### PR DESCRIPTION
Use the newest ocis to run the intergration tests.
