### PR TITLE
refactoring notification class to validate id inside getters

### DIFF
--- a/src/Notification.php
+++ b/src/Notification.php
@@ -10,6 +10,7 @@ use Owncloud\OcisPhpSdk\Exception\HttpException;
 use Owncloud\OcisPhpSdk\Exception\InternalServerErrorException;
 use Owncloud\OcisPhpSdk\Exception\NotFoundException;
 use Owncloud\OcisPhpSdk\Exception\UnauthorizedException;
+use Owncloud\OcisPhpSdk\Exception\InvalidResponseException;
 
 /**
  * Class representing a single notification emitted in ownCloud Infinite Scale
@@ -19,7 +20,7 @@ use Owncloud\OcisPhpSdk\Exception\UnauthorizedException;
 class Notification
 {
     private string $accessToken;
-    private string $id;
+    private mixed $id;
     private string $app;
     private string $user;
     private string $datetime;
@@ -63,7 +64,7 @@ class Notification
         string &$accessToken,
         array $connectionConfig,
         string $serviceUrl,
-        string $id,
+        mixed $id,
         $notificationContent
     ) {
         $this->id = $id;
@@ -95,6 +96,14 @@ class Notification
 
     public function getId(): string
     {
+        if (
+            !isset($this->id) ||
+            !is_string($this->id) ||
+            $this->id === "") {
+            throw new InvalidResponseException(
+                'Id is invalid or missing in notification response.'
+            );
+        }
         return $this->id;
     }
 

--- a/src/Ocis.php
+++ b/src/Ocis.php
@@ -773,15 +773,7 @@ class Ocis
         }
         $notifications = [];
         foreach ($ocsResponse['ocs']['data'] as $ocsData) {
-            if (
-                !isset($ocsData["notification_id"]) ||
-                !is_string($ocsData["notification_id"]) ||
-                $ocsData["notification_id"] === "") {
-                throw new InvalidResponseException(
-                    'Id is invalid or missing in notification response. Content: "' . $content . '"'
-                );
-            }
-            $id = $ocsData["notification_id"];
+            $id = $ocsData["notification_id"] ?? '';
             /**
              * @phpstan-var object{
              *    app: string,

--- a/tests/unit/Owncloud/OcisPhpSdk/OcisTest.php
+++ b/tests/unit/Owncloud/OcisPhpSdk/OcisTest.php
@@ -235,10 +235,11 @@ class OcisTest extends TestCase
     ): void {
         $this->expectException(InvalidResponseException::class);
         $this->expectExceptionMessage(
-            'Id is invalid or missing in notification response. Content: "' . $responseContent . '"'
+            'Id is invalid or missing in notification response'
         );
         $ocis = $this->setupMocksForNotificationTests($responseContent);
-        $ocis->getNotifications();
+        $notifications = $ocis->getNotifications();
+        $notifications[0]->getId();
     }
 
     public function testGetNotificationMissingDataInResponse(): void


### PR DESCRIPTION
previously we validated the notification id from server in ocis class but now this PR moves that logic to the getters of Notification class.

related to :https://github.com/owncloud/ocis-php-sdk/issues/99