### PR TITLE
Fix ocis cache check script

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -234,7 +234,7 @@ def buildOcis(branch):
 def cacheOcisPipeline(ctx):
     pipelines = []
     for branch in config["ocisBranches"]:
-        steps = checkForExistingOcisCache(ctx) + buildOcis(branch) + cacheOcis(branch)
+        steps = checkForExistingOcisCache(ctx, branch) + buildOcis(branch) + cacheOcis(branch)
         pipelines += [{
             "kind": "pipeline",
             "type": "docker",
@@ -257,7 +257,7 @@ def cacheOcisPipeline(ctx):
         }]
     return pipelines
 
-def checkForExistingOcisCache(ctx):
+def checkForExistingOcisCache(ctx, branch):
     repo_path = "https://raw.githubusercontent.com/owncloud/ocis-php-sdk/%s" % ctx.build.commit
     return [
         {
@@ -270,7 +270,7 @@ def checkForExistingOcisCache(ctx):
                 ". ./.drone.env",
                 "mc alias set s3 $MC_HOST $AWS_ACCESS_KEY_ID $AWS_SECRET_ACCESS_KEY",
                 "mc ls --recursive s3/$CACHE_BUCKET/ocis-build",
-                "bash check-oCIS-cache.sh",
+                "bash check-oCIS-cache.sh %s" % getCommitId(branch),
             ],
         },
     ]
@@ -291,7 +291,7 @@ def cacheOcis(branch):
     }]
 
 def restoreOcisCache(branch):
-    ocis_commit_id = "$OCIS_COMMITID" if branch == "master" else "$OCIS_STABLE_COMMITID"
+    ocis_commit_id = getCommitId(branch)
     return [{
         "name": "restore-ocis-cache",
         "image": MINIO_MC,

--- a/tests/check-oCIS-cache.sh
+++ b/tests/check-oCIS-cache.sh
@@ -2,16 +2,12 @@
 
 . .drone.env
 
-function validateCommand(){
-    ocis_cache=$(mc find s3/$1/ocis-build/$2/ocis 2>&1 | grep 'Object does not exist')
-    ociswrapper_cache=$(mc find s3/$1/ocis-build/$2/ociswrapper 2>&1 | grep 'Object does not exist')
+ocis_cache=$(mc find s3/$CACHE_BUCKET/ocis-build/$1/ocis 2>&1 | grep 'Object does not exist')
+ociswrapper_cache=$(mc find s3/$CACHE_BUCKET/ocis-build/$1/ociswrapper 2>&1 | grep 'Object does not exist')
 
-    if [[ "$ocis_cache" != "" ]] || [[ "$ociswrapper_cache" != "" ]]
-    then
-        echo "$2 doesn't exist"
-        exit 0
-    fi
-}
-validateCommand $CACHE_BUCKET $OCIS_STABLE_COMMITID
-validateCommand $CACHE_BUCKET $OCIS_COMMITID
+if [[ "$ocis_cache" != "" ]] || [[ "$ociswrapper_cache" != "" ]]
+then
+    echo "$1 doesn't exist"
+    exit 0
+fi
 exit 78


### PR DESCRIPTION
This PR changes the scripting file to check one commit ID once.
Checking both master and ocis commit id in the bash file makes it non-reusable for dynamic case.
In addition to that on CI,  `cache-ocis-master` and `cache-ocis-stable` run same bash script. 

  