### PR TITLE
fix: deprecations reported by phpunit

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="tests/unit/bootstrap.php" failOnRisky="true" failOnWarning="true" beStrictAboutOutputDuringTests="true" timeoutForSmallTests="900" timeoutForMediumTests="900" timeoutForLargeTests="900" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd" cacheDirectory=".phpunit.cache">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="tests/unit/bootstrap.php" displayDetailsOnTestsThatTriggerDeprecations="true" failOnDeprecation="true" failOnRisky="true" failOnWarning="true" beStrictAboutOutputDuringTests="true" timeoutForSmallTests="900" timeoutForMediumTests="900" timeoutForLargeTests="900" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd" cacheDirectory=".phpunit.cache">
   <testsuites>
     <testsuite name="unit">
       <directory suffix="Test.php">./tests/unit</directory>

--- a/src/Ocis.php
+++ b/src/Ocis.php
@@ -166,10 +166,10 @@ class Ocis
             'headers' => 'is_array',
             'verify' => 'is_bool',
             'webfinger' => 'is_bool',
-            'guzzle' => 'self::isGuzzleClient',
-            'drivesPermissionsApi' => 'self::isDrivesPermissionsApi',
-            'drivesApi' => 'self::isDrivesApi',
-            'drivesGetDrivesApi' => 'self::isDrivesGetDrivesApi',
+            'guzzle' => self::class . '::isGuzzleClient',
+            'drivesPermissionsApi' => self::class . '::isDrivesPermissionsApi',
+            'drivesApi' => self::class . '::isDrivesApi',
+            'drivesGetDrivesApi' => self::class . '::isDrivesGetDrivesApi',
             'proxy' => 'is_array',
         ];
         foreach ($connectionConfig as $key => $check) {
@@ -177,8 +177,6 @@ class Ocis
                 return false;
             }
 
-            // phpstan does not understand that the `$validConnectionConfigKeys` array has values that are callable
-            // @phpstan-ignore-next-line
             if (!\call_user_func($validConnectionConfigKeys[$key], $check)) {
                 return false;
             }
@@ -244,6 +242,9 @@ class Ocis
         }
         $tokenPayload = json_decode($plainPayload, true);
         if (!is_array($tokenPayload) || !array_key_exists('iss', $tokenPayload)) {
+            throw new \InvalidArgumentException(self::DECODE_TOKEN_ERROR_MESSAGE);
+        }
+        if (!is_string($tokenPayload['iss'])) {
             throw new \InvalidArgumentException(self::DECODE_TOKEN_ERROR_MESSAGE);
         }
         $iss = parse_url($tokenPayload['iss']);


### PR DESCRIPTION
phpunit 10 was reporting:
```
php -d memory_limit=4096M -d zend.enable_gc=0 -d xdebug.mode=coverage "vendor/bin/phpunit" --configuration ./phpunit.xml --testsuite unit
PHPUnit 10.5.5 by Sebastian Bergmann and contributors.

Runtime:       PHP 8.3.0 with Xdebug 3.3.0alpha2
Configuration: /home/phil/git/owncloud/ocis-php-sdk/phpunit.xml

.......................................D.DDDDDDDDDDDDDD........  63 / 157 ( 40%)
............DDDDDDDDDDDDDDDDDDDDD..DDDDDDDDDD.................. 126 / 157 ( 80%)
...............................                                 157 / 157 (100%)

Time: 00:00.871, Memory: 18.00 MB

OK, but there were issues!
Tests: 157, Assertions: 337, Deprecations: 2.

Generating code coverage report in Clover XML format ... done [00:00.021]
```

Lots of unit test cases are reporting deprecations.

In `phpunit.xml` I have enabled `displayDetailsOnTestsThatTriggerDeprecations="true" failOnDeprecation="true"`
So we can see what the deprecations are.

The phpunit output is:
```
php -d memory_limit=4096M -d zend.enable_gc=0 -d xdebug.mode=coverage "vendor/bin/phpunit" --configuration ./phpunit.xml --testsuite unit
PHPUnit 10.5.5 by Sebastian Bergmann and contributors.

Runtime:       PHP 8.3.0 with Xdebug 3.3.0alpha2
Configuration: /home/phil/git/owncloud/ocis-php-sdk/phpunit.xml

.......................................D.DDDDDDDDDDDDDD........  63 / 156 ( 40%)
............DDDDDDDDDDDDDDDDDDDDD..DDDDDDDDDD.................. 126 / 156 ( 80%)
..............................                                  156 / 156 (100%)

Time: 00:00.871, Memory: 16.00 MB

46 tests triggered 2 PHP deprecations:

1) /home/phil/git/owncloud/ocis-php-sdk/src/Ocis.php:182
Use of "self" in callables is deprecated

Triggered by:

* unit\Owncloud\OcisPhpSdk\OcisTest::testCreateDriveForbidden (2 times)
  /home/phil/git/owncloud/ocis-php-sdk/tests/unit/Owncloud/OcisPhpSdk/OcisTest.php:94
...
* unit\Owncloud\OcisPhpSdk\ResourceLinkTest::testInvalidSharingLinkWebUrlResponse (2 times)
  /home/phil/git/owncloud/ocis-php-sdk/tests/unit/Owncloud/OcisPhpSdk/ResourceLinkTest.php:147

2) /home/phil/git/owncloud/ocis-php-sdk/src/Ocis.php:249
parse_url(): Passing null to parameter #1 ($url) of type string is deprecated

Triggered by:

* unit\Owncloud\OcisPhpSdk\OcisWebfingerTest::testWebfingerInvalidToken#5
  /home/phil/git/owncloud/ocis-php-sdk/tests/unit/Owncloud/OcisPhpSdk/OcisWebfingerTest.php:110

OK, but there were issues!
Tests: 156, Assertions: 332, Deprecations: 2.

Generating code coverage report in Clover XML format ... done [00:00.020]
make: *** [Makefile:26: test-php-unit] Error 1
```

Fix these.
1) https://php.watch/versions/8.2/partially-supported-callable-deprecation 
2) https://www.php.net/manual/en/function.parse-url.php does not alllow `null` to be passed.