### PR TITLE
refactoring sharing role class to validate data from server inside getters

### DIFF
--- a/src/SharingRole.php
+++ b/src/SharingRole.php
@@ -11,10 +11,10 @@ use Owncloud\OcisPhpSdk\Exception\InvalidResponseException;
  */
 class SharingRole
 {
-    private string $id;
-    private string $displayName;
-    private string $description;
-    private int $weight;
+    private ?string $id;
+    private ?string $displayName;
+    private ?string $description;
+    private ?int $weight;
 
     /**
      * @ignore The developer using the SDK does not need to create SharingRole objects manually,
@@ -22,20 +22,24 @@ class SharingRole
      */
     public function __construct(UnifiedRoleDefinition $apiRole)
     {
-        $this->id = !is_string($apiRole->getId()) ?
-            throw new InvalidResponseException(
-                "Invalid id returned for sharing role '" . print_r($apiRole->getId(), true) . "'"
-            )
-            : (string)$apiRole->getId();
-        $this->displayName = !is_string($apiRole->getDisplayName()) ?
-            throw new InvalidResponseException(
-                "Invalid display name returned for sharing role '" .
-                print_r($apiRole->getId(), true) .
-                "'"
-            )
-            : (string)$apiRole->getDisplayName();
-        $this->description = !is_string($apiRole->getDescription()) ? "" : $apiRole->getDescription();
-        $this->weight = (int)$apiRole->getAtLibreGraphWeight();
+        $this->id = $apiRole->getId();
+        $this->displayName = $apiRole->getDisplayName();
+        $this->description = $apiRole->getDescription();
+        $this->weight = $apiRole->getAtLibreGraphWeight();
+    }
+    /**
+     * @param string|null|int $data
+     * @param string $dataKey
+     *
+     * @throws InvalidResponseException
+     * @return string
+     */
+    public function validateData($data, $dataKey): string
+    {
+        return ($data === null || $data === '') ?
+        throw new InvalidResponseException(
+            "Invalid $dataKey returned for user '" . print_r($data, true) . "'"
+        ) : (string)$data;
     }
 
     /**
@@ -43,7 +47,7 @@ class SharingRole
      */
     public function getId(): string
     {
-        return $this->id;
+        return $this->validateData($this->id, "id");
     }
 
     /**
@@ -51,7 +55,7 @@ class SharingRole
      */
     public function getDisplayName(): string
     {
-        return $this->displayName;
+        return $this->validateData($this->displayName, "display name");
     }
 
     /**
@@ -59,7 +63,7 @@ class SharingRole
      */
     public function getDescription(): string
     {
-        return $this->description;
+        return $this->validateData($this->description, "description");
     }
 
     /**
@@ -67,7 +71,7 @@ class SharingRole
      */
     public function getWeight(): int
     {
-        return $this->weight;
+        return (int)$this->validateData($this->weight, "weight");
     }
 
 

--- a/tests/integration/Owncloud/OcisPhpSdk/ShareGetShareByMeTest.php
+++ b/tests/integration/Owncloud/OcisPhpSdk/ShareGetShareByMeTest.php
@@ -74,7 +74,7 @@ class ShareGetShareByMeTest extends OcisPhpSdkTestCase
     {
         $this->sharedResource->createSharingLink(
             SharingLinkType::VIEW,
-            new \DateTimeImmutable('2024-12-31 01:02:03.456789'),
+            new \DateTimeImmutable(date('Y', strtotime('+1 year'))),
             self::VALID_LINK_PASSWORD,
             ''
         );
@@ -89,7 +89,7 @@ class ShareGetShareByMeTest extends OcisPhpSdkTestCase
         $this->sharedResource->invite($this->einstein, $this->editorRole);
         $this->sharedResource->createSharingLink(
             SharingLinkType::VIEW,
-            new \DateTimeImmutable('2024-12-31 01:02:03.456789'),
+            new \DateTimeImmutable(date('Y', strtotime('+1 year'))),
             self::VALID_LINK_PASSWORD,
             ''
         );

--- a/tests/unit/Owncloud/OcisPhpSdk/ResourceInviteTest.php
+++ b/tests/unit/Owncloud/OcisPhpSdk/ResourceInviteTest.php
@@ -10,6 +10,7 @@ use OpenAPI\Client\Model\Group as OpenAPIGroup;
 use OpenAPI\Client\Model\User as OpenAPIUser;
 use OpenAPI\Client\Model\Permission;
 use OpenAPI\Client\Model\UnifiedRoleDefinition;
+use Owncloud\OcisPhpSdk\Exception\InvalidResponseException;
 use Owncloud\OcisPhpSdk\Group;
 use Owncloud\OcisPhpSdk\OcisResource;
 use Owncloud\OcisPhpSdk\ShareCreated;
@@ -148,5 +149,99 @@ class ResourceInviteTest extends TestCase
 
         $result = $resource->invite($recipient, $role, $expiration);
         $this->assertInstanceOf(ShareCreated::class, $result);
+    }
+
+    /**
+     * @return array<int, array<int, array<string, int|string|null>|string>>
+     */
+    public static function invalidShareRoleData(): array
+    {
+        return [
+            [
+                [
+                    'id' => '',
+                    'display_name' => 'Manager',
+                    'description' => 'description',
+                    'weight' => 'at_libre_graph_weight',
+                ],"Invalid id returned for user ''"
+            ],
+            [
+                [
+                    'id' => null,
+                    'display_name' => 'Manager',
+                    'description' => 'description',
+                    'weight' => 2,
+                ],"Invalid id returned for user ''"
+            ],
+            [
+                [
+                    'id' => 'uuid-of-the-role',
+                    'display_name' => '',
+                    'description' => 'description',
+                    'weight' => 4,
+                ],"Invalid display name returned for user ''"
+            ],
+            [
+                [
+                    'id' => 'uuid-of-the-role',
+                    'display_name' => null,
+                    'description' => 'description',
+                    'weight' => 6,
+                ],"Invalid display name returned for user ''"
+            ],
+            [
+                [
+                    'id' => 'uuid-of-the-role',
+                    'display_name' => 'Manager',
+                    'description' => '',
+                    'weight' => 5,
+                ],"Invalid description returned for user ''"
+            ],
+            [
+                [
+                    'id' => 'uuid-of-the-role',
+                    'display_name' => 'Manager',
+                    'description' => null,
+                    'weight' => 24,
+                ],"Invalid description returned for user ''"
+            ],
+            [
+                [
+                    'id' => 'uuid-of-the-role',
+                    'display_name' => 'Manager',
+                    'description' => 'description',
+                    'weight' => '',
+                ],"Invalid weight returned for user ''"
+            ],
+            [
+                [
+                    'id' => 'uuid-of-the-role',
+                    'display_name' => 'Manager',
+                    'description' => 'description',
+                    'weight' => null,
+                ],"Invalid weight returned for user ''"
+            ],
+        ];
+    }
+
+    /**
+     * @param array<int, array<string, int|string|null>|string> $shareRoleData
+     * @param string $errorMessage
+     *
+     * @dataProvider invalidShareRoleData
+     *
+     * @return void
+     */
+    public function testShareRoleClass($shareRoleData, $errorMessage): void
+    {
+        $openAPIRole = new UnifiedRoleDefinition($shareRoleData);
+        $role = new SharingRole($openAPIRole);
+
+        $this->expectException(InvalidResponseException::class);
+        $this->expectExceptionMessage($errorMessage);
+        $role->getId();
+        $role->getDisplayName();
+        $role->getDescription();
+        $role->getWeight();
     }
 }


### PR DESCRIPTION
previously we validated the response from server in constructor in sharing role class but now this PR moves that logic to the getters.

related to :https://github.com/owncloud/ocis-php-sdk/issues/99