### PR TITLE
updated skipped test

### DIFF
--- a/tests/integration/Owncloud/OcisPhpSdk/OcisTest.php
+++ b/tests/integration/Owncloud/OcisPhpSdk/OcisTest.php
@@ -534,9 +534,6 @@ class OcisTest extends OcisPhpSdkTestCase
         $physicsLoversGroup = $ocis->createGroup("physicslovers", "physics lover group");
         $this->createdGroups = [$philosophyHatersGroup,$physicsLoversGroup];
         $groups = $ocis->getGroups(search: $searchText, orderBy: $orderDirection);
-        if(count($groups) <= 0) {
-            $this->markTestSkipped("no groups created");
-        }
         $this->assertCount(
             count($resultGroups),
             $groups,

--- a/tests/integration/Owncloud/OcisPhpSdk/ResourceInviteTest.php
+++ b/tests/integration/Owncloud/OcisPhpSdk/ResourceInviteTest.php
@@ -6,7 +6,7 @@ require_once __DIR__ . '/OcisPhpSdkTestCase.php';
 
 use Owncloud\OcisPhpSdk\Drive;
 use Owncloud\OcisPhpSdk\Exception\BadRequestException;
-use Owncloud\OcisPhpSdk\Exception\ForbiddenException;
+use Owncloud\OcisPhpSdk\Exception\ConflictException;
 use Owncloud\OcisPhpSdk\Ocis;
 use Owncloud\OcisPhpSdk\OcisResource;
 use Owncloud\OcisPhpSdk\ShareReceived; // @phan-suppress-current-line PhanUnreferencedUseNormal it's used in a comment
@@ -142,18 +142,14 @@ class ResourceInviteTest extends OcisPhpSdkTestCase
 
     public function testInviteSameUserAgain(): void
     {
-        $this->markTestSkipped('https://github.com/owncloud/ocis/issues/7842');
-        // @phpstan-ignore-next-line because the test is skipped
-        $this->expectException(ForbiddenException::class);
+        $this->expectException(ConflictException::class);
         $this->fileToShare->invite($this->einstein, $this->viewerRole);
         $this->fileToShare->invite($this->einstein, $this->viewerRole);
     }
 
     public function testInviteSameUserAgainWithDifferentRole(): void
     {
-        $this->markTestSkipped('https://github.com/owncloud/ocis/issues/7842');
-        // @phpstan-ignore-next-line because the test is skipped
-        $this->expectException(ForbiddenException::class);
+        $this->expectException(ConflictException::class);
         $this->fileToShare->invite($this->einstein, $this->viewerRole);
         $this->fileToShare->invite($this->einstein, $this->editorRole);
     }

--- a/tests/integration/Owncloud/OcisPhpSdk/ShareCreatedModifyTest.php
+++ b/tests/integration/Owncloud/OcisPhpSdk/ShareCreatedModifyTest.php
@@ -127,8 +127,6 @@ class ShareCreatedModifyTest extends OcisPhpSdkTestCase
 
     public function testDeleteAnAlreadyDeletedShare(): void
     {
-        $this->markTestSkipped('https://github.com/owncloud/ocis/issues/7872');
-        // @phpstan-ignore-next-line because the test is skipped
         $this->expectException(NotFoundException::class);
         $this->fileToShare->invite($this->einstein, $this->viewerRole);
         $this->fileToShare->invite($this->marie, $this->viewerRole);
@@ -139,8 +137,6 @@ class ShareCreatedModifyTest extends OcisPhpSdkTestCase
 
     public function testDeleteANotExistingShare(): void
     {
-        $this->markTestSkipped('https://github.com/owncloud/ocis/issues/7872');
-        // @phpstan-ignore-next-line because the test is skipped
         $this->expectException(NotFoundException::class);
         $permission = new Permission([
             'id' => 'does not exist'


### PR DESCRIPTION
This PR updates the test which were related to a fixed issue in ocis

related issue: https://github.com/owncloud/ocis-php-sdk/issues/192