### PR TITLE
make docs pipeline depend on cache-dependency pipeline

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -67,6 +67,8 @@ def main(ctx):
     dependsOn(testsPipelinesWithCoverage, sonarPipeline)
     afterPipelines = codeStylePipeline + phpStanPipeline + phanPipeline + testsPipelinesWithCoverage + testsPipelinesWithoutCoverage
     dependsOn(cacheDependencies(), afterPipelines)
+    docsPipeline = docs()
+    dependsOn(cacheDependencies(), docsPipeline)
     return (
         cacheDependencies() +
         cacheOcisPipeline(ctx) +
@@ -76,7 +78,7 @@ def main(ctx):
         testsPipelinesWithCoverage +
         testsPipelinesWithoutCoverage +
         sonarPipeline +
-        docs()
+        docsPipeline
     )
 
 def phpIntegrationTest(ctx, phpversions, coverage):
@@ -452,6 +454,7 @@ def docs():
                 },
             },
         ],
+        "depends_on": [],
         "trigger": trigger,
     }]
 


### PR DESCRIPTION
corrected version of #150

the docs pipeline might have run before the cache of the dependencies was build and by that installed the wrong dependencies

fixes #149

