### PR TITLE
refactoring share class to validate data from server inside getters

### DIFF
--- a/src/Share.php
+++ b/src/Share.php
@@ -53,11 +53,6 @@ class Share
     ) {
         $this->apiPermission = $apiPermission;
         $this->driveId = $driveId;
-        if (!is_string($apiPermission->getId())) {
-            throw new InvalidResponseException(
-                "Invalid id returned for permission '" . print_r($apiPermission->getId(), true) . "'"
-            );
-        }
 
         $this->resourceId = $resourceId;
         $this->accessToken = &$accessToken;
@@ -88,9 +83,13 @@ class Share
 
     public function getPermissionId(): string
     {
-        // in the constructor the value is checked for being the right type, but phan does not know
-        // so simply cast to string
-        return (string)$this->apiPermission->getId();
+        $id = $this->apiPermission->getId();
+        if ($id === null || $id === '') {
+            throw new InvalidResponseException(
+                "Invalid id returned for permission '" . print_r($id, true) . "'"
+            );
+        }
+        return (string)$id;
     }
 
     public function getExpiration(): ?\DateTimeImmutable

--- a/tests/unit/Owncloud/OcisPhpSdk/ResourceLinkTest.php
+++ b/tests/unit/Owncloud/OcisPhpSdk/ResourceLinkTest.php
@@ -130,7 +130,8 @@ class ResourceLinkTest extends TestCase
         $permissionMock = $this->createMock(Permission::class);
         $drivesPermissionsApi = $this->createMock(DrivesPermissionsApi::class);
         $drivesPermissionsApi->method('createLink')->willReturn($permissionMock);
-        $this->createResource($drivesPermissionsApi)->createSharingLink(password:self::PASSWORD);
+        $link = $this->createResource($drivesPermissionsApi)->createSharingLink(password:self::PASSWORD);
+        $link->getPermissionId();
     }
 
     public function testInvalidLinkResponse(): void


### PR DESCRIPTION
previously we validated the response from server in constructor in share class but now this PR moves that logic to the getters.

related to :https://github.com/owncloud/ocis-php-sdk/issues/99