### PR TITLE
Refactor DriveTest to simplify it

### DIFF
--- a/.phan/config.php
+++ b/.phan/config.php
@@ -82,4 +82,7 @@ return [
     'parent_constructor_required' => [
     ],
 
+    'plugins' => [
+        'PHPUnitAssertionPlugin'
+    ]
 ];


### PR DESCRIPTION
- use the `PHPUnitAssertionPlugin` for phan. That makes phan understand that after PHPunit assert methods, like `assertInstanceOf`, that the variable now has to be of the asserted type. That makes the phan analysis better match the test code.
- replace a lot of "if (some variable is empty) then throw an exception" with `assertInstanceOf` PHPunit checks
- remove a lot of try/catch blocks that are not needed. We were catching an unexpected `EndPointNotImplementedException` exception and then calling `$this->fail`. But if an unexpected exception happens, PHPunit will fail the test anyway, and report the exception that happened.

I think that this simplifies the code flow of a lot of the test cases. Please review.

If people agree, then it can be done for other test code.