### PR TITLE
test: use phpunit 10.5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /vendor/
 composer.lock
 .php-cs-fixer.cache
+.phpunit.cache
 .phpunit.result.cache
 /tests/output/
 # phpDocumentor

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # docker compose command, defaults to v3
 # for v2: set this as docker-compose using the environment variable
 DCO:=docker compose
-PHPUNIT=phpdbg -qrr -d memory_limit=4096M -d zend.enable_gc=0 "vendor/bin/phpunit"
+PHPUNIT=php -d memory_limit=4096M -d zend.enable_gc=0 -d xdebug.mode=coverage "vendor/bin/phpunit"
 run-with-cleanup = $(1) && $(2) || (ret=$$?; $(2) && exit $$ret)
 
 #

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.26",
         "phan/phan": "^5.4",
-        "phpunit/phpunit": "^9.6",
+        "phpunit/phpunit": "^10.5",
         "phpstan/phpstan": "^1.10"
     }
 }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,12 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<phpunit bootstrap="tests/unit/bootstrap.php"
-        verbose="true"
-        failOnRisky="true"
-        failOnWarning="true"
-        beStrictAboutOutputDuringTests="true"
-        timeoutForSmallTests="900"
-        timeoutForMediumTests="900"
-        timeoutForLargeTests="900">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="tests/unit/bootstrap.php" failOnRisky="true" failOnWarning="true" beStrictAboutOutputDuringTests="true" timeoutForSmallTests="900" timeoutForMediumTests="900" timeoutForLargeTests="900" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd" cacheDirectory=".phpunit.cache">
   <testsuites>
     <testsuite name="unit">
       <directory suffix="Test.php">./tests/unit</directory>
@@ -16,11 +9,13 @@
     </testsuite>
   </testsuites>
   <coverage>
-    <include>
-      <directory suffix=".php">./src</directory>
-    </include>
     <report>
       <clover outputFile="./tests/output/clover.xml"/>
     </report>
   </coverage>
+  <source>
+    <include>
+      <directory suffix=".php">./src</directory>
+    </include>
+  </source>
 </phpunit>

--- a/tests/integration/Owncloud/OcisPhpSdk/OcisResourceTest.php
+++ b/tests/integration/Owncloud/OcisPhpSdk/OcisResourceTest.php
@@ -298,7 +298,7 @@ class OcisResourceTest extends OcisPhpSdkTestCase
     /**
      * @return array<int, array<int, string>>
      */
