### PR TITLE
tests for updating drive share role and inviting another user

### DIFF
--- a/tests/integration/Owncloud/OcisPhpSdk/DriveTest.php
+++ b/tests/integration/Owncloud/OcisPhpSdk/DriveTest.php
@@ -591,41 +591,22 @@ class DriveTest extends OcisPhpSdkTestCase
         $marieOcis = $this->initUser('marie', 'radioactivity');
         $katherineOcis = $this->getOcis('katherine', 'gemini');
         $katherine = $this->ocis->getUsers('katherine')[0];
-
         $marie = $this->ocis->getUsers('marie')[0];
-
-        $managerRole = null;
-
+        // ocis stable doesn't support root endpoint
         if (getenv('OCIS_VERSION') === "stable") {
-            // ocis version < 6.0.0 doesn't support root endpoint so mocking getRoles values
-            $role = [
-                "id" => "312c0871-5ef7-4b3a-85b6-0e4074c64049",
-                "description" => "Allows managing a space",
-                "displayName" => "Manager",
-                "@libre.graph.weight" => 3
-            ];
-
-            $shareRoles = [new SharingRole(new UnifiedRoleDefinition($role))];
-        } else {
-            $shareRoles = $this->drive->getRoles();
+            $this->markTestSkipped("This method is not implemented in this ocis version");
         }
+        $shareRoles = $this->drive->getRoles();
         foreach ($shareRoles as $role) {
             if ($role->getId() === self::getPermissionsRoleIdByName('Manager')) {
                 $managerRole = $role;
                 break;
             }
         }
-
         if (empty($managerRole)) {
             throw new \Error(
                 "manager role not found "
             );
-        }
-        // ocis stable doesn't support root endpoint
-        if (getenv('OCIS_VERSION') === "stable") {
-            $this->expectException(EndPointNotImplementedException::class);
-            $this->expectExceptionMessage("This method is not implemented in this ocis version");
-            $this->drive->invite($marie, $managerRole);
         }
 
         try {
@@ -638,12 +619,6 @@ class DriveTest extends OcisPhpSdkTestCase
                 . " but found " . $marieReceivedProjectDrive->getId()
             );
             $driveInvitation = $marieReceivedProjectDrive->invite($katherine, $managerRole);
