### PR TITLE
Add support for get roles of drive using root endpoint

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -142,6 +142,7 @@ def phpIntegrationTest(ctx, phpVersions, coverage):
                         "OCIS_URL": "https://ocis:9200",
                         "OCISWRAPPER_URL": "http://ocis:5200",
                         "COMPOSER_HOME": "%s/.cache/composer" % dir["base"],
+                        "OCIS_VERSION": branch,
                     },
                     "commands": [
                         installPhpXdebugCommand(phpVersion),

--- a/src/Ocis.php
+++ b/src/Ocis.php
@@ -8,6 +8,7 @@ use GuzzleHttp\Exception\GuzzleException;
 use OpenAPI\Client\Api\DrivesApi;
 use OpenAPI\Client\Api\DrivesGetDrivesApi;
 use OpenAPI\Client\Api\DrivesPermissionsApi;
+use OpenAPI\Client\Api\DrivesRootApi;
 use OpenAPI\Client\Api\GroupApi;
 use OpenAPI\Client\Api\MeDriveApi;
 use OpenAPI\Client\Api\MeDrivesApi;
@@ -43,7 +44,8 @@ use OpenAPI\Client\Model\Group as OpenAPIGroup;
  *                     'guzzle'?:Client,
  *                     'drivesApi'?:DrivesApi,
  *                     'drivesGetDrivesApi'?:DrivesGetDrivesApi,
- *                     'drivesPermissionsApi'?:DrivesPermissionsApi
+ *                     'drivesPermissionsApi'?:DrivesPermissionsApi,
+ *                     'drivesRootApi'?:DrivesRootApi
  *  }
  */
 class Ocis
@@ -155,6 +157,11 @@ class Ocis
         return $api instanceof DrivesGetDrivesApi;
     }
 
+    public static function isDrivesRootApi(mixed $api): bool
+    {
+        return $api instanceof DrivesRootApi;
+    }
+
     /**
      * @param array<mixed> $connectionConfig
      * @ignore This function is used for internal purposes only and should not be shown in the documentation.
@@ -170,6 +177,7 @@ class Ocis
             'drivesPermissionsApi' => self::class . '::isDrivesPermissionsApi',
             'drivesApi' => self::class . '::isDrivesApi',
             'drivesGetDrivesApi' => self::class . '::isDrivesGetDrivesApi',
+            'drivesRootApi' => self::class . '::isDrivesRootApi',
             'proxy' => 'is_array',
         ];
         foreach ($connectionConfig as $key => $check) {

--- a/tests/integration/Owncloud/OcisPhpSdk/DriveTest.php
+++ b/tests/integration/Owncloud/OcisPhpSdk/DriveTest.php
@@ -6,6 +6,7 @@ use Owncloud\OcisPhpSdk\Drive;
 use Owncloud\OcisPhpSdk\Exception\BadRequestException;
 use Owncloud\OcisPhpSdk\Exception\NotFoundException;
 use Owncloud\OcisPhpSdk\Ocis;
+use Owncloud\OcisPhpSdk\SharingRole;
 
 require_once __DIR__ . '/OcisPhpSdkTestCase.php';
 
@@ -67,5 +68,15 @@ class DriveTest extends OcisPhpSdkTestCase
         $this->expectException(BadRequestException::class);
         $this->expectExceptionMessage('invalidRequest - error: bad request: can\'t purge enabled space');
         $this->drive->delete();
+    }
+
+    public function testGetDriveRole(): void
+    {
+        $role = $this->drive->getRoles();
+        $this->assertContainsOnlyInstancesOf(
+            SharingRole::class,
+            $role,
+            "Array contains not only 'SharingRole' items"
+        );
     }
 }

--- a/tests/integration/Owncloud/OcisPhpSdk/DriveTest.php
+++ b/tests/integration/Owncloud/OcisPhpSdk/DriveTest.php
@@ -72,9 +72,13 @@ class DriveTest extends OcisPhpSdkTestCase
 
     public function testGetDriveRole(): void
     {
+        // At the time of writing, "stable" is major version 5 of ocis.
+        // This functionality works with major version 6.
+        // When ocis major version 6 has been released as "stable" then remove this test skip.
         if (getenv('OCIS_VERSION') === "stable") {
-            $this->markTestSkipped('This test is skipped because root endpoint for drive share is
-             not applicable for the stable version of OCIS.');
+            $this->markTestSkipped(
+                'This test is skipped because root endpoint for drive share is not applicable for version 5 of OCIS.'
+            );
         };
         $role = $this->drive->getRoles();
         $this->assertContainsOnlyInstancesOf(

--- a/tests/integration/Owncloud/OcisPhpSdk/DriveTest.php
+++ b/tests/integration/Owncloud/OcisPhpSdk/DriveTest.php
@@ -72,6 +72,10 @@ class DriveTest extends OcisPhpSdkTestCase
 
     public function testGetDriveRole(): void
     {
+        if (getenv('OCIS_VERSION') === "stable") {
+            $this->markTestSkipped('This test is skipped because root endpoint for drive share is
+             not applicable for the stable version of OCIS.');
+        };
         $role = $this->drive->getRoles();
         $this->assertContainsOnlyInstancesOf(
             SharingRole::class,


### PR DESCRIPTION
This PR adds function which gets permission list of drives using root endpoint 
- added tests coverage for getRole()

Part of issue #223 