### PR TITLE
refactoring sharelink class to validate data from server inside getters

### DIFF
--- a/tests/integration/Owncloud/OcisPhpSdk/ShareGetShareByMeTest.php
+++ b/tests/integration/Owncloud/OcisPhpSdk/ShareGetShareByMeTest.php
@@ -74,7 +74,7 @@ class ShareGetShareByMeTest extends OcisPhpSdkTestCase
     {
         $this->sharedResource->createSharingLink(
             SharingLinkType::VIEW,
-            new \DateTimeImmutable('2023-12-31 01:02:03.456789'),
+            new \DateTimeImmutable('2024-12-31 01:02:03.456789'),
             self::VALID_LINK_PASSWORD,
             ''
         );
@@ -89,7 +89,7 @@ class ShareGetShareByMeTest extends OcisPhpSdkTestCase
         $this->sharedResource->invite($this->einstein, $this->editorRole);
         $this->sharedResource->createSharingLink(
             SharingLinkType::VIEW,
-            new \DateTimeImmutable('2023-12-31 01:02:03.456789'),
+            new \DateTimeImmutable('2024-12-31 01:02:03.456789'),
             self::VALID_LINK_PASSWORD,
             ''
         );

--- a/tests/unit/Owncloud/OcisPhpSdk/ResourceLinkTest.php
+++ b/tests/unit/Owncloud/OcisPhpSdk/ResourceLinkTest.php
@@ -141,7 +141,8 @@ class ResourceLinkTest extends TestCase
         $permissionMock->method('getId')->willReturn('uuid-of-the-permission');
         $drivesPermissionsApi = $this->createMock(DrivesPermissionsApi::class);
         $drivesPermissionsApi->method('createLink')->willReturn($permissionMock);
-        $this->createResource($drivesPermissionsApi)->createSharingLink(password:self::PASSWORD);
+        $link = $this->createResource($drivesPermissionsApi)->createSharingLink(password:self::PASSWORD);
+        $link->getType();
     }
 
     public function testInvalidSharingLinkWebUrlResponse(): void
@@ -155,7 +156,8 @@ class ResourceLinkTest extends TestCase
         $drivesPermissionsApi = $this->createMock(DrivesPermissionsApi::class);
         $drivesPermissionsApi->method('createLink')->willReturn($permissionMock);
 
-        $this->createResource($drivesPermissionsApi)->createSharingLink(password:self::PASSWORD);
+        $link = $this->createResource($drivesPermissionsApi)->createSharingLink(password:self::PASSWORD);
+        $link->getWebUrl();
     }
 
     public function testInvalidSharingLinkTypeResponse(): void
@@ -170,6 +172,7 @@ class ResourceLinkTest extends TestCase
         $drivesPermissionsApi = $this->createMock(DrivesPermissionsApi::class);
         $drivesPermissionsApi->method('createLink')->willReturn($permissionMock);
 
-        $this->createResource($drivesPermissionsApi)->createSharingLink(password:self::PASSWORD);
+        $link = $this->createResource($drivesPermissionsApi)->createSharingLink(password:self::PASSWORD);
+        $link->getType();
     }
 }


### PR DESCRIPTION
previously we validated the response from server in constructor in `ShareLink` class but now this PR moves that logic to the getters.

related to :https://github.com/owncloud/ocis-php-sdk/issues/99