-            $this->assertInstanceOf(
-                Permission::class,
-                $driveInvitation,
-                "Expected class to be 'Permission' but found "
-                . get_class($driveInvitation)
-            );
             $katherineReceivedProjectDrive = $katherineOcis->getDriveById($this->drive->getId());
             $this->assertSame(
                 $this->drive->getName(),
@@ -672,50 +647,29 @@ class DriveTest extends OcisPhpSdkTestCase
         $marieOcis = $this->initUser('marie', 'radioactivity');
         $katherineOcis = $this->initUser('katherine', 'gemini');
         $katherine = $this->ocis->getUsers('katherine')[0];
-
         $marie = $this->ocis->getUsers('marie')[0];
-        $viewerRole = null;
-
+        // ocis stable doesn't support root endpoint
         if (getenv('OCIS_VERSION') === "stable") {
-            // ocis version < 6.0.0 doesn't support root endpoint so mocking getRoles values
-            $role = [
-                "id" => "a8d5fe5e-96e3-418d-825b-534dbdf22b99",
-                "description" => "View and download",
-                "displayName" => "Space Viewer",
-                "@libre.graph.weight" => 1
-            ];
-
-            $shareRoles = [new SharingRole(new UnifiedRoleDefinition($role))];
-        } else {
-            $shareRoles = $this->drive->getRoles();
+            $this->markTestSkipped("This method is not implemented in this ocis version");
         }
+        $shareRoles = $this->drive->getRoles();
         foreach ($shareRoles as $role) {
-            //            any permission role other than Manager can't invite other user to the drive'
             if ($role->getId() === self::getPermissionsRoleIdByName('Space Viewer')) {
                 $viewerRole = $role;
                 break;
             }
         }
-
         if (empty($viewerRole)) {
             throw new \Error(
                 "Space viewer role not found "
             );
         }
-        // ocis stable doesn't support root endpoint
-        if (getenv('OCIS_VERSION') === "stable") {
-            $this->expectException(EndPointNotImplementedException::class);
-            $this->expectExceptionMessage("This method is not implemented in this ocis version");
-            $this->drive->invite($marie, $viewerRole);
-        }
-
         try {
             $this->drive->invite($marie, $viewerRole);
             $marieReceivedProjectDrive = $marieOcis->getDriveById($this->drive->getId());
             $this->expectException(ForbiddenException::class);
             $this->expectExceptionMessage("accessDenied - add grant: error: permission denied:");
             $marieReceivedProjectDrive->invite($katherine, $viewerRole);
-
         } catch(EndPointNotImplementedException) {
             // test should fail if ocis version is less than 6.0.0
             $this->fail("EndPointNotImplementedException was thrown unexpectedly");
@@ -736,41 +690,23 @@ class DriveTest extends OcisPhpSdkTestCase
     public function testReceiverUpdatesDriveShareRole(): void
     {
         $marieOcis = $this->initUser('marie', 'radioactivity');
-
         $marie = $this->ocis->getUsers('marie')[0];
 
-        $managerRole = null;
-
+        // ocis stable doesn't support root endpoint
         if (getenv('OCIS_VERSION') === "stable") {
-            // ocis version < 6.0.0 doesn't support root endpoint so mocking getRoles values
-            $role = [
-                "id" => "312c0871-5ef7-4b3a-85b6-0e4074c64049",
-                "description" => "Allows managing a space",
-                "displayName" => "Manager",
-                "@libre.graph.weight" => 3
-            ];
-
-            $shareRoles = [new SharingRole(new UnifiedRoleDefinition($role))];
-        } else {
-            $shareRoles = $this->drive->getRoles();
+            $this->markTestSkipped("This method is not implemented in this ocis version");
         }
+        $shareRoles = $this->drive->getRoles();
         foreach ($shareRoles as $role) {
             if ($role->getId() === self::getPermissionsRoleIdByName('Manager')) {
                 $managerRole = $role;
                 break;
             }
         }
-
         if (empty($managerRole)) {
             throw new \Error(
                 "manager role not found "
             );
-        }
-        // ocis stable doesn't support root endpoint
-        if (getenv('OCIS_VERSION') === "stable") {
-            $this->expectException(EndPointNotImplementedException::class);
-            $this->expectExceptionMessage("This method is not implemented in this ocis version");
-            $this->drive->invite($marie, $managerRole);
         }
 
         try {
@@ -780,15 +716,21 @@ class DriveTest extends OcisPhpSdkTestCase
                 throw new \Error(" Permission not found of user Marie Curie");
             }
             $receivedInvitationDrive = $marieOcis->getDriveById($this->drive->getId());
-
             $shareRoles = $receivedInvitationDrive->getRoles();
-
+            $spaceViewerRole = null;
             foreach ($shareRoles as $role) {
                 if ($role->getId() === self::getPermissionsRoleIdByName('Space Viewer')) {
-                    $isRoleSet = $receivedInvitationDrive->setPermissionRole($permissionId, $role);
-                    $this->assertTrue($isRoleSet, "Failed to set role id");
+                    $spaceViewerRole = $role;
+                    break;
                 }
             }
+            if (empty($spaceViewerRole)) {
+                throw new \Error(
+                    "Space viewer role not found "
+                );
+            }
+            $isRoleSet = $receivedInvitationDrive->setPermissionRole($permissionId, $spaceViewerRole);
+            $this->assertTrue($isRoleSet, "Failed to set role id");
         } catch(EndPointNotImplementedException) {
             // test should fail if ocis version is less than 6.0.0
             $this->fail("EndPointNotImplementedException was thrown unexpectedly");
@@ -809,41 +751,22 @@ class DriveTest extends OcisPhpSdkTestCase
     public function testReceiverUpdatesDriveShareRoleNoEnoughPermission(): void
     {
         $marieOcis = $this->initUser('marie', 'radioactivity');
-
         $marie = $this->ocis->getUsers('marie')[0];
-
-        $viewerRole = null;
-
+        // ocis stable doesn't support root endpoint
         if (getenv('OCIS_VERSION') === "stable") {
-            // ocis version < 6.0.0 doesn't support root endpoint so mocking getRoles values
-            $role = [
-                "id" => "a8d5fe5e-96e3-418d-825b-534dbdf22b99",
-                "description" => "View and download",
-                "displayName" => "Space Viewer",
-                "@libre.graph.weight" => 1
-            ];
-
-            $shareRoles = [new SharingRole(new UnifiedRoleDefinition($role))];
-        } else {
-            $shareRoles = $this->drive->getRoles();
+            $this->markTestSkipped("This method is not implemented in this ocis version");
         }
+        $shareRoles = $this->drive->getRoles();
         foreach ($shareRoles as $role) {
             if ($role->getId() === self::getPermissionsRoleIdByName('Space Viewer')) {
                 $viewerRole = $role;
                 break;
             }
         }
-
         if (empty($viewerRole)) {
             throw new \Error(
                 "manager role not found "
             );
-        }
-        // ocis stable doesn't support root endpoint
-        if (getenv('OCIS_VERSION') === "stable") {
-            $this->expectException(EndPointNotImplementedException::class);
-            $this->expectExceptionMessage("This method is not implemented in this ocis version");
-            $this->drive->invite($marie, $viewerRole);
         }
 
         try {
@@ -853,9 +776,7 @@ class DriveTest extends OcisPhpSdkTestCase
             if (empty($permissionId)) {
                 throw new \Error(" Permission not found of user Marie Curie");
             }
-
             $receivedInvitationDrive = $marieOcis->getDriveById($this->drive->getId());
-
             $shareRoles = $receivedInvitationDrive->getRoles();
 
             foreach ($shareRoles as $role) {


### PR DESCRIPTION
Tests added:
- testReceiverInviteOtherUserToDriveShare
- testReceiverInviteOtherUserToDriveShareWithNoInvitePermission
- testReceiverUpdatesDriveShareRole
- testReceiverUpdatesDriveShareRoleNoEnoughPermission
Part of https://github.com/owncloud/ocis-php-sdk/issues/223