### PR TITLE
fix: allow id or display name to be '0'

### DIFF
--- a/src/User.php
+++ b/src/User.php
@@ -30,7 +30,7 @@ class User
      */
     public function getDisplayName(): string
     {
-        return empty($this->displayName) ?
+        return (($this->displayName === null) || ($this->displayName === '')) ?
         throw new InvalidResponseException(
             "Invalid displayName returned for user '" . print_r($this->displayName, true) . "'"
         )
@@ -42,7 +42,7 @@ class User
      */
     public function getId(): string
     {
-        return empty($this->id) ?
+        return (($this->id === null) || ($this->id === '')) ?
         throw new InvalidResponseException(
             "Invalid id returned for user '" . print_r($this->id, true) . "'"
         ) : (string)$this->id;

--- a/tests/unit/Owncloud/OcisPhpSdk/UserTest.php
+++ b/tests/unit/Owncloud/OcisPhpSdk/UserTest.php
@@ -15,12 +15,22 @@ class UserTest extends TestCase
     public static function validUserData(): array
     {
         return [
-            [[
-                "id" => "id",
-                "display_name" => "displayname",
-                "mail" => "mail@mail.com",
-                "on_premises_sam_account_name" => "sd",
-            ]],
+            [
+                [
+                    "id" => "id",
+                    "display_name" => "displayname",
+                    "mail" => "mail@mail.com",
+                    "on_premises_sam_account_name" => "sd",
+                ],
+            ],
+            [
+                [
+                    "id" => "0",
+                    "display_name" => "0",
+                    "mail" => "0@mail.com",
+                    "on_premises_sam_account_name" => "sd",
+                ],
+            ],
         ];
     }
 


### PR DESCRIPTION
We have been using the PHP `empty` function in a few places for validation.
That is dangerous because things like the ASCII string "0" are considered "empty". And there can be unusual edge cases where "0" is a valid string value. For example, someone could set their display name to the ASCII string "0".

This PR replaces 2 uses of `empty` with more specific validation.

We should look for other uses of `empty` and inspect them and replace with more specific checks.