-    public function resources()
+    public static function resources()
     {
         return [
             ['somefile.txt','file'],
@@ -334,7 +334,7 @@ class OcisResourceTest extends OcisPhpSdkTestCase
     /**
      * @return array<int, array<int, string>>
      */
-    public function invalidResources()
+    public static function invalidResources()
     {
         return [
             ['nonExistentFile.txt'],

--- a/tests/integration/Owncloud/OcisPhpSdk/OcisTest.php
+++ b/tests/integration/Owncloud/OcisPhpSdk/OcisTest.php
@@ -157,7 +157,7 @@ class OcisTest extends OcisPhpSdkTestCase
     /**
      * @return array<int, array<int, int|DriveType>>
      */
-    public function drivesType()
+    public static function drivesType()
     {
         return [
             [DriveType::PROJECT],
@@ -297,7 +297,7 @@ class OcisTest extends OcisPhpSdkTestCase
     /**
      * @return array<int,array<int,int>>
      */
-    public function invalidQuotaProvider()
+    public static function invalidQuotaProvider()
     {
         return [
             [-1],
@@ -321,7 +321,7 @@ class OcisTest extends OcisPhpSdkTestCase
     /**
      * @return array<int, array<int,array<int, string>>>
      */
-    public function groupNameList(): array
+    public static function groupNameList(): array
     {
         return[
             [["philosophyhaters", "physicslovers"]],
@@ -372,7 +372,7 @@ class OcisTest extends OcisPhpSdkTestCase
     /**
      * @return array<int, array<int, array<int, string>|int|string>>
      */
-    public function searchText(): array
+    public static function searchText(): array
     {
         return [
             ["ph",["philosophyhaters", "physicslovers"]],
@@ -402,7 +402,7 @@ class OcisTest extends OcisPhpSdkTestCase
     /**
      * @return array<int, array<int, array<int,  string>|int|OrderDirection|string>>
      */
-    public function orderDirection(): array
+    public static function orderDirection(): array
     {
         return [
             [OrderDirection::ASC, "ph", ["philosophyhaters", "physicslovers"]],

--- a/tests/integration/Owncloud/OcisPhpSdk/ResourceShareLinkTest.php
+++ b/tests/integration/Owncloud/OcisPhpSdk/ResourceShareLinkTest.php
@@ -50,7 +50,7 @@ class ResourceShareLinkTest extends OcisPhpSdkTestCase
     /**
      * @return array<int,array<int,SharingLinkType|bool|string>>
      */
-    public function sharingLinkTypeDataProvider(): array
+    public static function sharingLinkTypeDataProvider(): array
     {
         return [
             [SharingLinkType::INTERNAL, true, true, ''],

--- a/tests/unit/Owncloud/OcisPhpSdk/DriveOrderTest.php
+++ b/tests/unit/Owncloud/OcisPhpSdk/DriveOrderTest.php
@@ -10,7 +10,7 @@ class DriveOrderTest extends TestCase
     /**
      * @return array<int,array{0:DriveOrder,1:string}>
      */
-    public function validDriveOrders(): array
+    public static function validDriveOrders(): array
     {
         return [
             [DriveOrder::LASTMODIFIED, "lastModifiedDateTime"],

--- a/tests/unit/Owncloud/OcisPhpSdk/DriveTypeTest.php
+++ b/tests/unit/Owncloud/OcisPhpSdk/DriveTypeTest.php
@@ -9,7 +9,7 @@ class DriveTypeTest extends TestCase
 {
     /**
      * @return array<int,array{0:DriveType,1:string}>     */
-    public function validDriveTypes(): array
+    public static function validDriveTypes(): array
     {
         return [
             [DriveType::PERSONAL, "personal"],

--- a/tests/unit/Owncloud/OcisPhpSdk/Exception/ExceptionHelperTest.php
+++ b/tests/unit/Owncloud/OcisPhpSdk/Exception/ExceptionHelperTest.php
@@ -22,7 +22,7 @@ class ExceptionHelperTest extends TestCase
     /**
      * @return array<int,array{0:string,1:string,2:int, 3:class-string}>
      */
-    public function exceptionData(): array
+    public static function exceptionData(): array
     {
         return [
             ["GuzzleHttpRequestException", "bad request", 400, BadRequestException::class],

--- a/tests/unit/Owncloud/OcisPhpSdk/GroupTest.php
+++ b/tests/unit/Owncloud/OcisPhpSdk/GroupTest.php
@@ -12,7 +12,7 @@ class GroupTest extends TestCase
     /**
      * @return array<int, array<int, array<string, array<int, string>|string>>>
      */
-    public function validGroupData(): array
+    public static function validGroupData(): array
     {
         return [
             [[
@@ -64,7 +64,7 @@ class GroupTest extends TestCase
      *      ],
      *
      */
-    public function InvalidGroupData(): array
+    public static function invalidGroupData(): array
     {
         return [
             [[ // id is null
@@ -99,7 +99,7 @@ class GroupTest extends TestCase
     }
 
     /**
-     * @dataProvider InvalidGroupData
+     * @dataProvider invalidGroupData
      *
      * @param array<string,string|array<int,string>> $data
      * @param string $key

--- a/tests/unit/Owncloud/OcisPhpSdk/OcisTest.php
+++ b/tests/unit/Owncloud/OcisPhpSdk/OcisTest.php
@@ -166,7 +166,7 @@ class OcisTest extends TestCase
     /**
      * @return array<int, mixed>
      */
-    public function invalidJsonNotificationResponse(): array
+    public static function invalidJsonNotificationResponse(): array
     {
         return [
             [""],
@@ -191,7 +191,7 @@ class OcisTest extends TestCase
     /**
      * @return array<int, mixed>
      */
-    public function invalidOcsNotificationResponse(): array
+    public static function invalidOcsNotificationResponse(): array
     {
         return [
             ['{"ocs":{"meta":{"message":"","status":"","statuscode":200}}}'],
@@ -218,7 +218,7 @@ class OcisTest extends TestCase
     /**
      * @return array<int, mixed>
      */
-    public function invalidOrMissingIdInOcsNotificationResponse(): array
+    public static function invalidOrMissingIdInOcsNotificationResponse(): array
     {
         return [
             ['{"ocs":{"data":[{"notification_id":""}]}}'],
@@ -262,7 +262,7 @@ class OcisTest extends TestCase
     /**
      * @return array<int, mixed>
      */
-    public function connectionConfigDataProvider(): array
+    public static function connectionConfigDataProvider(): array
     {
         return [
             [
@@ -375,7 +375,7 @@ class OcisTest extends TestCase
     /**
      * @return array<int, mixed>
      */
-    public function noNotificationsDataProvider(): array
+    public static function noNotificationsDataProvider(): array
     {
         return [
             ['{"ocs":{"data":[]}}'],

--- a/tests/unit/Owncloud/OcisPhpSdk/OcisWebfingerTest.php
+++ b/tests/unit/Owncloud/OcisPhpSdk/OcisWebfingerTest.php
@@ -76,7 +76,7 @@ class OcisWebfingerTest extends TestCase
     /**
      * @return array<array<string>>
      **/
-    public function invalidTokenProvider(): array
+    public static function invalidTokenProvider(): array
     {
         return [
             ["onlyHeaderNoPayload"],
@@ -125,7 +125,7 @@ class OcisWebfingerTest extends TestCase
     /**
      * @return array<array<string>>
      **/
-    public function invalidResponseContentProvider(): array
+    public static function invalidResponseContentProvider(): array
     {
         return [
             ["notJson"],

--- a/tests/unit/Owncloud/OcisPhpSdk/OrderDirectionTest.php
+++ b/tests/unit/Owncloud/OcisPhpSdk/OrderDirectionTest.php
@@ -10,7 +10,7 @@ class OrderDirectionTest extends TestCase
     /**
      * @return array<int,array{0:OrderDirection,1:string}>
      */
-    public function validOrderDirections(): array
+    public static function validOrderDirections(): array
     {
         return [
             [OrderDirection::ASC, "asc"],

--- a/tests/unit/Owncloud/OcisPhpSdk/ResourceInviteTest.php
+++ b/tests/unit/Owncloud/OcisPhpSdk/ResourceInviteTest.php
@@ -22,7 +22,7 @@ class ResourceInviteTest extends TestCase
     /**
      * @return array<mixed>
      */
-    public function inviteDataProvider(): array
+    public static function inviteDataProvider(): array
     {
         $openAPIUser = new OpenAPIUser(
             [

--- a/tests/unit/Owncloud/OcisPhpSdk/ResourceLinkTest.php
+++ b/tests/unit/Owncloud/OcisPhpSdk/ResourceLinkTest.php
@@ -18,7 +18,7 @@ class ResourceLinkTest extends TestCase
     /**
      * @return array<mixed>
      */
-    public function createLinkDataProvider(): array
+    public static function createLinkDataProvider(): array
     {
         return [
             // create a view link with minimal data

--- a/tests/unit/Owncloud/OcisPhpSdk/ResourceTest.php
+++ b/tests/unit/Owncloud/OcisPhpSdk/ResourceTest.php
@@ -25,7 +25,7 @@ class ResourceTest extends TestCase
     /**
      * @return array<int,array<int,string|null>>
      */
-    public function dataProviderValidFileType(): array
+    public static function dataProviderValidFileType(): array
     {
         return [
             ['{DAV:}collection', 'folder'],
@@ -63,7 +63,7 @@ class ResourceTest extends TestCase
     /**
      * @return array<int, array<int, int|string>>
      */
-    public function dataProviderInvalidFileType(): array
+    public static function dataProviderInvalidFileType(): array
     {
         return ([
             ["as"],
@@ -92,7 +92,7 @@ class ResourceTest extends TestCase
     /**
      * @return array<int, array<int, int|string|null>>
      */
-    public function validSizes(): array
+    public static function validSizes(): array
     {
         return [
             [0, 0, null, '{DAV:}getcontentlength'],
@@ -134,7 +134,7 @@ class ResourceTest extends TestCase
     /**
      * @return array<int, array<int, int|string|null>>
      */
-    public function inValidSizes(): array
+    public static function inValidSizes(): array
     {
         return [
             ["g", '{DAV:}collection', '{http://owncloud.org/ns}size'],
@@ -159,7 +159,7 @@ class ResourceTest extends TestCase
     /**
      * @return array<int, array<int, int|string|null>>
      */
-    public function validContentType(): array
+    public static function validContentType(): array
     {
         return [
             ['text/plain', null],
@@ -207,7 +207,7 @@ class ResourceTest extends TestCase
     /**
      * @return array<int, array<int, int|string|null>>
      */
-    public function favoriteValue(): array
+    public static function favoriteValue(): array
     {
         return [
             [0],
@@ -232,7 +232,7 @@ class ResourceTest extends TestCase
     /**
      * @return array<int, array<int, string>>
      */
-    public function invalidFavoriteValues(): array
+    public static function invalidFavoriteValues(): array
     {
         return [
             ['2'],
@@ -256,7 +256,7 @@ class ResourceTest extends TestCase
     /**
      * @return array<int, array<int, array<string, string>|string|null>>
      */
-    public function checkSumValue(): array
+    public static function checkSumValue(): array
     {
         return [
             [["aa" => "aa"], null],

--- a/tests/unit/Owncloud/OcisPhpSdk/UserTest.php
+++ b/tests/unit/Owncloud/OcisPhpSdk/UserTest.php
@@ -12,7 +12,7 @@ class UserTest extends TestCase
     /**
      * @return array<int, array<int, array<string, string>>>
      */
-    public function validUserData(): array
+    public static function validUserData(): array
     {
         return [
             [[
@@ -42,7 +42,7 @@ class UserTest extends TestCase
     /**
      * @return array<int, array<int, array<string, string|null>>>
      */
-    public function invalidUserData(): array
+    public static function invalidUserData(): array
     {
         return [
 

--- a/tests/unit/Owncloud/OcisPhpSdk/WebDavClientTest.php
+++ b/tests/unit/Owncloud/OcisPhpSdk/WebDavClientTest.php
@@ -10,7 +10,7 @@ class WebDavClientTest extends TestCase
     /**
      * @return array<int, array<int, array<mixed>|string>>
      */
-    public function connectionConfigProvider(): array
+    public static function connectionConfigProvider(): array
     {
         return [
             [[], 'https://ocis.sdk.tests:9009', [CURLOPT_HTTPAUTH => CURLAUTH_BEARER, CURLOPT_XOAUTH2_BEARER => 'token']],


### PR DESCRIPTION
PHPunit major version 10 requires PHP 8.1 and later. This project also requires PHPunit 8.1 or later. So we can use the latest PHPunit `10.5.*` release for testing.

Passes for me locally - it needs `php-xdebug` in CI.
I added drone starlark code to install `php8.n-xdebug` in the pipelines that run `phpunit`. And adjusted the command for running unit tests so that it has "coverage" mode enabled for the PHP xdebug extension. That gets things working in CI and locally.