### PR TITLE
decode token using Base64Url

### DIFF
--- a/src/Ocis.php
+++ b/src/Ocis.php
@@ -239,11 +239,11 @@ class Ocis
                 " No payload found."
             );
         }
-        $plainPayload = base64_decode($tokenDataArray[1], true);
+        $plainPayload = base64_decode(\strtr($tokenDataArray[1], '-_', '+/'), true);
         if (!$plainPayload) {
             throw new \InvalidArgumentException(
                 self::DECODE_TOKEN_ERROR_MESSAGE .
-                " Payload not base64 encoded."
+                " Payload not Base64Url encoded."
             );
         }
         $tokenPayload = json_decode($plainPayload, true);

--- a/src/Ocis.php
+++ b/src/Ocis.php
@@ -48,7 +48,7 @@ use OpenAPI\Client\Model\Group as OpenAPIGroup;
  */
 class Ocis
 {
-    private const DECODE_TOKEN_ERROR_MESSAGE = 'could not decode token';
+    private const DECODE_TOKEN_ERROR_MESSAGE = 'Could not decode token.';
     public const FUNCTION_NOT_IMPLEMENTED_YET_ERROR_MESSAGE =
         'This function is not implemented yet! Place, name and signature of the function might change!';
     private string $serviceUrl;
@@ -234,22 +234,55 @@ class Ocis
     {
         $tokenDataArray = explode(".", $this->accessToken);
         if (!array_key_exists(1, $tokenDataArray)) {
-            throw new \InvalidArgumentException(self::DECODE_TOKEN_ERROR_MESSAGE);
+            throw new \InvalidArgumentException(
+                self::DECODE_TOKEN_ERROR_MESSAGE .
+                " No payload found. Token: '" .
+                $this->accessToken .
+                "'"
+            );
         }
         $plainPayload = base64_decode($tokenDataArray[1], true);
         if (!$plainPayload) {
-            throw new \InvalidArgumentException(self::DECODE_TOKEN_ERROR_MESSAGE);
+            throw new \InvalidArgumentException(
+                self::DECODE_TOKEN_ERROR_MESSAGE .
+                " Payload not base64 encoded. Token: '" .
+                $this->accessToken .
+                "'"
+            );
         }
         $tokenPayload = json_decode($plainPayload, true);
-        if (!is_array($tokenPayload) || !array_key_exists('iss', $tokenPayload)) {
-            throw new \InvalidArgumentException(self::DECODE_TOKEN_ERROR_MESSAGE);
+        if (!is_array($tokenPayload)) {
+            throw new \InvalidArgumentException(
+                self::DECODE_TOKEN_ERROR_MESSAGE .
+                " Payload not valid JSON. Token: '" .
+                $this->accessToken .
+                "'"
+            );
+        }
+        if (!array_key_exists('iss', $tokenPayload)) {
+            throw new \InvalidArgumentException(
+                self::DECODE_TOKEN_ERROR_MESSAGE .
+                " Payload does not contain 'iss' key. Token: '" .
+                $this->accessToken .
+                "'"
+            );
         }
         if (!is_string($tokenPayload['iss'])) {
-            throw new \InvalidArgumentException(self::DECODE_TOKEN_ERROR_MESSAGE);
+            throw new \InvalidArgumentException(
+                self::DECODE_TOKEN_ERROR_MESSAGE .
+                " 'iss' key is not a string. Token: '" .
+                $this->accessToken .
+                "'"
+            );
         }
         $iss = parse_url($tokenPayload['iss']);
         if (!is_array($iss) || !array_key_exists('host', $iss)) {
-            throw new \InvalidArgumentException(self::DECODE_TOKEN_ERROR_MESSAGE);
+            throw new \InvalidArgumentException(
+                self::DECODE_TOKEN_ERROR_MESSAGE .
+                " Content of 'iss' has no 'host' part. Token: '" .
+                $this->accessToken .
+                "'"
+            );
         }
         try {
             $webfingerResponse = $this->guzzle->get($webfingerUrl . '?resource=acct:me@' . $iss['host']);

--- a/src/Ocis.php
+++ b/src/Ocis.php
@@ -236,52 +236,40 @@ class Ocis
         if (!array_key_exists(1, $tokenDataArray)) {
             throw new \InvalidArgumentException(
                 self::DECODE_TOKEN_ERROR_MESSAGE .
-                " No payload found. Token: '" .
-                $this->accessToken .
-                "'"
+                " No payload found."
             );
         }
         $plainPayload = base64_decode($tokenDataArray[1], true);
         if (!$plainPayload) {
             throw new \InvalidArgumentException(
                 self::DECODE_TOKEN_ERROR_MESSAGE .
-                " Payload not base64 encoded. Token: '" .
-                $this->accessToken .
-                "'"
+                " Payload not base64 encoded."
             );
         }
         $tokenPayload = json_decode($plainPayload, true);
         if (!is_array($tokenPayload)) {
             throw new \InvalidArgumentException(
                 self::DECODE_TOKEN_ERROR_MESSAGE .
-                " Payload not valid JSON. Token: '" .
-                $this->accessToken .
-                "'"
+                " Payload not valid JSON."
             );
         }
         if (!array_key_exists('iss', $tokenPayload)) {
             throw new \InvalidArgumentException(
                 self::DECODE_TOKEN_ERROR_MESSAGE .
-                " Payload does not contain 'iss' key. Token: '" .
-                $this->accessToken .
-                "'"
+                " Payload does not contain 'iss' key."
             );
         }
         if (!is_string($tokenPayload['iss'])) {
             throw new \InvalidArgumentException(
                 self::DECODE_TOKEN_ERROR_MESSAGE .
-                " 'iss' key is not a string. Token: '" .
-                $this->accessToken .
-                "'"
+                " 'iss' key is not a string."
             );
         }
         $iss = parse_url($tokenPayload['iss']);
         if (!is_array($iss) || !array_key_exists('host', $iss)) {
             throw new \InvalidArgumentException(
                 self::DECODE_TOKEN_ERROR_MESSAGE .
-                " Content of 'iss' has no 'host' part. Token: '" .
-                $this->accessToken .
-                "'"
+                " Content of 'iss' has no 'host' part."
             );
         }
         try {

--- a/tests/unit/Owncloud/OcisPhpSdk/OcisWebfingerTest.php
+++ b/tests/unit/Owncloud/OcisPhpSdk/OcisWebfingerTest.php
@@ -111,7 +111,7 @@ class OcisWebfingerTest extends TestCase
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage(
-            'Could not decode token. ' . $expectedExceptionMessage . ' Token: \'' . $token . '\''
+            'Could not decode token. ' . $expectedExceptionMessage
         );
         $ocis = new Ocis(
             'https://webfinger.example.com',

--- a/tests/unit/Owncloud/OcisPhpSdk/OcisWebfingerTest.php
+++ b/tests/unit/Owncloud/OcisPhpSdk/OcisWebfingerTest.php
@@ -79,38 +79,40 @@ class OcisWebfingerTest extends TestCase
     public static function invalidTokenProvider(): array
     {
         return [
-            ["onlyHeaderNoPayload"],
-            ["header.butPäylöädNötBäs€64"],
+            ["onlyHeaderNoPayload", "No payload found."],
+            ["header.butPäylöädNötBäs€64", "Payload not base64 encoded."],
 
             // payload is not JSON
-            ["header.cGF5bG9hZElzTm90SlNPTgo="],
+            ["header.cGF5bG9hZElzTm90SlNPTgo=", "Payload not valid JSON."],
 
             // payload is not an JSON object
-            ["header.InBheWxvYWRJc05vdEFuT2JqZWN0Igo="],
+            ["header.InBheWxvYWRJc05vdEFuT2JqZWN0Igo=", "Payload not valid JSON."],
 
             // payload is a JSON object, but does not contain 'iss' key
-            ["header.eyJrZXkiOiAidmFsdWUifQo="],
+            ["header.eyJrZXkiOiAidmFsdWUifQo=", "Payload does not contain 'iss' key."],
 
             // payload contains 'iss' key but the value is null
-            ["header.eyJpc3MiOiBudWxsfQo="],
+            ["header.eyJpc3MiOiBudWxsfQo=", "'iss' key is not a string."],
 
             // payload contains 'iss' key but the value is 'https://'
-            ["header.eyJpc3MiOiAiaHR0cHM6Ly8ifQo="],
+            ["header.eyJpc3MiOiAiaHR0cHM6Ly8ifQo=", "Content of 'iss' has no 'host' part."],
 
             // payload contains 'iss' key but the value is 'host'
-            ["header.eyJpc3MiOiAiaG9zdCJ9Cg=="],
+            ["header.eyJpc3MiOiAiaG9zdCJ9Cg==", "Content of 'iss' has no 'host' part."],
 
             // payload contains 'iss' key but the value is 'https://:9000'
-            ["header.eyJpc3MiOiAiaHR0cHM6Ly86OTAwMCJ9Cg=="],
+            ["header.eyJpc3MiOiAiaHR0cHM6Ly86OTAwMCJ9Cg==", "Content of 'iss' has no 'host' part."],
         ];
     }
     /**
      * @dataProvider invalidTokenProvider
      */
-    public function testWebfingerInvalidToken(string $token): void
+    public function testWebfingerInvalidToken(string $token, string $expectedExceptionMessage): void
     {
         $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage("could not decode token");
+        $this->expectExceptionMessage(
+            'Could not decode token. ' . $expectedExceptionMessage . ' Token: \'' . $token . '\''
+        );
         $ocis = new Ocis(
             'https://webfinger.example.com',
             $token,

--- a/tests/unit/Owncloud/OcisPhpSdk/OcisWebfingerTest.php
+++ b/tests/unit/Owncloud/OcisPhpSdk/OcisWebfingerTest.php
@@ -21,10 +21,16 @@ class OcisWebfingerTest extends TestCase
         ];
         $tokenPayload = [
             "iss" => "https://sso.example.com",
+            // this will generate a token that will contain `-` and `_` after base64Url encoding
+            "special" => "????>>>????>>>"
         ];
-        return base64_encode((string)json_encode($tokenHeader)) . "." .
-            base64_encode((string)json_encode($tokenPayload)) .
+
+        $base64EncodedToken = base64_encode((string)json_encode($tokenHeader)) . "." .
+            base64_encode((string)json_encode($tokenPayload, JSON_UNESCAPED_UNICODE)) .
             ".signatureDoesNotMatter";
+        // the token needs to be base64Url encoded not just base64
+        // see  https://jwt.io/introduction/
+        return rtrim(\strtr($base64EncodedToken, '+/', '-_'), '=');
     }
     private function getGuzzleMock(?string $responseContent = null): MockObject
     {
@@ -80,7 +86,7 @@ class OcisWebfingerTest extends TestCase
     {
         return [
             ["onlyHeaderNoPayload", "No payload found."],
-            ["header.butPäylöädNötBäs€64", "Payload not base64 encoded."],
+            ["header.butPäylöädNötBäs€64", "Payload not Base64Url encoded."],
 
             // payload is not JSON
             ["header.cGF5bG9hZElzTm90SlNPTgo=", "Payload not valid JSON."],


### PR DESCRIPTION
The token is not decoded using `base64` but `base64Url` see https://jwt.io/introduction/
`base64Url` uses `-` and `_` instead of `+` and `/`, see https://datatracker.ietf.org/doc/html/rfc4648#section-5

This PR is on top of #207, so review only last commit and merge after #207

fixes #208