### PR TITLE
ci: run tests with PHP 8.3

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -61,8 +61,8 @@ def main(ctx):
     phanPipeline = tests(ctx, "phan", "make test-php-phan", [DEFAULT_PHP_VERSION], False)
     testsPipelinesWithCoverage = tests(ctx, "php-unit", "make test-php-unit", [DEFAULT_PHP_VERSION], True, True)
     testsPipelinesWithCoverage += phpIntegrationTest(ctx, [DEFAULT_PHP_VERSION], True)
-    testsPipelinesWithoutCoverage = tests(ctx, "php-unit", "make test-php-unit", [8.2], False, True)
-    testsPipelinesWithoutCoverage += phpIntegrationTest(ctx, [8.2], False)
+    testsPipelinesWithoutCoverage = tests(ctx, "php-unit", "make test-php-unit", [8.2, 8.3], False, True)
+    testsPipelinesWithoutCoverage += phpIntegrationTest(ctx, [8.2, 8.3], False)
     sonarPipeline = sonarAnalysis(ctx)
     dependsOn(testsPipelinesWithCoverage, sonarPipeline)
     afterPipelines = codeStylePipeline + phpStanPipeline + phanPipeline + testsPipelinesWithCoverage + testsPipelinesWithoutCoverage


### PR DESCRIPTION
https://drone.owncloud.com/owncloud/ocis-php-sdk/880/9/3
`Error response from daemon: manifest for owncloudci/php:8.3 not found: manifest unknown: manifest unknown`

I will make a PR upstream to generate an `owncloudci/php:8.3` - done in PR https://github.com/owncloud-ci/php/pull/169

Passes now - please review.