### PR TITLE
Refactor phpstan doc for ConnectionConfig

### DIFF
--- a/src/Drive.php
+++ b/src/Drive.php
@@ -25,6 +25,8 @@ use Sabre\HTTP\ClientHttpException as SabreClientHttpException;
 
 /**
  * Class representing a single drive/space in ownCloud Infinite Scale
+ *
+ * @phpstan-import-type ConnectionConfig from Ocis
  */
 class Drive
 {
@@ -33,12 +35,7 @@ class Drive
     private string $webDavUrl = '';
 
     /**
-     * @phpstan-var array{
-     *                      'headers'?:array<string, mixed>,
-     *                      'verify'?:bool,
-     *                      'webfinger'?:bool,
-     *                      'guzzle'?:\GuzzleHttp\Client
-     *                    }
+     * @phpstan-var ConnectionConfig
      */
     private array $connectionConfig;
     private Configuration $graphApiConfig;
@@ -47,12 +44,7 @@ class Drive
     /**
      * @ignore The developer using the SDK does not need to create drives manually, but should use the Ocis class
      *         to get or create drives, so this constructor should not be listed in the documentation.
-     * @phpstan-param array{
-     *                      'headers'?:array<string, mixed>,
-     *                      'verify'?:bool,
-     *                      'webfinger'?:bool,
-     *                      'guzzle'?:\GuzzleHttp\Client
-     *                      } $connectionConfig
+     * @phpstan-param ConnectionConfig $connectionConfig
      * @throws \InvalidArgumentException
      */
     public function __construct(

--- a/src/Group.php
+++ b/src/Group.php
@@ -17,6 +17,9 @@ use Owncloud\OcisPhpSdk\Exception\NotFoundException;
 use Owncloud\OcisPhpSdk\Exception\UnauthorizedException;
 use OpenAPI\Client\ApiException;
 
+/**
+ * @phpstan-import-type ConnectionConfig from Ocis
+ */
 class Group
 {
     private string $id;
@@ -36,12 +39,7 @@ class Group
     private string $accessToken;
 
     /**
-     * @phpstan-param array{
-     *                      'headers'?:array<string, mixed>,
-     *                      'verify'?:bool,
-     *                      'webfinger'?:bool,
-     *                      'guzzle'?:\GuzzleHttp\Client
-     *                      } $connectionConfig
+     * @phpstan-var ConnectionConfig
      * @ignore The developer using the SDK does not need to create Group objects manually,
      *         but should use the Ocis class to query the server for groups
      */
@@ -50,12 +48,7 @@ class Group
     /**
      * @param OpenApiGroup $openApiGroup
      * @param string $serviceUrl
-     * @phpstan-param array{
-     *                      'headers'?:array<string, mixed>,
-     *                      'verify'?:bool,
-     *                      'webfinger'?:bool,
-     *                      'guzzle'?:\GuzzleHttp\Client
-     *                      } $connectionConfig
+     * @phpstan-param ConnectionConfig $connectionConfig
      * @param string $accessToken
      */
     public function __construct(

--- a/src/Notification.php
+++ b/src/Notification.php
@@ -13,6 +13,8 @@ use Owncloud\OcisPhpSdk\Exception\UnauthorizedException;
 
 /**
  * Class representing a single notification emitted in ownCloud Infinite Scale
+ *
+ * @phpstan-import-type ConnectionConfig from Ocis
  */
 class Notification
 {
@@ -35,17 +37,12 @@ class Notification
     private string $serviceUrl;
 
     /**
-     * @phpstan-var array{'headers'?:array<string, mixed>, 'verify'?:bool}
+     * @phpstan-var ConnectionConfig
      */
     private array $connectionConfig;
 
     /**
-     * @phpstan-param array{
-     *                        'headers'?:array<string, mixed>,
-     *                        'verify'?:bool,
-     *                        'webfinger'?:bool,
-     *                        'guzzle'?:\GuzzleHttp\Client
-     *                        } $connectionConfig
+     * @phpstan-param ConnectionConfig $connectionConfig
      * @phpstan-param object{
      *    app: string,
      *    user: string,

--- a/src/Ocis.php
+++ b/src/Ocis.php
@@ -34,6 +34,17 @@ use OpenAPI\Client\Model\Group as OpenAPIGroup;
 
 /**
  * Basic class to establish the connection to an ownCloud Infinite Scale instance
+ *
+ * @phpstan-type ConnectionConfig array{
+ *                     'headers'?:array<string, mixed>,
+ *                     'proxy'?:array{'http'?:string, 'https'?:string, 'no'?:array<string>}|string,
+ *                     'verify'?:bool,
+ *                     'webfinger'?:bool,
+ *                     'guzzle'?:Client,
+ *                     'drivesApi'?:DrivesApi,
+ *                     'drivesGetDrivesApi'?:DrivesGetDrivesApi,
+ *                     'drivesPermissionsApi'?:DrivesPermissionsApi
+ *  }
  */
 class Ocis
 {
@@ -47,30 +58,12 @@ class Ocis
     private string $notificationsEndpoint = '/ocs/v2.php/apps/notifications/api/v1/notifications?format=json';
 
     /**
-     * @phpstan-var array{
-     *                    'headers'?:array<string, mixed>,
-     *                    'proxy'?:array{'http'?:string, 'https'?:string, 'no'?:array<string>}|string,
-     *                    'verify'?:bool,
-     *                    'webfinger'?:bool,
-     *                    'guzzle'?:Client,
-     *                    'drivesApi'?:DrivesApi,
-     *                    'drivesGetDrivesApi'?:DrivesGetDrivesApi,
-     *                    'drivesPermissionsApi'?:DrivesPermissionsApi
-     * }
+     * @phpstan-var ConnectionConfig
      */
     private array $connectionConfig;
 
     /**
-     * @phpstan-param array{
-     *                      'headers'?:array<string, mixed>,
-     *                      'proxy'?:array{'http'?:string, 'https'?:string, 'no'?:array<string>}|string,
-     *                      'verify'?:bool,
-     *                      'webfinger'?:bool,
-     *                      'guzzle'?:Client,
-     *                      'drivesApi'?:DrivesApi,
-     *                      'drivesGetDrivesApi'?:DrivesGetDrivesApi,
-     *                      'drivesPermissionsApi'?:DrivesPermissionsApi
-     *                      } $connectionConfig
+     * @phpstan-param ConnectionConfig $connectionConfig
      *        valid config keys are: headers, proxy, verify, webfinger, guzzle
      *        headers has to be an array in the form like
      *        [
@@ -201,13 +194,7 @@ class Ocis
      * @throws \InvalidArgumentException
      * @ignore This function is used for internal purposes only and should not be shown in the documentation.
      *         The function is public to make it testable.
-     * @phpstan-param array{
-     *                       'headers'?:array<string, mixed>,
-     *                       'proxy'?:array{'http'?:string, 'https'?:string, 'no'?:array<string>}|string,
-     *                       'verify'?:bool,
-     *                       'webfinger'?:bool,
-     *                       'guzzle'?:Client
-     *                       } $connectionConfig
+     * @phpstan-param ConnectionConfig $connectionConfig
      */
     public static function createGuzzleConfig(array $connectionConfig, string $accessToken): array
     {

--- a/src/OcisResource.php
+++ b/src/OcisResource.php
@@ -27,6 +27,8 @@ use Sabre\HTTP\ResponseInterface;
 
 /**
  * Class representing a file or folder inside a Drive in ownCloud Infinite Scale
+ *
+ * @phpstan-import-type ConnectionConfig from Ocis
  */
 class OcisResource
 {
@@ -36,16 +38,10 @@ class OcisResource
     private array $metadata;
     private string $accessToken;
     private string $serviceUrl;
-    /**
-     * @phpstan-var array{
-     *                      'headers'?:array<string, mixed>,
-     *                      'verify'?:bool,
-     *                      'webfinger'?:bool,
-     *                      'guzzle'?:\GuzzleHttp\Client,
-     *                      'drivesPermissionsApi'?:\OpenAPI\Client\Api\DrivesPermissionsApi,
-     *                    }
-     */
 
+    /**
+     * @phpstan-var ConnectionConfig
+     */
     private array $connectionConfig;
     private Configuration $graphApiConfig;
 
@@ -54,7 +50,7 @@ class OcisResource
      *        the format of the array is directly taken from the PROPFIND response
      *        returned by Sabre\DAV\Client
      *        for details about accepted metadata see: ResourceMetadata
-     * @param array $connectionConfig
+     * @phpstan-param ConnectionConfig $connectionConfig
      * @param string $serviceUrl
      * @param string $accessToken
      * @throws BadRequestException
@@ -64,14 +60,6 @@ class OcisResource
      * @throws NotFoundException
      * @throws UnauthorizedException
      * @throws InternalServerErrorException
-     * @phpstan-param array{
-     *              'headers'?:array<string, mixed>,
-     *              'verify'?:bool,
-     *              'webfinger'?:bool,
-     *              'guzzle'?:Client,
-     *              'drivesPermissionsApi'?:DrivesPermissionsApi,
-     *              'drivesApi'?:DrivesApi
-     *             } $connectionConfig
      * @return void
      * @ignore The developer using the SDK does not need to create OcisResource objects manually,
      *         but should use the Drive class to query the server for resources

--- a/src/Share.php
+++ b/src/Share.php
@@ -19,18 +19,14 @@ use Owncloud\OcisPhpSdk\Exception\UnauthorizedException;
 
 /**
  * Parent class representing different types of share objects
+ *
+ * @phpstan-import-type ConnectionConfig from Ocis
  */
 class Share
 {
     protected string $accessToken;
     /**
-     * @phpstan-var array{
-     *                      'headers'?:array<string, mixed>,
-     *                      'verify'?:bool,
-     *                      'webfinger'?:bool,
-     *                      'guzzle'?:\GuzzleHttp\Client,
-     *                      'drivesPermissionsApi'?:\OpenAPI\Client\Api\DrivesPermissionsApi,
-     *                    }
+     * @phpstan-var ConnectionConfig
      */
     protected array $connectionConfig;
     protected string $serviceUrl;
@@ -42,13 +38,7 @@ class Share
 
     /**
      * @throws InvalidResponseException
-     * @phpstan-param array{
-     *                       'headers'?:array<string, mixed>,
-     *                       'verify'?:bool,
-     *                       'webfinger'?:bool,
-     *                       'guzzle'?:\GuzzleHttp\Client,
-     *                       'drivesPermissionsApi'?:\OpenAPI\Client\Api\DrivesPermissionsApi,
-     *                     } $connectionConfig
+     * @phpstan-param ConnectionConfig $connectionConfig
      * @ignore The developer using the SDK does not need to create share objects manually,
      *         but should use the OcisResource class to invite people to a resource and
      *         that will create ShareCreated objects

--- a/src/ShareLink.php
+++ b/src/ShareLink.php
@@ -19,6 +19,8 @@ use Owncloud\OcisPhpSdk\Exception\UnauthorizedException;
 
 /**
  * Class representing a public link to a resource
+ *
+ * @phpstan-import-type ConnectionConfig from Ocis
  */
 class ShareLink extends Share
 {
@@ -26,13 +28,7 @@ class ShareLink extends Share
 
     /**
      * @throws InvalidResponseException
-     * @phpstan-param array{
-     *                       'headers'?:array<string, mixed>,
-     *                       'verify'?:bool,
-     *                       'webfinger'?:bool,
-     *                       'guzzle'?:\GuzzleHttp\Client,
-     *                       'drivesPermissionsApi'?:\OpenAPI\Client\Api\DrivesPermissionsApi,
-     *                     } $connectionConfig
+     * @phpstan-param ConnectionConfig $connectionConfig
      * @ignore The developer using the SDK does not need to create ShareLink objects manually,
      *         but should use the OcisResource class to share resources using a link
      *         and that will create ShareLink objects

--- a/src/WebDavClient.php
+++ b/src/WebDavClient.php
@@ -18,6 +18,7 @@ use Owncloud\OcisPhpSdk\Exception\ExceptionHelper;
 
 /**
  * @ignore This is only used for internal purposes and should not show up in the documentation
+ * @phpstan-import-type ConnectionConfig from Ocis
  */
 class WebDavClient extends Client
 {
@@ -58,9 +59,7 @@ class WebDavClient extends Client
     }
 
     /**
-     * @phpstan-param array{
-     *                       'headers'?:array<string, mixed>,
-     *                      } $connectionConfig
+     * @phpstan-param ConnectionConfig $connectionConfig
      * @return array<int, mixed>
      */
     private function getCurlHeaders(array $connectionConfig): array
@@ -75,9 +74,7 @@ class WebDavClient extends Client
     }
 
     /**
-     * @phpstan-param array{
-     *                       'verify'?:bool
-     *                      } $connectionConfig
+     * @phpstan-param ConnectionConfig $connectionConfig
      * @return array<int, mixed>
      */
     private function getCurlVerifySettings(array $connectionConfig): array
@@ -91,9 +88,7 @@ class WebDavClient extends Client
     }
 
     /**
-     * @phpstan-param array{
-     *                      'proxy'?:array{'http'?:string, 'https'?:string, 'no'?:array<string>}|string,
-     *                     } $connectionConfig
+     * @phpstan-param ConnectionConfig $connectionConfig
      * @return array<int, mixed>
      */
     private function getCurlProxySettings(array $connectionConfig): array
@@ -129,13 +124,7 @@ class WebDavClient extends Client
     }
 
     /**
-     * @phpstan-param array{
-     *                      'headers'?:array<string, mixed>,
-     *                      'proxy'?:array{'http'?:string, 'https'?:string, 'no'?:array<string>}|string,
-     *                      'verify'?:bool,
-     *                      'webfinger'?:bool,
-     *                      'guzzle'?:\GuzzleHttp\Client
-     *                     } $connectionConfig
+     * @phpstan-param ConnectionConfig $connectionConfig
      * @return array<int, mixed>
      */
     public function createCurlSettings(array $connectionConfig, string $accessToken): array
@@ -151,13 +140,7 @@ class WebDavClient extends Client
     /**
      * set curl settings
      * enable exceptions for send method
-     * @phpstan-param array{
-     *                       'headers'?:array<string, mixed>,
-     *                       'proxy'?:array{'http'?:string, 'https'?:string, 'no'?:array<string>}|string,
-     *                       'verify'?:bool,
-     *                       'webfinger'?:bool,
-     *                       'guzzle'?:\GuzzleHttp\Client
-     *                      } $connectionConfig     *
+     * @phpstan-param ConnectionConfig $connectionConfig
      */
     public function setCustomSetting(array $connectionConfig, string $accessToken): void
     {

--- a/tests/unit/Owncloud/OcisPhpSdk/WebDavClientTest.php
+++ b/tests/unit/Owncloud/OcisPhpSdk/WebDavClientTest.php
@@ -5,6 +5,9 @@ namespace unit\Owncloud\OcisPhpSdk;
 use Owncloud\OcisPhpSdk\WebDavClient;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * @phpstan-import-type ConnectionConfig from \Owncloud\OcisPhpSdk\Ocis
+ */
 class WebDavClientTest extends TestCase
 {
     /**
@@ -89,12 +92,7 @@ class WebDavClientTest extends TestCase
     }
 
     /**
-     * @phpstan-param array{
-     *                      'headers'?:array<string, mixed>,
-     *                      'verify'?:bool,
-     *                      'webfinger'?:bool,
-     *                      'guzzle'?:\GuzzleHttp\Client
-     *                     } $connectionConfig
+     * @phpstan-param ConnectionConfig $connectionConfig
      * @param array<mixed> $expectedCurlSettingsArray
      * @dataProvider connectionConfigProvider
      */


### PR DESCRIPTION
Declare a `phpstan-type` called `ConnectionConfig` to be the long declaration of what a connection config array can contain.
Use that in the places where we have various long declarations of the array-shape of a connection config.
In some places, the array-shape currently just declared a minimal set of things that were relevant to the method (for example, `getCurlHeaders` in `WebDavClient.php` only mentioned the "headers" array key). But we can happily pass a whole connection config array, and the method `getCurlHeaders` takes it, and only happens to deal with the "headers" key.
So I think it is OK (and good) to declare that all these methods take any `ConnectionConfig` as an input parameter.

PBPstan documentation for this feature is at https://phpstan.org/writing-php-code/phpdoc-types#local-type-aliases