### PR TITLE
refactoring group class to validate data from server inside getters

### DIFF
--- a/src/Group.php
+++ b/src/Group.php
@@ -19,13 +19,13 @@ use OpenAPI\Client\ApiException;
 
 class Group
 {
-    private string $id;
-    private string $description;
-    private string $displayName;
+    private string|null $id;
+    private string|null $description;
+    private string|null $displayName;
     /**
-     * @var array<int,string>
+     * @var ?array<int,string>
      */
-    private array $groupTypes;
+    private array|null $groupTypes;
     /**
      * @var array<int,User>
      */
@@ -64,18 +64,10 @@ class Group
         array $connectionConfig,
         string &$accessToken
     ) {
-        $this->id = empty($openApiGroup->getId()) ?
-        throw new InvalidResponseException(
-            "Invalid id returned for group '" . print_r($openApiGroup->getId(), true) . "'"
-        )
-        : (string)$openApiGroup->getId();
-        $this->displayName = empty($openApiGroup->getDisplayName()) ?
-        throw new InvalidResponseException(
-            "Invalid displayName returned for group '" . print_r($openApiGroup->getDisplayName(), true) . "'"
-        )
-        : (string)$openApiGroup->getDisplayName();
-        $this->description = $openApiGroup->getDescription() ?? "";
-        $this->groupTypes = $openApiGroup->getGroupTypes() ?? [];
+        $this->id = $openApiGroup->getId();
+        $this->displayName = $openApiGroup->getDisplayName();
+        $this->description = $openApiGroup->getDescription();
+        $this->groupTypes = $openApiGroup->getGroupTypes();
         $openApiUser = $openApiGroup->getMembers() ?? [];
         $this->members = [];
         foreach ($openApiUser as $user) {
@@ -97,7 +89,10 @@ class Group
      */
     public function getId(): string
     {
-        return $this->id;
+        return (($this->id === null) || ($this->id === '')) ?
+        throw new InvalidResponseException(
+            "Invalid id returned for group '" . print_r($this->id, true) . "'"
+        ) : (string)$this->id;
     }
 
     /**
@@ -105,7 +100,7 @@ class Group
      */
     public function getDescription(): string
     {
-        return $this->description;
+        return (string)$this->description;
     }
 
     /**
@@ -113,7 +108,10 @@ class Group
      */
     public function getDisplayName(): string
     {
-        return $this->displayName;
+        return (($this->displayName === null) || ($this->displayName === '')) ?
+        throw new InvalidResponseException(
+            "Invalid displayName returned for group '" . print_r($this->displayName, true) . "'"
+        ) : $this->displayName;
     }
 
     /**
@@ -121,7 +119,7 @@ class Group
      */
     public function getGroupTypes(): array
     {
-        return $this->groupTypes;
+        return $this->groupTypes ?? [];
     }
 
     /**
@@ -130,6 +128,15 @@ class Group
     public function getMembers(): array
     {
         return $this->members;
+    }
+
+    /**
+     * Set the value of members
+     * @param User $member
+     */
+    public function setMembers(User $member): void
+    {
+        $this->members[] = $member;
     }
 
     /**
@@ -158,7 +165,7 @@ class Group
         } catch (ApiException $e) {
             throw ExceptionHelper::getHttpErrorException($e);
         }
-        $this->members[] = $user;
+        $this->setMembers($user);
     }
 
     /**

--- a/tests/unit/Owncloud/OcisPhpSdk/GroupTest.php
+++ b/tests/unit/Owncloud/OcisPhpSdk/GroupTest.php
@@ -3,6 +3,8 @@
 namespace unit\Owncloud\OcisPhpSdk;
 
 use OpenAPI\Client\Model\Group;
+use Owncloud\OcisPhpSdk\User as SdkUser;
+use OpenAPI\Client\Model\User;
 use Owncloud\OcisPhpSdk\Exception\InvalidResponseException;
 use Owncloud\OcisPhpSdk\Group as SdkGroup;
 use PHPUnit\Framework\TestCase;
@@ -108,10 +110,42 @@ class GroupTest extends TestCase
      */
     public function testInvalidDataInListGroup(array $data, string $key, string $errorMsg)
     {
-        $this->expectException(InvalidResponseException::class);
         $this->expectExceptionMessage("Invalid $errorMsg returned for group '" . print_r($data[$key], true));
         $libGroup = new Group($data);
         $accessToken = "acstok";
+        $this->expectException(InvalidResponseException::class);
         $group = new SdkGroup($libGroup, "url", [], $accessToken);
+        $group->getId();
+        $group->getDisplayName();
+        $group->getMembers();
+    }
+
+    public function testSetMembers(): void
+    {
+        $libGroup = new Group(
+            [
+                "id" => "as",
+                "description" => "a",
+                "display_name" => "name",
+                "group_types" => ["aa"],
+                "members" => [],
+            ]
+        );
+        $accessToken = "acstok";
+        $group = new SdkGroup($libGroup, "url", [], $accessToken);
+        $this->assertCount(0, $group->getMembers());
+        $group->setMembers(
+            new SdkUser(
+                new User(
+                    [
+                        "id" => "id",
+                        "display_name" => "displayname",
+                        "mail" => "mail@mail.com",
+                        "on_premises_sam_account_name" => "sd",
+                    ],
+                )
+            )
+        );
+        $this->assertCount(1, $group->getMembers());
     }
 }


### PR DESCRIPTION
previously we validated the response from server in constructor in group class but now this PR moves that logic to the getters.

related to :https://github.com/owncloud/ocis-php-sdk/issues/99