### PR TITLE
fix: do not explicitly declare GdImage

### DIFF
--- a/src/Drive.php
+++ b/src/Drive.php
@@ -336,8 +336,11 @@ class Drive
 
     /**
      * @todo This function is not implemented yet! Place, name and signature of the function might change!
+     *
+     * The type of $image is likely to be \GdImage when implemented.
+     * That would require the php-gd extension to be installed.
      */
-    public function setImage(\GdImage $image): Drive
+    public function setImage(object $image): Drive
     {
         // upload image to dav/spaces/<space-id>/.space/<image-name>
         // PATCH space


### PR DESCRIPTION
fixes #220 

I declared `object $image` because that is the closest that we know is likely, and it keeps `phpstan` happy that a type is declared.