### PR TITLE
refactoring setmembers function in group.php and unit tests related to it

### DIFF
--- a/src/Group.php
+++ b/src/Group.php
@@ -124,15 +124,6 @@ class Group
     }
 
     /**
-     * Set the value of members
-     * @param User $member
-     */
-    public function setMembers(User $member): void
-    {
-        $this->members[] = $member;
-    }
-
-    /**
      * @param User $user
      *
      * @throws BadRequestException
@@ -158,7 +149,7 @@ class Group
         } catch (ApiException $e) {
             throw ExceptionHelper::getHttpErrorException($e);
         }
-        $this->setMembers($user);
+        $this->members[] = $user;
     }
 
     /**

--- a/tests/unit/Owncloud/OcisPhpSdk/GroupTest.php
+++ b/tests/unit/Owncloud/OcisPhpSdk/GroupTest.php
@@ -3,8 +3,6 @@
 namespace unit\Owncloud\OcisPhpSdk;
 
 use OpenAPI\Client\Model\Group;
-use Owncloud\OcisPhpSdk\User as SdkUser;
-use OpenAPI\Client\Model\User;
 use Owncloud\OcisPhpSdk\Exception\InvalidResponseException;
 use Owncloud\OcisPhpSdk\Group as SdkGroup;
 use PHPUnit\Framework\TestCase;
@@ -118,34 +116,5 @@ class GroupTest extends TestCase
         $group->getId();
         $group->getDisplayName();
         $group->getMembers();
-    }
-
-    public function testSetMembers(): void
-    {
-        $libGroup = new Group(
-            [
-                "id" => "as",
-                "description" => "a",
-                "display_name" => "name",
-                "group_types" => ["aa"],
-                "members" => [],
-            ]
-        );
-        $accessToken = "acstok";
-        $group = new SdkGroup($libGroup, "url", [], $accessToken);
-        $this->assertCount(0, $group->getMembers());
-        $group->setMembers(
-            new SdkUser(
-                new User(
-                    [
-                        "id" => "id",
-                        "display_name" => "displayname",
-                        "mail" => "mail@mail.com",
-                        "on_premises_sam_account_name" => "sd",
-                    ],
-                )
-            )
-        );
-        $this->assertCount(1, $group->getMembers());
     }
 }


### PR DESCRIPTION
function `setMembers` only had one line of code which was used in only one place so refactoring `setMembers` function in `Group.php` and unit tests related to it.