### PR TITLE
fix: improve handling of OdataError

### DIFF
--- a/src/Exception/ExceptionHelper.php
+++ b/src/Exception/ExceptionHelper.php
@@ -4,6 +4,7 @@ namespace Owncloud\OcisPhpSdk\Exception;
 
 use GuzzleHttp\Exception\GuzzleException;
 use OpenAPI\Client\ApiException;
+use OpenAPI\Client\Model\OdataError;
 use Sabre\HTTP\ClientException as SabreClientException;
 use Sabre\HTTP\ClientHttpException as SabreClientHttpException;
 
@@ -18,7 +19,7 @@ class ExceptionHelper
      * that is more specific to the HTTP error
      */
     public static function getHttpErrorException(
-        GuzzleException|ApiException|SabreClientHttpException|SabreClientException $e
+        GuzzleException|ApiException|SabreClientHttpException|SabreClientException|HttpException $e
     ): BadRequestException|
     NotFoundException|
     ForbiddenException|
@@ -89,5 +90,45 @@ class ExceptionHelper
                 $e
             ),
         };
+    }
+
+    /**
+     * Takes an OdataError object and returns a custom exception
+     * that is more specific to the error if it has a numeric error code.
+     * Otherwise, it returns an InvalidResponseException
+     *
+     * @param string $methodName the name of the method that received the OdataError
+     */
+    public static function getExceptionFromOdataError(
+        OdataError $odataError,
+        string $methodName
+    ): BadRequestException|
+    NotFoundException|
+    ForbiddenException|
+    UnauthorizedException|
+    HttpException|
+    ConflictException|
+    TooEarlyException|
+    InternalServerErrorException {
+        $error = $odataError->getError();
+        $errorCode = $error->getCode();
+        $errorMessage = $error->getMessage();
+        if (is_numeric($errorCode)) {
+            $genericHttpException = new HttpException(
+                $errorMessage,
+                (int) $errorCode
+            );
+            return self::getHttpErrorException($genericHttpException);
+        }
+        // The error code was not numeric, which is not really expected to happen.
+        // So throw an InternalServerErrorException with numeric code 500 and
+        // put the details in the exception message so that the caller has a chance
+        // to understand what happened.
+        return new InternalServerErrorException(
+            "$methodName returned an OdataError with code '" .
+            $errorCode .
+            "' and message '" . $errorMessage . "'",
+            500
+        );
     }
 }

--- a/src/Ocis.php
+++ b/src/Ocis.php
@@ -320,10 +320,7 @@ class Ocis
             throw ExceptionHelper::getHttpErrorException($e);
         }
         if ($allDrivesList instanceof OdataError) {
-            // ToDo: understand how this can happen, and what to do about it.
-            throw new InvalidResponseException(
-                "listAllDrives returned an OdataError - " . $allDrivesList->getError()
-            );
+            throw ExceptionHelper::getExceptionFromOdataError($allDrivesList, "listAllDrives");
         }
         $apiDrives = $allDrivesList->getValue();
         $apiDrives = $apiDrives ?? [];
@@ -380,10 +377,7 @@ class Ocis
         }
 
         if ($allDrivesList instanceof OdataError) {
-            // ToDo: understand how this can happen, and what to do about it.
-            throw new InvalidResponseException(
-                "listMyDrives returned an OdataError - " . $allDrivesList->getError()
-            );
+            throw ExceptionHelper::getExceptionFromOdataError($allDrivesList, "listMyDrives");
         }
         $apiDrives = $allDrivesList->getValue();
         $apiDrives = $apiDrives ?? [];


### PR DESCRIPTION
Issue #200 

If API calls return an OdataError object, then find the error code and message in the object, and use it to create and throw the appropriate HTTP error exception, like other code does. So consumers of the SDK can get a consistent type of exception when something goes wrong.
