### PR TITLE
Coding style PER-CS2.0

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -5,5 +5,5 @@ $finder = PhpCsFixer\Finder::create()
 
 $config = new PhpCsFixer\Config();
 $config->setFinder($finder);
-$config->setRules(['@PSR12' => true]);
+$config->setRules(['@PER-CS2.0' => true]);
 return $config;

--- a/src/BaseUser.php
+++ b/src/BaseUser.php
@@ -19,7 +19,7 @@ class BaseUser
      *         but should use the Ocis class to query the server for users
      */
     public function __construct(
-        User|EducationUser $user
+        User|EducationUser $user,
     ) {
         $this->id = $user->getId();
         $this->displayName = $user->getDisplayName();
@@ -34,9 +34,9 @@ class BaseUser
     {
         return (($this->displayName === null) || ($this->displayName === '')) ?
         throw new InvalidResponseException(
-            "Invalid displayName returned for user '" . print_r($this->displayName, true) . "'"
+            "Invalid displayName returned for user '" . print_r($this->displayName, true) . "'",
         )
-        : (string)$this->displayName;
+        : (string) $this->displayName;
     }
 
     /**
@@ -46,8 +46,8 @@ class BaseUser
     {
         return (($this->id === null) || ($this->id === '')) ?
         throw new InvalidResponseException(
-            "Invalid id returned for user '" . print_r($this->id, true) . "'"
-        ) : (string)$this->id;
+            "Invalid id returned for user '" . print_r($this->id, true) . "'",
+        ) : (string) $this->id;
     }
 
     /**
@@ -57,9 +57,9 @@ class BaseUser
     {
         return empty($this->mail) ?
         throw new InvalidResponseException(
-            "Invalid mail returned for user '" . print_r($this->mail, true) . "'"
+            "Invalid mail returned for user '" . print_r($this->mail, true) . "'",
         )
-        : (string)$this->mail;
+        : (string) $this->mail;
     }
 
     /**

--- a/src/Drive.php
+++ b/src/Drive.php
@@ -65,7 +65,7 @@ class Drive
         array $connectionConfig,
         string $serviceUrl,
         string &$accessToken,
-        string $ocisVersion
+        string $ocisVersion,
     ) {
         $this->apiDrive = $apiDrive;
         $this->accessToken = &$accessToken;
@@ -97,7 +97,7 @@ class Drive
 
     public function getAlias(): string
     {
-        return (string)$this->apiDrive->getDriveAlias();
+        return (string) $this->apiDrive->getDriveAlias();
     }
 
     /**
@@ -105,19 +105,19 @@ class Drive
      */
     public function getType(): DriveType
     {
-        $driveTypeString = (string)$this->apiDrive->getDriveType();
+        $driveTypeString = (string) $this->apiDrive->getDriveType();
         $driveType = DriveType::tryFrom($driveTypeString);
         if ($driveType instanceof DriveType) {
             return $driveType;
         }
         throw new InvalidResponseException(
-            'Invalid DriveType returned by apiDrive: "' . print_r($driveTypeString, true) . '"'
+            'Invalid DriveType returned by apiDrive: "' . print_r($driveTypeString, true) . '"',
         );
     }
 
     public function getId(): string
     {
-        return (string)$this->apiDrive->getId();
+        return (string) $this->apiDrive->getId();
     }
 
     public function getRoot(): ?DriveItem
@@ -127,7 +127,7 @@ class Drive
 
     public function getWebUrl(): string
     {
-        return (string)$this->apiDrive->getWebUrl();
+        return (string) $this->apiDrive->getWebUrl();
     }
 
     public function getWebDavUrl(): string
@@ -138,7 +138,7 @@ class Drive
              * but it does exist, see vendor/owncloud/libre-graph-api-php/lib/Model/DriveItem.php:83
              */
             /* @phpstan-ignore-next-line */
-            $this->webDavUrl = rtrim((string)($this->getRoot())['web_dav_url'], '/') . '/';
+            $this->webDavUrl = rtrim((string) ($this->getRoot())['web_dav_url'], '/') . '/';
         }
         return $this->webDavUrl;
     }
@@ -153,7 +153,7 @@ class Drive
             return $date;
         }
         throw new InvalidResponseException(
-            'Invalid LastModifiedDateTime returned: "' . print_r($date, true) . '"'
+            'Invalid LastModifiedDateTime returned: "' . print_r($date, true) . '"',
         );
     }
 
@@ -172,7 +172,7 @@ class Drive
             return $quota;
         }
         throw new InvalidResponseException(
-            'Invalid quota returned: "' . print_r($quota, true) . '"'
+            'Invalid quota returned: "' . print_r($quota, true) . '"',
         );
     }
 
@@ -191,11 +191,11 @@ class Drive
         }
 
         $guzzle = new Client(
-            Ocis::createGuzzleConfig($this->connectionConfig, $this->accessToken)
+            Ocis::createGuzzleConfig($this->connectionConfig, $this->accessToken),
         );
         return new DrivesRootApi(
             $guzzle,
-            $this->graphApiConfig
+            $this->graphApiConfig,
         );
     }
 
@@ -214,7 +214,7 @@ class Drive
         $root = $this->apiDrive->getRoot();
         if (!($root instanceof DriveItem)) {
             throw new InvalidResponseException(
-                'Could not get root of drive "' . print_r($root, true) . '"'
+                'Could not get root of drive "' . print_r($root, true) . '"',
             );
         }
         $deleted = $root->getDeleted();
@@ -244,15 +244,15 @@ class Drive
     {
         $connectionConfig = array_merge(
             $this->connectionConfig,
-            ['headers' => ['Purge' => 'T']]
+            ['headers' => ['Purge' => 'T']],
         );
         $guzzle = new Client(
-            Ocis::createGuzzleConfig($connectionConfig, $this->accessToken)
+            Ocis::createGuzzleConfig($connectionConfig, $this->accessToken),
         );
 
         $apiInstance = new DrivesApi(
             $guzzle,
-            $this->graphApiConfig
+            $this->graphApiConfig,
         );
         try {
             $apiInstance->deleteDrive($this->getId());
@@ -277,11 +277,11 @@ class Drive
     public function disable(): void
     {
         $guzzle = new Client(
-            Ocis::createGuzzleConfig($this->connectionConfig, $this->accessToken)
+            Ocis::createGuzzleConfig($this->connectionConfig, $this->accessToken),
         );
         $apiInstance = new DrivesApi(
             $guzzle,
-            $this->graphApiConfig
+            $this->graphApiConfig,
         );
         try {
             $apiInstance->deleteDrive($this->getId());
@@ -306,15 +306,15 @@ class Drive
     {
         $connectionConfig = array_merge(
             $this->connectionConfig,
-            ['headers' => ['Restore' => 'true']]
+            ['headers' => ['Restore' => 'true']],
         );
         $guzzle = new Client(
-            Ocis::createGuzzleConfig($connectionConfig, $this->accessToken)
+            Ocis::createGuzzleConfig($connectionConfig, $this->accessToken),
         );
 
         $apiInstance = new DrivesApi(
             $guzzle,
-            $this->graphApiConfig
+            $this->graphApiConfig,
         );
         try {
             $apiInstance->updateDrive($this->getId(), new DriveUpdate(['name' => $this->getName()]));
@@ -396,7 +396,7 @@ class Drive
                     $response,
                     $this->connectionConfig,
                     $this->serviceUrl,
-                    $this->accessToken
+                    $this->accessToken,
                 );
             }
             unset($resources[0]); // skip first propfind response, because its the parent folder
@@ -443,7 +443,7 @@ class Drive
         $webDavClient = $this->createWebDavClient();
         return $webDavClient->sendRequest(
             "GET",
-            $this->webDavUrl . rawurlencode(ltrim($path, "/"))
+            $this->webDavUrl . rawurlencode(ltrim($path, "/")),
         )->getBodyAsStream();
     }
 
@@ -587,11 +587,11 @@ class Drive
     private function updateDriveObject(): void
     {
         $guzzle = new Client(
-            Ocis::createGuzzleConfig($this->connectionConfig, $this->accessToken)
+            Ocis::createGuzzleConfig($this->connectionConfig, $this->accessToken),
         );
         $apiInstance = new DrivesApi(
             $guzzle,
-            $this->graphApiConfig
+            $this->graphApiConfig,
         );
         try {
             $apiDrive = $apiInstance->getDrive($this->getId());
@@ -601,7 +601,7 @@ class Drive
 
         if ($apiDrive instanceof OdataError) {
             throw new InvalidResponseException(
-                "getDrive returned an OdataError - " . $apiDrive->getError()
+                "getDrive returned an OdataError - " . $apiDrive->getError(),
             );
         }
 
@@ -653,7 +653,7 @@ class Drive
         }
         if ($permissions instanceof OdataError) {
             throw new InvalidResponseException(
-                "invite returned an OdataError - " . $permissions->getError()
+                "invite returned an OdataError - " . $permissions->getError(),
             );
         }
         $permissionsValue = $permissions->getValue();
@@ -663,7 +663,7 @@ class Drive
             !($permissionsValue[0] instanceof Permission)
         ) {
             throw new InvalidResponseException(
-                "invite returned invalid data " . print_r($permissionsValue, true)
+                "invite returned invalid data " . print_r($permissionsValue, true),
             );
         }
 
@@ -691,7 +691,7 @@ class Drive
         $apiRoles = $this->sendGetPermissionsRequest()->getAtLibreGraphPermissionsRolesAllowedValues();
         if (empty($apiRoles)) {
             throw new InvalidResponseException(
-                'Drive has no roles'
+                'Drive has no roles',
             );
         }
         $roles = [];
@@ -719,7 +719,7 @@ class Drive
         try {
             $this->getDrivesRootApi()->deletePermissionSpaceRoot(
                 $this->getId(),
-                $permissionId
+                $permissionId,
             );
         } catch (ApiException $e) {
             throw ExceptionHelper::getHttpErrorException($e);
@@ -754,7 +754,7 @@ class Drive
 
         if ($collectionOfPermissions instanceof OdataError) {
             throw new InvalidResponseException(
-                "listPermissions returned an OdataError - " . $collectionOfPermissions->getError()
+                "listPermissions returned an OdataError - " . $collectionOfPermissions->getError(),
             );
         }
         return $collectionOfPermissions;
@@ -774,7 +774,7 @@ class Drive
         $permissions = $this->sendGetPermissionsRequest()->getValue();
         if (empty($permissions)) {
             throw new InvalidResponseException(
-                'Expected Collection of Permission but got empty array.'
+                'Expected Collection of Permission but got empty array.',
             );
         }
         return $permissions;
@@ -797,14 +797,14 @@ class Drive
             $permission = $this->getDrivesRootApi()->updatePermissionSpaceRoot(
                 $this->getId(),
                 $permissionId,
-                $apiPermission
+                $apiPermission,
             );
         } catch (ApiException $e) {
             throw ExceptionHelper::getHttpErrorException($e);
         }
         if ($permission instanceof OdataError) {
             throw new InvalidResponseException(
-                "updatePermission returned an OdataError - " . $permission->getError()
+                "updatePermission returned an OdataError - " . $permission->getError(),
             );
         }
         $this->updateDriveObject();

--- a/src/EducationUser.php
+++ b/src/EducationUser.php
@@ -4,6 +4,4 @@ namespace Owncloud\OcisPhpSdk;
 
 use Owncloud\OcisPhpSdk\BaseUser;
 
-class EducationUser extends BaseUser
-{
-}
+class EducationUser extends BaseUser {}

--- a/src/Exception/BadRequestException.php
+++ b/src/Exception/BadRequestException.php
@@ -5,6 +5,4 @@ namespace Owncloud\OcisPhpSdk\Exception;
 /**
  * Exception for HTTP 400 errors
  */
-class BadRequestException extends \Exception
-{
-}
+class BadRequestException extends \Exception {}

--- a/src/Exception/ConflictException.php
+++ b/src/Exception/ConflictException.php
@@ -5,6 +5,4 @@ namespace Owncloud\OcisPhpSdk\Exception;
 /**
  * Exception for HTTP 409 errors
  */
-class ConflictException extends \Exception
-{
-}
+class ConflictException extends \Exception {}

--- a/src/Exception/EndPointNotImplementedException.php
+++ b/src/Exception/EndPointNotImplementedException.php
@@ -5,6 +5,4 @@ namespace Owncloud\OcisPhpSdk\Exception;
 /**
  * Exception for endpoint that are not available in Ocis version
  */
-class EndPointNotImplementedException extends \Exception
-{
-}
+class EndPointNotImplementedException extends \Exception {}

--- a/src/Exception/ExceptionHelper.php
+++ b/src/Exception/ExceptionHelper.php
@@ -19,7 +19,7 @@ class ExceptionHelper
      * that is more specific to the HTTP error
      */
     public static function getHttpErrorException(
-        GuzzleException|ApiException|SabreClientHttpException|SabreClientException|HttpException $e
+        GuzzleException|ApiException|SabreClientHttpException|SabreClientException|HttpException $e,
     ): BadRequestException|
     NotFoundException|
     ForbiddenException|
@@ -53,41 +53,41 @@ class ExceptionHelper
             400 => new BadRequestException(
                 $message,
                 $e->getCode(),
-                $e
+                $e,
             ),
             401 => new UnauthorizedException(
                 $message,
                 $e->getCode(),
-                $e
+                $e,
             ),
             403 => new ForbiddenException(
                 $message,
                 $e->getCode(),
-                $e
+                $e,
             ),
             404 => new NotFoundException(
                 $message,
                 $e->getCode(),
-                $e
+                $e,
             ),
             409 => new ConflictException(
                 $message,
                 $e->getCode(),
-                $e
+                $e,
             ),
             425 => new TooEarlyException(
                 $e->getCode(),
-                $e
+                $e,
             ),
             500 => new InternalServerErrorException(
                 $message,
                 $e->getCode(),
-                $e
+                $e,
             ),
             default => new HttpException(
                 $message,
                 $e->getCode(),
-                $e
+                $e,
             ),
         };
     }
@@ -101,7 +101,7 @@ class ExceptionHelper
      */
     public static function getExceptionFromOdataError(
         OdataError $odataError,
-        string $methodName
+        string $methodName,
     ): BadRequestException|
     NotFoundException|
     ForbiddenException|
@@ -116,7 +116,7 @@ class ExceptionHelper
         if (is_numeric($errorCode)) {
             $genericHttpException = new HttpException(
                 $errorMessage,
-                (int) $errorCode
+                (int) $errorCode,
             );
             return self::getHttpErrorException($genericHttpException);
         }
@@ -128,7 +128,7 @@ class ExceptionHelper
             "$methodName returned an OdataError with code '" .
             $errorCode .
             "' and message '" . $errorMessage . "'",
-            500
+            500,
         );
     }
 }

--- a/src/Exception/ForbiddenException.php
+++ b/src/Exception/ForbiddenException.php
@@ -5,6 +5,4 @@ namespace Owncloud\OcisPhpSdk\Exception;
 /**
  * Exception for HTTP 403 errors
  */
-class ForbiddenException extends \Exception
-{
-}
+class ForbiddenException extends \Exception {}

--- a/src/Exception/HttpException.php
+++ b/src/Exception/HttpException.php
@@ -5,6 +5,4 @@ namespace Owncloud\OcisPhpSdk\Exception;
 /**
  * general exception for HTTP error responses that are not handled by the other custom exceptions
  */
-class HttpException extends \Exception
-{
-}
+class HttpException extends \Exception {}

--- a/src/Exception/InternalServerErrorException.php
+++ b/src/Exception/InternalServerErrorException.php
@@ -5,6 +5,4 @@ namespace Owncloud\OcisPhpSdk\Exception;
 /**
  * Exception for HTTP 500 errors
  */
-class InternalServerErrorException extends \Exception
-{
-}
+class InternalServerErrorException extends \Exception {}

--- a/src/Exception/InvalidResponseException.php
+++ b/src/Exception/InvalidResponseException.php
@@ -5,6 +5,4 @@ namespace Owncloud\OcisPhpSdk\Exception;
 /**
  * Exception thrown if the ownCloud Infinite Scale server returns an invalid response.
  */
-class InvalidResponseException extends \Exception
-{
-}
+class InvalidResponseException extends \Exception {}

--- a/src/Exception/NotFoundException.php
+++ b/src/Exception/NotFoundException.php
@@ -5,6 +5,4 @@ namespace Owncloud\OcisPhpSdk\Exception;
 /**
  * Exception for HTTP 404 errors
  */
-class NotFoundException extends \Exception
-{
-}
+class NotFoundException extends \Exception {}

--- a/src/Exception/NotImplementedException.php
+++ b/src/Exception/NotImplementedException.php
@@ -5,6 +5,4 @@ namespace Owncloud\OcisPhpSdk\Exception;
 /**
  * Exception for functionalities that are planned but are not implemented yet
  */
-class NotImplementedException extends \Exception
-{
-}
+class NotImplementedException extends \Exception {}

--- a/src/Exception/TooEarlyException.php
+++ b/src/Exception/TooEarlyException.php
@@ -13,7 +13,7 @@ class TooEarlyException extends \Exception
         parent::__construct(
             'Too early',
             $code,
-            $previous
+            $previous,
         );
     }
 }

--- a/src/Exception/UnauthorizedException.php
+++ b/src/Exception/UnauthorizedException.php
@@ -5,6 +5,4 @@ namespace Owncloud\OcisPhpSdk\Exception;
 /**
  * Exception for HTTP 401 errors
  */
-class UnauthorizedException extends \Exception
-{
-}
+class UnauthorizedException extends \Exception {}

--- a/src/Group.php
+++ b/src/Group.php
@@ -55,7 +55,7 @@ class Group
         OpenApiGroup $openApiGroup,
         string $serviceUrl,
         array $connectionConfig,
-        string &$accessToken
+        string &$accessToken,
     ) {
         $this->id = $openApiGroup->getId();
         $this->displayName = $openApiGroup->getDisplayName();
@@ -72,7 +72,7 @@ class Group
         $this->graphApiConfig = Configuration::getDefaultConfiguration()
             ->setHost($this->serviceUrl . '/graph');
         $this->guzzle = new Client(
-            Ocis::createGuzzleConfig($connectionConfig, $this->accessToken)
+            Ocis::createGuzzleConfig($connectionConfig, $this->accessToken),
         );
     }
 
@@ -84,8 +84,8 @@ class Group
     {
         return (($this->id === null) || ($this->id === '')) ?
         throw new InvalidResponseException(
-            "Invalid id returned for group '" . print_r($this->id, true) . "'"
-        ) : (string)$this->id;
+            "Invalid id returned for group '" . print_r($this->id, true) . "'",
+        ) : (string) $this->id;
     }
 
     /**
@@ -93,7 +93,7 @@ class Group
      */
     public function getDescription(): string
     {
-        return (string)$this->description;
+        return (string) $this->description;
     }
 
     /**
@@ -103,7 +103,7 @@ class Group
     {
         return (($this->displayName === null) || ($this->displayName === '')) ?
         throw new InvalidResponseException(
-            "Invalid displayName returned for group '" . print_r($this->displayName, true) . "'"
+            "Invalid displayName returned for group '" . print_r($this->displayName, true) . "'",
         ) : $this->displayName;
     }
 
@@ -141,8 +141,8 @@ class Group
         $apiInstance = new GroupApi($this->guzzle, $this->graphApiConfig);
         $memberRef = new MemberReference(
             [
-                "at_odata_id" => $this->graphApiConfig->getHost(). "/v1.0/users/" . $user->getId()
-            ]
+                "at_odata_id" => $this->graphApiConfig->getHost() . "/v1.0/users/" . $user->getId(),
+            ],
         );
         try {
             $apiInstance->addMember($this->getId(), $memberRef);

--- a/src/Notification.php
+++ b/src/Notification.php
@@ -64,7 +64,7 @@ class Notification
         array $connectionConfig,
         string $serviceUrl,
         string $id,
-        $notificationContent
+        $notificationContent,
     ) {
         $this->id = $id;
         $this->app = $notificationContent->app;
@@ -167,13 +167,13 @@ class Notification
         $guzzle = new \GuzzleHttp\Client(
             Ocis::createGuzzleConfig(
                 $this->connectionConfig,
-                $this->accessToken
-            )
+                $this->accessToken,
+            ),
         );
         try {
             $guzzle->delete(
                 $this->serviceUrl . '/ocs/v2.php/apps/notifications/api/v1/notifications/',
-                ['body' => json_encode(["ids" => [$this->id]])]
+                ['body' => json_encode(["ids" => [$this->id]])],
             );
         } catch (GuzzleException $e) {
             throw ExceptionHelper::getHttpErrorException($e);

--- a/src/Ocis.php
+++ b/src/Ocis.php
@@ -94,7 +94,7 @@ class Ocis
     public function __construct(
         string $serviceUrl,
         string $accessToken,
-        array $connectionConfig = []
+        array $connectionConfig = [],
     ) {
         if (!self::isConnectionConfigValid($connectionConfig)) {
             throw new \InvalidArgumentException('Connection configuration is not valid');
@@ -113,7 +113,7 @@ class Ocis
 
         $this->connectionConfig = $connectionConfig;
         $this->graphApiConfig = Configuration::getDefaultConfiguration()->setHost(
-            $this->serviceUrl . '/graph'
+            $this->serviceUrl . '/graph',
         );
     }
 
@@ -215,7 +215,7 @@ class Ocis
         }
         $connectionConfig['headers'] = array_merge(
             $connectionConfig['headers'],
-            ['Authorization' => 'Bearer ' . $accessToken]
+            ['Authorization' => 'Bearer ' . $accessToken],
         );
         return $connectionConfig;
     }
@@ -247,40 +247,40 @@ class Ocis
         if (!array_key_exists(1, $tokenDataArray)) {
             throw new \InvalidArgumentException(
                 self::DECODE_TOKEN_ERROR_MESSAGE .
-                " No payload found."
+                " No payload found.",
             );
         }
         $plainPayload = base64_decode(\strtr($tokenDataArray[1], '-_', '+/'), true);
         if (!$plainPayload) {
             throw new \InvalidArgumentException(
                 self::DECODE_TOKEN_ERROR_MESSAGE .
-                " Payload not Base64Url encoded."
+                " Payload not Base64Url encoded.",
             );
         }
         $tokenPayload = json_decode($plainPayload, true);
         if (!is_array($tokenPayload)) {
             throw new \InvalidArgumentException(
                 self::DECODE_TOKEN_ERROR_MESSAGE .
-                " Payload not valid JSON."
+                " Payload not valid JSON.",
             );
         }
         if (!array_key_exists('iss', $tokenPayload)) {
             throw new \InvalidArgumentException(
                 self::DECODE_TOKEN_ERROR_MESSAGE .
-                " Payload does not contain 'iss' key."
+                " Payload does not contain 'iss' key.",
             );
         }
         if (!is_string($tokenPayload['iss'])) {
             throw new \InvalidArgumentException(
                 self::DECODE_TOKEN_ERROR_MESSAGE .
-                " 'iss' key is not a string."
+                " 'iss' key is not a string.",
             );
         }
         $iss = parse_url($tokenPayload['iss']);
         if (!is_array($iss) || !array_key_exists('host', $iss)) {
             throw new \InvalidArgumentException(
                 self::DECODE_TOKEN_ERROR_MESSAGE .
-                " Content of 'iss' has no 'host' part."
+                " Content of 'iss' has no 'host' part.",
             );
         }
         try {
@@ -328,7 +328,7 @@ class Ocis
             if (!isset($body->data->version->productversion)) {
                 throw new InvalidResponseException('Missing productversion element in XML response');
             }
-            $version = (string)$body->data->version->productversion;
+            $version = (string) $body->data->version->productversion;
             $pattern = '(\d\.\d\.\d)';
             preg_match($pattern, $version, $matches);
             $this->ocisVersion = $matches[0];
@@ -352,14 +352,14 @@ class Ocis
     public function getAllDrives(
         DriveOrder     $orderBy = DriveOrder::NAME,
         OrderDirection $orderDirection = OrderDirection::ASC,
-        ?DriveType      $type = null
+        ?DriveType      $type = null,
     ): array {
         if (array_key_exists('drivesGetDrivesApi', $this->connectionConfig)) {
             $apiInstance = $this->connectionConfig['drivesGetDrivesApi'];
         } else {
             $apiInstance = new DrivesGetDrivesApi(
                 $this->guzzle,
-                $this->graphApiConfig
+                $this->graphApiConfig,
             );
         }
         $order = $this->getListDrivesOrderString($orderBy, $orderDirection);
@@ -389,7 +389,7 @@ class Ocis
                 $this->connectionConfig,
                 $this->serviceUrl,
                 $this->accessToken,
-                $this->getOcisVersion()
+                $this->getOcisVersion(),
             );
             $drives[] = $drive;
         }
@@ -413,11 +413,11 @@ class Ocis
     public function getMyDrives(
         DriveOrder     $orderBy = DriveOrder::NAME,
         OrderDirection $orderDirection = OrderDirection::ASC,
-        ?DriveType      $type = null
+        ?DriveType      $type = null,
     ): array {
         $apiInstance = new MeDrivesApi(
             $this->guzzle,
-            $this->graphApiConfig
+            $this->graphApiConfig,
         );
         $drives = [];
         $order = $this->getListDrivesOrderString($orderBy, $orderDirection);
@@ -447,7 +447,7 @@ class Ocis
                 $this->connectionConfig,
                 $this->serviceUrl,
                 $this->accessToken,
-                $this->getOcisVersion()
+                $this->getOcisVersion(),
             );
             $drives[] = $drive;
         }
@@ -456,13 +456,13 @@ class Ocis
 
     private function getListDrivesOrderString(
         DriveOrder     $orderBy = DriveOrder::NAME,
-        OrderDirection $orderDirection = OrderDirection::ASC
+        OrderDirection $orderDirection = OrderDirection::ASC,
     ): string {
         return $orderBy->value . ' ' . $orderDirection->value;
     }
 
     private function getListDrivesFilterString(
-        ?DriveType $type = null
+        ?DriveType $type = null,
     ): ?string {
         if ($type !== null) {
             $filter = 'driveType eq \'' . $type->value . '\'';
@@ -487,7 +487,7 @@ class Ocis
     {
         $apiInstance = new DrivesApi(
             $this->guzzle,
-            $this->graphApiConfig
+            $this->graphApiConfig,
         );
         try {
             $apiDrive = $apiInstance->getDrive($driveId);
@@ -497,7 +497,7 @@ class Ocis
 
         if ($apiDrive instanceof OdataError) {
             throw new InvalidResponseException(
-                "getDrive returned an OdataError - " . $apiDrive->getError()
+                "getDrive returned an OdataError - " . $apiDrive->getError(),
             );
         }
         return new Drive(
@@ -505,7 +505,7 @@ class Ocis
             $this->connectionConfig,
             $this->serviceUrl,
             $this->accessToken,
-            $this->getOcisVersion()
+            $this->getOcisVersion(),
         );
     }
 
@@ -526,7 +526,7 @@ class Ocis
     public function createDrive(
         string $name,
         int $quota = 0,
-        ?string $description = null
+        ?string $description = null,
     ): Drive {
         if ($quota < 0) {
             throw new \InvalidArgumentException('Quota cannot be less than 0');
@@ -536,15 +536,15 @@ class Ocis
         } else {
             $apiInstance = new DrivesApi(
                 $this->guzzle,
-                $this->graphApiConfig
+                $this->graphApiConfig,
             );
         }
         $apiDrive = new ApiDrive(
             [
                 'description' => $description,
                 'name' => $name,
-                'quota' => new Quota(['total' => $quota])
-            ]
+                'quota' => new Quota(['total' => $quota]),
+            ],
         );
         try {
             $newlyCreatedDrive = $apiInstance->createDrive($apiDrive);
@@ -558,13 +558,13 @@ class Ocis
                 $this->connectionConfig,
                 $this->serviceUrl,
                 $this->accessToken,
-                $this->getOcisVersion()
+                $this->getOcisVersion(),
             );
         }
         throw new InvalidResponseException(
             "Drive could not be created. '" .
             $newlyCreatedDrive->getError()->getMessage() .
-            "'"
+            "'",
         );
     }
 
@@ -587,7 +587,7 @@ class Ocis
     public function getGroups(
         string $search = "",
         OrderDirection $orderBy = OrderDirection::ASC,
-        bool $expandMembers = false
+        bool $expandMembers = false,
     ) {
         $apiInstance = new GroupsApi($this->guzzle, $this->graphApiConfig);
         $orderByString = $orderBy->value === OrderDirection::ASC->value ? "displayName" : "displayName desc";
@@ -596,7 +596,7 @@ class Ocis
                 $search,
                 [$orderByString],
                 [],
-                $expandMembers ? ["members"] : null
+                $expandMembers ? ["members"] : null,
             );
         } catch (ApiException $e) {
             throw ExceptionHelper::getHttpErrorException($e);
@@ -604,7 +604,7 @@ class Ocis
 
         if ($allGroupsList instanceof OdataError) {
             throw new InvalidResponseException(
-                "listGroups returned an OdataError - " . $allGroupsList->getError()
+                "listGroups returned an OdataError - " . $allGroupsList->getError(),
             );
         }
         $apiGroups = $allGroupsList->getValue() ?? [];
@@ -614,7 +614,7 @@ class Ocis
                 $group,
                 $this->serviceUrl,
                 $this->connectionConfig,
-                $this->accessToken
+                $this->accessToken,
             );
             $groupList[] = $newGroup;
         }
@@ -644,7 +644,7 @@ class Ocis
                 $responses,
                 $this->connectionConfig,
                 $this->serviceUrl,
-                $this->accessToken
+                $this->accessToken,
             );
         } catch (SabreClientHttpException|SabreClientException $e) {
             throw ExceptionHelper::getHttpErrorException($e);
@@ -673,7 +673,7 @@ class Ocis
         $users = [];
         $apiInstance = new UsersApi(
             $this->guzzle,
-            $this->graphApiConfig
+            $this->graphApiConfig,
         );
         try {
             $collectionOfApiUsers = $apiInstance->listUsers($search);
@@ -683,7 +683,7 @@ class Ocis
 
         if ($collectionOfApiUsers instanceof OdataError) {
             throw new InvalidResponseException(
-                "listUsers returned an OdataError - " . $collectionOfApiUsers->getError()
+                "listUsers returned an OdataError - " . $collectionOfApiUsers->getError(),
             );
         }
         $apiUsers = $collectionOfApiUsers->getValue() ?? [];
@@ -706,7 +706,7 @@ class Ocis
     {
         $apiInstance = new UserApi(
             $this->guzzle,
-            $this->graphApiConfig
+            $this->graphApiConfig,
         );
         try {
             $apiUser = $apiInstance->getUser($userId);
@@ -716,7 +716,7 @@ class Ocis
 
         if ($apiUser instanceof OdataError) {
             throw new InvalidResponseException(
-                "getUser returned an OdataError - " . $apiUser->getError()
+                "getUser returned an OdataError - " . $apiUser->getError(),
             );
         }
         return new User($apiUser);
@@ -740,7 +740,7 @@ class Ocis
         $users = [];
         $apiInstance = new EducationUserApi(
             $this->guzzle,
-            $this->graphApiConfig
+            $this->graphApiConfig,
         );
         try {
             $collectionOfApiUsers = $apiInstance->listEducationUsers($search);
@@ -750,7 +750,7 @@ class Ocis
 
         if ($collectionOfApiUsers instanceof OdataError) {
             throw new InvalidResponseException(
-                "listUsers returned an OdataError - " . $collectionOfApiUsers->getError()
+                "listUsers returned an OdataError - " . $collectionOfApiUsers->getError(),
             );
         }
         $apiUsers = $collectionOfApiUsers->getValue() ?? [];
@@ -773,7 +773,7 @@ class Ocis
     {
         $apiInstance = new EducationUserApi(
             $this->guzzle,
-            $this->graphApiConfig
+            $this->graphApiConfig,
         );
         try {
             $apiUser = $apiInstance->getEducationUser($userId);
@@ -783,7 +783,7 @@ class Ocis
 
         if ($apiUser instanceof OdataError) {
             throw new InvalidResponseException(
-                "getUser returned an OdataError - " . $apiUser->getError()
+                "getUser returned an OdataError - " . $apiUser->getError(),
             );
         }
         return new EducationUser($apiUser);
@@ -802,7 +802,7 @@ class Ocis
     {
         $apiInstance = new GroupApi(
             $this->guzzle,
-            $this->graphApiConfig
+            $this->graphApiConfig,
         );
         try {
             $apiGroup = $apiInstance->getGroup($groupId);
@@ -812,14 +812,14 @@ class Ocis
 
         if ($apiGroup instanceof OdataError) {
             throw new InvalidResponseException(
-                "getGroup returned an OdataError - " . $apiGroup->getError()
+                "getGroup returned an OdataError - " . $apiGroup->getError(),
             );
         }
         return new Group(
             $apiGroup,
             $this->serviceUrl,
             $this->connectionConfig,
-            $this->accessToken
+            $this->accessToken,
         );
     }
 
@@ -856,7 +856,7 @@ class Ocis
     {
         try {
             $response = $this->guzzle->get(
-                $this->serviceUrl . $this->notificationsEndpoint
+                $this->serviceUrl . $this->notificationsEndpoint,
             );
         } catch (GuzzleException|GuzzleClientException $e) {
             throw ExceptionHelper::getHttpErrorException($e);
@@ -884,11 +884,11 @@ class Ocis
          *  }
          *} $ocsResponse
          */
-        $ocsResponse = (array)json_decode($content, true);
+        $ocsResponse = (array) json_decode($content, true);
 
         if (!$this->isNotificationResponseValid($ocsResponse)) {
             throw new InvalidResponseException(
-                'Notification response is invalid. Content: "' .  $content . '"'
+                'Notification response is invalid. Content: "' . $content . '"',
             );
         }
 
@@ -902,7 +902,7 @@ class Ocis
                 !is_string($ocsData["notification_id"]) ||
                 $ocsData["notification_id"] === "") {
                 throw new InvalidResponseException(
-                    'Id is invalid or missing in notification response. Content: "' . $content . '"'
+                    'Id is invalid or missing in notification response. Content: "' . $content . '"',
                 );
             }
             $id = $ocsData["notification_id"];
@@ -948,7 +948,7 @@ class Ocis
                 $this->connectionConfig,
                 $this->serviceUrl,
                 $id,
-                $notificationContent
+                $notificationContent,
             );
         }
         return $notifications;
@@ -980,14 +980,14 @@ class Ocis
         }
         if ($newlyCreatedGroup instanceof OdataError) {
             throw new InvalidResponseException(
-                "createGroup returned an OdataError - " . $newlyCreatedGroup->getError()
+                "createGroup returned an OdataError - " . $newlyCreatedGroup->getError(),
             );
         }
         return new Group(
             $newlyCreatedGroup,
             $this->serviceUrl,
             $this->connectionConfig,
-            $this->accessToken
+            $this->accessToken,
         );
     }
 
@@ -1028,7 +1028,7 @@ class Ocis
     {
         $apiInstance = new MeDriveApi(
             $this->guzzle,
-            $this->graphApiConfig
+            $this->graphApiConfig,
         );
         try {
             $shareList = $apiInstance->listSharedWithMe();
@@ -1037,14 +1037,14 @@ class Ocis
         }
         if ($shareList instanceof OdataError) {
             throw new InvalidResponseException(
-                "listSharedWithMe returned an OdataError - " . $shareList->getError()
+                "listSharedWithMe returned an OdataError - " . $shareList->getError(),
             );
         }
         $apiShares = $shareList->getValue() ?? [];
         $shares = [];
         foreach ($apiShares as $share) {
             $shares[] = new ShareReceived(
-                $share
+                $share,
             );
         }
         return $shares;
@@ -1064,7 +1064,7 @@ class Ocis
     {
         $apiInstance = new MeDriveApi(
             $this->guzzle,
-            $this->graphApiConfig
+            $this->graphApiConfig,
         );
         try {
             $shareList = $apiInstance->listSharedByMe();
@@ -1073,27 +1073,27 @@ class Ocis
         }
         if ($shareList instanceof OdataError) {
             throw new InvalidResponseException(
-                "listSharedByMe returned an OdataError - " . $shareList->getError()
+                "listSharedByMe returned an OdataError - " . $shareList->getError(),
             );
         }
         if ($shareList->getValue() === null) {
             throw new InvalidResponseException(
-                "listSharedByMe returned 'null' where an array of data were expected"
+                "listSharedByMe returned 'null' where an array of data were expected",
             );
         }
         $shares = [];
         foreach ($shareList->getValue() as $share) {
             $resourceId = empty($share->getId()) ?
                 throw new InvalidResponseException(
-                    "Invalid resource id '" . print_r($share->getId(), true) . "'"
+                    "Invalid resource id '" . print_r($share->getId(), true) . "'",
                 )
-                : (string)$share->getId();
+                : (string) $share->getId();
 
             $driveId = empty($share->getParentReference()) || empty($share->getParentReference()->getDriveId()) ?
                 throw new InvalidResponseException(
-                    "Invalid driveId '" . print_r($share->getParentReference(), true) . "'"
+                    "Invalid driveId '" . print_r($share->getParentReference(), true) . "'",
                 )
-                : (string)$share->getParentReference()->getDriveId();
+                : (string) $share->getParentReference()->getDriveId();
 
             if (!is_iterable($share->getPermissions())) {
                 throw new InvalidResponseException("Invalid permissions provided");
@@ -1106,7 +1106,7 @@ class Ocis
                         $driveId,
                         $this->connectionConfig,
                         $this->serviceUrl,
-                        $this->accessToken
+                        $this->accessToken,
                     );
                 } else {
                     $shares[] = new ShareLink(
@@ -1115,7 +1115,7 @@ class Ocis
                         $driveId,
                         $this->connectionConfig,
                         $this->serviceUrl,
-                        $this->accessToken
+                        $this->accessToken,
                     );
                 }
             }

--- a/src/OcisResource.php
+++ b/src/OcisResource.php
@@ -68,7 +68,7 @@ class OcisResource
         array $metadata,
         array $connectionConfig,
         string $serviceUrl,
-        string &$accessToken
+        string &$accessToken,
     ) {
         $this->metadata = $metadata;
         $this->accessToken = &$accessToken;
@@ -104,7 +104,7 @@ class OcisResource
         }
         if ($metadata === []) {
             throw new InvalidResponseException(
-                'Could not find property "' . $property->getKey() . '" in response'
+                'Could not find property "' . $property->getKey() . '" in response',
             );
         }
         if ($metadata[$property->getKey()] === null && $property->getKey() !== "tags") {
@@ -114,7 +114,7 @@ class OcisResource
             return $metadata[$property->getKey()]->getValue();
         }
         if ($metadata[$property->getKey()] === null) {
-            return (string)$metadata[$property->getKey()];
+            return (string) $metadata[$property->getKey()];
         }
         /** @phpstan-ignore-next-line because next line might return mixed data*/
         return $metadata[$property->getKey()];
@@ -134,7 +134,7 @@ class OcisResource
     public function getRoles(): array
     {
         $guzzle = new Client(
-            Ocis::createGuzzleConfig($this->connectionConfig, $this->accessToken)
+            Ocis::createGuzzleConfig($this->connectionConfig, $this->accessToken),
         );
 
         if (array_key_exists('drivesPermissionsApi', $this->connectionConfig)) {
@@ -142,7 +142,7 @@ class OcisResource
         } else {
             $apiInstance = new DrivesPermissionsApi(
                 $guzzle,
-                $this->graphApiConfig
+                $this->graphApiConfig,
             );
         }
         try {
@@ -152,7 +152,7 @@ class OcisResource
         }
         if ($collectionOfPermissions instanceof OdataError) {
             throw new InvalidResponseException(
-                "listPermissions returned an OdataError - " . $collectionOfPermissions->getError()
+                "listPermissions returned an OdataError - " . $collectionOfPermissions->getError(),
             );
         }
         $apiRoles = $collectionOfPermissions->getAtLibreGraphPermissionsRolesAllowedValues() ?? [];
@@ -199,11 +199,11 @@ class OcisResource
             $apiInstance = $this->connectionConfig['drivesPermissionsApi'];
         } else {
             $guzzle = new Client(
-                Ocis::createGuzzleConfig($this->connectionConfig, $this->accessToken)
+                Ocis::createGuzzleConfig($this->connectionConfig, $this->accessToken),
             );
             $apiInstance = new DrivesPermissionsApi(
                 $guzzle,
-                $this->graphApiConfig
+                $this->graphApiConfig,
             );
         }
 
@@ -215,7 +215,7 @@ class OcisResource
         }
         if ($permissions instanceof OdataError) {
             throw new InvalidResponseException(
-                "invite returned an OdataError - " . $permissions->getError()
+                "invite returned an OdataError - " . $permissions->getError(),
             );
         }
         $permissionsValue = $permissions->getValue();
@@ -225,7 +225,7 @@ class OcisResource
             !($permissionsValue[0] instanceof Permission)
         ) {
             throw new InvalidResponseException(
-                "invite returned invalid data " . print_r($permissionsValue, true)
+                "invite returned invalid data " . print_r($permissionsValue, true),
             );
         }
 
@@ -235,7 +235,7 @@ class OcisResource
             $this->getSpaceId(),
             $this->connectionConfig,
             $this->serviceUrl,
-            $this->accessToken
+            $this->accessToken,
         );
     }
 
@@ -254,17 +254,17 @@ class OcisResource
         SharingLinkType $type = SharingLinkType::VIEW,
         ?\DateTimeImmutable $expiration = null,
         ?string $password = null,
-        ?string $displayName = null
+        ?string $displayName = null,
     ): ShareLink {
         if (array_key_exists('drivesPermissionsApi', $this->connectionConfig)) {
             $apiInstance = $this->connectionConfig['drivesPermissionsApi'];
         } else {
             $guzzle = new Client(
-                Ocis::createGuzzleConfig($this->connectionConfig, $this->accessToken)
+                Ocis::createGuzzleConfig($this->connectionConfig, $this->accessToken),
             );
             $apiInstance = new DrivesPermissionsApi(
                 $guzzle,
-                $this->graphApiConfig
+                $this->graphApiConfig,
             );
         }
         if ($expiration !== null) {
@@ -277,7 +277,7 @@ class OcisResource
             'type' => $type,
             'password' => $password,
             'expiration_date_time' => $expirationMutable,
-            'display_name' => $displayName
+            'display_name' => $displayName,
         ]);
         try {
             $permission = $apiInstance->createLink($this->getSpaceId(), $this->getId(), $createLinkData);
@@ -286,7 +286,7 @@ class OcisResource
         }
         if ($permission instanceof OdataError) {
             throw new InvalidResponseException(
-                "createLink returned an OdataError - " . $permission->getError()
+                "createLink returned an OdataError - " . $permission->getError(),
             );
         }
 
@@ -296,7 +296,7 @@ class OcisResource
             $this->getSpaceId(),
             $this->connectionConfig,
             $this->serviceUrl,
-            $this->accessToken
+            $this->accessToken,
         );
 
     }
@@ -392,7 +392,7 @@ class OcisResource
             return "file";
         }
         throw new InvalidResponseException(
-            "Received invalid data for the key \"resourcetype\" in the response array"
+            "Received invalid data for the key \"resourcetype\" in the response array",
         );
     }
 
@@ -405,13 +405,13 @@ class OcisResource
         if ($this->getType() === "folder") {
             $size = $this->getMetadata(ResourceMetadata::FOLDERSIZE);
             if (is_numeric($size)) {
-                return (int)$size;
+                return (int) $size;
             }
             throw new InvalidResponseException("Received an invalid value for size in the response");
         }
         $size = $this->getMetadata(ResourceMetadata::FILESIZE);
         if (is_numeric($size)) {
-            return (int)$size;
+            return (int) $size;
         }
         throw new InvalidResponseException("Received an invalid value for size in the response");
     }
@@ -468,7 +468,7 @@ class OcisResource
     {
         $result = $this->getMetadata(ResourceMetadata::FAVORITE);
         if (in_array($result, [1, 0, '1', '0'])) {
-            return (bool)$result;
+            return (bool) $result;
         }
         throw new InvalidResponseException("Value of property \"favorite\" invalid in the server response");
     }
@@ -500,7 +500,7 @@ class OcisResource
         $privateLink = $this->getMetadata(ResourceMetadata::PRIVATELINK);
         if (!is_string($privateLink)) {
             throw new InvalidResponseException(
-                'Invalid private link in response from server: ' . print_r($privateLink, true)
+                'Invalid private link in response from server: ' . print_r($privateLink, true),
             );
         }
         return rawurldecode($privateLink);

--- a/src/Share.php
+++ b/src/Share.php
@@ -49,7 +49,7 @@ class Share
         string        $driveId,
         array         $connectionConfig,
         string        $serviceUrl,
-        string        &$accessToken
+        string        &$accessToken,
     ) {
         $this->apiPermission = $apiPermission;
         $this->driveId = $driveId;
@@ -73,11 +73,11 @@ class Share
             return $this->connectionConfig['drivesPermissionsApi'];
         }
         $guzzle = new Client(
-            Ocis::createGuzzleConfig($this->connectionConfig, $this->accessToken)
+            Ocis::createGuzzleConfig($this->connectionConfig, $this->accessToken),
         );
         return new DrivesPermissionsApi(
             $guzzle,
-            $this->graphApiConfig
+            $this->graphApiConfig,
         );
     }
 
@@ -86,7 +86,7 @@ class Share
         $id = $this->apiPermission->getId();
         if ($id === null || $id === '') {
             throw new InvalidResponseException(
-                "Invalid id returned for permission '" . print_r($id, true) . "'"
+                "Invalid id returned for permission '" . print_r($id, true) . "'",
             );
         }
         return $id;
@@ -128,7 +128,7 @@ class Share
             $this->getDrivesPermissionsApi()->deletePermission(
                 $this->driveId,
                 $this->resourceId,
-                $this->getPermissionId()
+                $this->getPermissionId(),
             );
         } catch (ApiException $e) {
             throw ExceptionHelper::getHttpErrorException($e);
@@ -163,14 +163,14 @@ class Share
                 $this->driveId,
                 $this->resourceId,
                 $this->getPermissionId(),
-                $apiPermission
+                $apiPermission,
             );
         } catch (ApiException $e) {
             throw ExceptionHelper::getHttpErrorException($e);
         }
         if ($apiPermission instanceof OdataError) {
             throw new InvalidResponseException(
-                "updatePermission returned an OdataError - " . $apiPermission->getError()
+                "updatePermission returned an OdataError - " . $apiPermission->getError(),
             );
         }
         $this->apiPermission = $apiPermission;

--- a/src/ShareCreated.php
+++ b/src/ShareCreated.php
@@ -20,7 +20,7 @@ class ShareCreated extends Share
     {
         // in the constructor the value is checked for being the right type, but phan does not know
         // so simply cast to string
-        return (string)$this->apiPermission->getId();
+        return (string) $this->apiPermission->getId();
     }
 
     /**
@@ -45,14 +45,14 @@ class ShareCreated extends Share
                 $this->driveId,
                 $this->resourceId,
                 $this->getPermissionId(),
-                $apiPermission
+                $apiPermission,
             );
         } catch (ApiException $e) {
             throw ExceptionHelper::getHttpErrorException($e);
         }
         if ($apiPermission instanceof OdataError) {
             throw new InvalidResponseException(
-                "updatePermission returned an OdataError - " . $apiPermission->getError()
+                "updatePermission returned an OdataError - " . $apiPermission->getError(),
             );
         }
         $this->apiPermission = $apiPermission;
@@ -74,22 +74,22 @@ class ShareCreated extends Share
         $receiver = $this->apiPermission->getGrantedToV2();
         if ($receiver === null) {
             throw new InvalidResponseException(
-                "could not determine the receiver, getGrantedToV2 returned 'null'"
+                "could not determine the receiver, getGrantedToV2 returned 'null'",
             );
         }
         $user = $receiver->getUser();
         if ($user !== null && $user->getId() !== null) {
             // casting to string only to make phan happy
-            return $ocis->getUserById((string)$user->getId());
+            return $ocis->getUserById((string) $user->getId());
         }
         $group = $receiver->getGroup();
         if ($group !== null && $group->getId() !== null) {
             // casting to string only to make phan happy
-            return $ocis->getGroupById((string)$group->getId());
+            return $ocis->getGroupById((string) $group->getId());
         }
         throw new InvalidResponseException(
             "could not determine the receiver, neither group nor user was returned - " .
-            print_r($receiver, true)
+            print_r($receiver, true),
         );
     }
 }

--- a/src/ShareLink.php
+++ b/src/ShareLink.php
@@ -30,7 +30,7 @@ class ShareLink extends Share
             throw new InvalidResponseException(
                 "Invalid link returned for permission '" .
                 print_r($sharingLink, true) .
-                "'"
+                "'",
             );
         }
         return $sharingLink;
@@ -43,7 +43,7 @@ class ShareLink extends Share
             throw new InvalidResponseException(
                 "Invalid type returned for sharing link '" .
                 print_r($type, true) .
-                "'"
+                "'",
             );
         }
         return $type;
@@ -55,15 +55,15 @@ class ShareLink extends Share
             throw new InvalidResponseException(
                 "Invalid webUrl returned for sharing link '" .
                 print_r($this->getSharingLink()->getWebUrl(), true) .
-                "'"
+                "'",
             );
         }
-        return (string)$this->getSharingLink()->getWebUrl();
+        return (string) $this->getSharingLink()->getWebUrl();
     }
 
     public function getDisplayName(): string
     {
-        return (string)$this->getSharingLink()->getAtLibreGraphDisplayName();
+        return (string) $this->getSharingLink()->getAtLibreGraphDisplayName();
     }
 
     /**
@@ -113,7 +113,7 @@ class ShareLink extends Share
     public function setPassword(string $password): bool
     {
         $newPassword = new SharingLinkPassword([
-            'password' => $password
+            'password' => $password,
         ]);
 
         try {
@@ -121,14 +121,14 @@ class ShareLink extends Share
                 $this->driveId,
                 $this->resourceId,
                 $this->getPermissionId(),
-                $newPassword
+                $newPassword,
             );
         } catch (ApiException $e) {
             throw ExceptionHelper::getHttpErrorException($e);
         }
         if ($apiPermission instanceof OdataError) {
             throw new InvalidResponseException(
-                "setPassword returned an OdataError - " . $apiPermission->getError()
+                "setPassword returned an OdataError - " . $apiPermission->getError(),
             );
         }
         $this->apiPermission = $apiPermission;
@@ -154,14 +154,14 @@ class ShareLink extends Share
                 $this->driveId,
                 $this->resourceId,
                 $this->getPermissionId(),
-                $this->apiPermission
+                $this->apiPermission,
             );
         } catch (ApiException $e) {
             throw ExceptionHelper::getHttpErrorException($e);
         }
         if ($apiPermission instanceof OdataError) {
             throw new InvalidResponseException(
-                "updatePermission returned an OdataError - " . $apiPermission->getError()
+                "updatePermission returned an OdataError - " . $apiPermission->getError(),
             );
         }
         $this->apiPermission = $apiPermission;

--- a/src/ShareReceived.php
+++ b/src/ShareReceived.php
@@ -20,7 +20,7 @@ class ShareReceived
      * @param DriveItem $shareReceived
      */
     public function __construct(
-        DriveItem $shareReceived
+        DriveItem $shareReceived,
     ) {
         $this->shareReceived = $shareReceived;
     }
@@ -32,7 +32,7 @@ class ShareReceived
     {
         return empty($this->shareReceived->getId())
             ? throw new InvalidResponseException(
-                "Invalid Id '" . print_r($this->shareReceived->getId(), true) . "'"
+                "Invalid Id '" . print_r($this->shareReceived->getId(), true) . "'",
             )
             : $this->shareReceived->getId();
     }
@@ -45,7 +45,7 @@ class ShareReceived
     {
         return empty($this->shareReceived->getName())
             ? throw new InvalidResponseException(
-                "Invalid resource name '" . print_r($this->shareReceived->getName(), true) . "'"
+                "Invalid resource name '" . print_r($this->shareReceived->getName(), true) . "'",
             )
             : $this->shareReceived->getName();
     }
@@ -57,7 +57,7 @@ class ShareReceived
     {
         return empty($this->shareReceived->getETag())
             ? throw new InvalidResponseException(
-                "Invalid Etag '" . print_r($this->shareReceived->getETag(), true) . "'"
+                "Invalid Etag '" . print_r($this->shareReceived->getETag(), true) . "'",
             )
         : $this->shareReceived->getETag();
     }
@@ -71,7 +71,7 @@ class ShareReceived
         $time = $this->shareReceived->getLastModifiedDateTime();
         if (empty($time)) {
             throw new InvalidResponseException(
-                "Invalid last modified DateTime'" . print_r($time, true) . "'"
+                "Invalid last modified DateTime'" . print_r($time, true) . "'",
             );
         }
         return \DateTimeImmutable::createFromMutable($time);
@@ -84,7 +84,7 @@ class ShareReceived
     {
         return empty($this->shareReceived->getRemoteItem())
             ? throw new InvalidResponseException(
-                "Invalid remote item '" . print_r($this->shareReceived->getParentReference(), true) . "'"
+                "Invalid remote item '" . print_r($this->shareReceived->getParentReference(), true) . "'",
             ) : $this->shareReceived->getRemoteItem();
     }
 
@@ -97,7 +97,7 @@ class ShareReceived
         $remoteItem = $this->getRemoteItem();
         return empty($remoteItem->getId())
             ? throw new InvalidResponseException(
-                "Invalid remote item id '" . print_r($this->shareReceived->getRemoteItem(), true) . "'"
+                "Invalid remote item id '" . print_r($this->shareReceived->getRemoteItem(), true) . "'",
             )
             : $remoteItem->getId();
     }
@@ -110,7 +110,7 @@ class ShareReceived
         return empty($this->shareReceived->getCreatedBy())
         || empty($this->shareReceived->getCreatedBy()->getUser()) ?
             throw new InvalidResponseException(
-                "Invalid share createdBy information '" . print_r($this->shareReceived->getCreatedBy(), true) . "'"
+                "Invalid share createdBy information '" . print_r($this->shareReceived->getCreatedBy(), true) . "'",
             ) : $this->shareReceived->getCreatedBy()->getUser();
     }
 
@@ -122,7 +122,7 @@ class ShareReceived
         $createdByUser = $this->getCreatedByUser();
         return empty($createdByUser->getDisplayName())
             ? throw new InvalidResponseException(
-                "Invalid share owner name '" . print_r($createdByUser, true) . "'"
+                "Invalid share owner name '" . print_r($createdByUser, true) . "'",
             )
             : $createdByUser->getDisplayName();
     }
@@ -134,7 +134,7 @@ class ShareReceived
     {
         $createdByUser = $this->getCreatedByUser();
         return empty($createdByUser->getId()) ? throw new InvalidResponseException(
-            "Invalid share owner id '" . print_r($createdByUser->getId(), true) . "'"
+            "Invalid share owner id '" . print_r($createdByUser->getId(), true) . "'",
         ) : $createdByUser->getId();
     }
 

--- a/src/SharingRole.php
+++ b/src/SharingRole.php
@@ -38,8 +38,8 @@ class SharingRole
     {
         return ($data === null || $data === '') ?
         throw new InvalidResponseException(
-            "Invalid $dataKey returned for user '" . print_r($data, true) . "'"
-        ) : (string)$data;
+            "Invalid $dataKey returned for user '" . print_r($data, true) . "'",
+        ) : (string) $data;
     }
 
     /**
@@ -71,7 +71,7 @@ class SharingRole
      */
     public function getWeight(): int
     {
-        return (int)$this->validateData($this->weight, "weight");
+        return (int) $this->validateData($this->weight, "weight");
     }
 
 

--- a/src/User.php
+++ b/src/User.php
@@ -4,6 +4,4 @@ namespace Owncloud\OcisPhpSdk;
 
 use Owncloud\OcisPhpSdk\BaseUser;
 
-class User extends BaseUser
-{
-}
+class User extends BaseUser {}

--- a/tests/integration/Owncloud/OcisPhpSdk/DriveTest.php
+++ b/tests/integration/Owncloud/OcisPhpSdk/DriveTest.php
@@ -90,7 +90,7 @@ class DriveTest extends OcisPhpSdkTestCase
         $this->assertContainsOnlyInstancesOf(
             SharingRole::class,
             $role,
-            "Array contains not only 'SharingRole' items"
+            "Array contains not only 'SharingRole' items",
         );
     }
 
@@ -119,7 +119,7 @@ class DriveTest extends OcisPhpSdkTestCase
                 "id" => "312c0871-5ef7-4b3a-85b6-0e4074c64049",
                 "description" => "Allows managing a space",
                 "displayName" => "Manager",
-                "@libre.graph.weight" => 3
+                "@libre.graph.weight" => 3,
             ];
 
             $shareRoles = [new SharingRole(new UnifiedRoleDefinition($role))];
@@ -147,7 +147,7 @@ class DriveTest extends OcisPhpSdkTestCase
             Permission::class,
             $driveInvitation,
             "Expected class to be 'Permission' but found "
-            . get_class($driveInvitation)
+            . get_class($driveInvitation),
         );
         $this->assertNull($driveInvitation->getExpirationDateTime(), "Expiration date for sharing drive wasn't found to be null");
         $receivedInvitationDrive = $marieOcis->getDriveById($this->drive->getId());
@@ -155,12 +155,12 @@ class DriveTest extends OcisPhpSdkTestCase
             $this->drive->getId(),
             $receivedInvitationDrive->getId(),
             "Expected driveId to be " . $this->drive->getId()
-            . " but found " . $receivedInvitationDrive->getId()
+            . " but found " . $receivedInvitationDrive->getId(),
         );
         $this->assertSame(
             $this->drive->getName(),
             $receivedInvitationDrive->getName(),
-            "Expected shared drive name to be " . $this->drive->getName() . " but found " . $receivedInvitationDrive->getName()
+            "Expected shared drive name to be " . $this->drive->getName() . " but found " . $receivedInvitationDrive->getName(),
         );
     }
 
@@ -335,7 +335,7 @@ class DriveTest extends OcisPhpSdkTestCase
 
         $philosophyHatersGroup =  $this->ocis->createGroup(
             'philosophyhaters',
-            'philosophy haters group'
+            'philosophy haters group',
         );
         $this->createdGroups = [$philosophyHatersGroup];
         $philosophyHatersGroup->addUser($marie);
@@ -348,7 +348,7 @@ class DriveTest extends OcisPhpSdkTestCase
                 "id" => "312c0871-5ef7-4b3a-85b6-0e4074c64049",
                 "description" => "Allows managing a space",
                 "displayName" => "Manager",
-                "@libre.graph.weight" => 3
+                "@libre.graph.weight" => 3,
             ];
 
             $shareRoles = [new SharingRole(new UnifiedRoleDefinition($role))];
@@ -377,12 +377,12 @@ class DriveTest extends OcisPhpSdkTestCase
             $this->drive->getId(),
             $receivedInvitationDrive->getId(),
             "Expected driveId to be " . $this->drive->getId()
-            . " but found " . $receivedInvitationDrive->getId()
+            . " but found " . $receivedInvitationDrive->getId(),
         );
         $this->assertSame(
             $this->drive->getName(),
             $receivedInvitationDrive->getName(),
-            "Expected shared drive name to be " . $this->drive->getName() . " but found " . $receivedInvitationDrive->getName()
+            "Expected shared drive name to be " . $this->drive->getName() . " but found " . $receivedInvitationDrive->getName(),
         );
     }
 
@@ -412,7 +412,7 @@ class DriveTest extends OcisPhpSdkTestCase
                 "id" => "312c0871-5ef7-4b3a-85b6-0e4074c64049",
                 "description" => "Allows managing a space",
                 "displayName" => "Manager",
-                "@libre.graph.weight" => 3
+                "@libre.graph.weight" => 3,
             ];
 
             $shareRoles = [new SharingRole(new UnifiedRoleDefinition($role))];
@@ -440,13 +440,13 @@ class DriveTest extends OcisPhpSdkTestCase
         $this->assertSame(
             $this->drive->getName(),
             $receivedInvitationDrive->getName(),
-            "Expected shared drive name to be " . $this->drive->getName() . " but found " . $receivedInvitationDrive->getName()
+            "Expected shared drive name to be " . $this->drive->getName() . " but found " . $receivedInvitationDrive->getName(),
         );
         $this->assertSame(
             'myfolder',
             $receivedInvitationDrive->getResources()[0]->getName(),
             "Expected resource name to be myfolder"
-            . " but found " . $receivedInvitationDrive->getResources()[0]->getName()
+            . " but found " . $receivedInvitationDrive->getResources()[0]->getName(),
         );
     }
 
@@ -476,7 +476,7 @@ class DriveTest extends OcisPhpSdkTestCase
                 "id" => "312c0871-5ef7-4b3a-85b6-0e4074c64049",
                 "description" => "Allows managing a space",
                 "displayName" => "Manager",
-                "@libre.graph.weight" => 3
+                "@libre.graph.weight" => 3,
             ];
 
             $shareRoles = [new SharingRole(new UnifiedRoleDefinition($role))];
@@ -514,7 +514,7 @@ class DriveTest extends OcisPhpSdkTestCase
                     ),
                     "Expected drivename to be either:"
                 . "'katherine Project Drive' or 'test drive' but found "
-                . $drive->getName()
+                . $drive->getName(),
                 );
             }
         }
@@ -559,14 +559,14 @@ class DriveTest extends OcisPhpSdkTestCase
             $this->drive->getId(),
             $marieReceivedProjectDrive->getId(),
             "Expected driveId to be " . $this->drive->getId()
-            . " but found " . $marieReceivedProjectDrive->getId()
+            . " but found " . $marieReceivedProjectDrive->getId(),
         );
         $marieReceivedProjectDrive->invite($katherine, $managerRole);
         $katherineReceivedProjectDrive = $katherineOcis->getDriveById($this->drive->getId());
         $this->assertSame(
             $this->drive->getName(),
             $katherineReceivedProjectDrive->getName(),
-            "Expected shared drive name to be " . $this->drive->getName() . " but found " . $katherineReceivedProjectDrive->getName()
+            "Expected shared drive name to be " . $this->drive->getName() . " but found " . $katherineReceivedProjectDrive->getName(),
         );
     }
 

--- a/tests/integration/Owncloud/OcisPhpSdk/GroupsTest.php
+++ b/tests/integration/Owncloud/OcisPhpSdk/GroupsTest.php
@@ -22,7 +22,7 @@ class GroupsTest extends OcisPhpSdkTestCase
         $userName = $users[0]->getDisplayName();
         $philosophyHatersGroup =  $ocis->createGroup(
             "philosophyhaters",
-            "philosophy haters group"
+            "philosophy haters group",
         );
         $this->createdGroups = [$philosophyHatersGroup];
         $philosophyHatersGroup->addUser($users[0]);
@@ -34,13 +34,13 @@ class GroupsTest extends OcisPhpSdkTestCase
                 $group->getMembers(),
                 "The group " . $group->getDisplayName()
                 . " should have 1 member but found "
-                . count($group->getMembers()) . " members"
+                . count($group->getMembers()) . " members",
             );
             $this->assertSame(
                 $userName,
                 $group->getMembers()[0]->getDisplayName(),
                 $userName . " user be the first member" . $group->getDisplayName() . " group but found "
-                . $group->getMembers()[0]->getDisplayName()
+                . $group->getMembers()[0]->getDisplayName(),
             );
         }
     }
@@ -55,7 +55,7 @@ class GroupsTest extends OcisPhpSdkTestCase
         $users = $ocis->getUsers();
         $philosophyHatersGroup =  $ocis->createGroup(
             "philosophyhaters",
-            "philosophy haters group"
+            "philosophy haters group",
         );
         $this->createdGroups = [$philosophyHatersGroup];
         foreach ($users as $user) {
@@ -75,13 +75,13 @@ class GroupsTest extends OcisPhpSdkTestCase
             count($createdGroup[0]->getMembers()),
             "Expected " . ($initialMemberCount - 1)
             . " group member(s) but got "
-            . count($createdGroup[0]->getMembers())
+            . count($createdGroup[0]->getMembers()),
         );
         $this->assertSame(
             $adminUserName,
             $createdGroup[0]->getMembers()[0]->getDisplayName(),
             "Username of group member should be "
-            . $adminUserName . " but found " . $createdGroup[0]->getMembers()[0]->getDisplayName()
+            . $adminUserName . " but found " . $createdGroup[0]->getMembers()[0]->getDisplayName(),
         );
     }
 
@@ -96,7 +96,7 @@ class GroupsTest extends OcisPhpSdkTestCase
         $users = $ocis->getUsers();
         $philosophyHatersGroup =  $ocis->createGroup(
             "philosophyhaters",
-            "philosophy haters group"
+            "philosophy haters group",
         );
         $this->createdGroups = [$philosophyHatersGroup];
         foreach ($users as $user) {
@@ -125,7 +125,7 @@ class GroupsTest extends OcisPhpSdkTestCase
         $users = $ocis->getUsers('admin');
         $philosophyHatersGroup =  $ocis->createGroup(
             "philosophyhaters",
-            "philosophy haters group"
+            "philosophy haters group",
         );
         $this->createdGroups = [$philosophyHatersGroup];
         $philosophyHatersGroup->removeUser($users[0]);
@@ -140,7 +140,7 @@ class GroupsTest extends OcisPhpSdkTestCase
         $ocis = $this->getOcis('admin', 'admin');
         $philosophyHatersGroup =  $ocis->createGroup(
             "philosophyhaters",
-            "philosophy haters group"
+            "philosophy haters group",
         );
         $this->createdGroups = [$philosophyHatersGroup];
         $user = new User(
@@ -149,7 +149,7 @@ class GroupsTest extends OcisPhpSdkTestCase
                 "display_name" => "displayname",
                 "mail" => "mail@mail.com",
                 "on_premises_sam_account_name" => "sd",
-            ]
+            ],
         );
         $sdkUser = new \Owncloud\OcisPhpSdk\User($user);
         $groups = $ocis->getGroups(search:"philosophyhaters");
@@ -186,24 +186,24 @@ class GroupsTest extends OcisPhpSdkTestCase
         $ocis = $this->getOcis('admin', 'admin');
         $philosophyHatersGroup =  $ocis->createGroup(
             "philosophyhaters",
-            "philosophy haters group"
+            "philosophy haters group",
         );
         $physicsLoversGroup = $ocis->createGroup(
             "physicslovers",
-            "physics lover group"
+            "physics lover group",
         );
         $philosophyHatersGroup->delete();
         $this->createdGroups = [$physicsLoversGroup];
         $this->assertCount(
             1,
             $ocis->getGroups(),
-            "Expected one group but found " . count($ocis->getGroups())
+            "Expected one group but found " . count($ocis->getGroups()),
         );
         $this->assertSame(
             "physicslovers",
             $ocis->getGroups()[0]->getDisplayName(),
             "Group should be deleted but exists "
-            . $ocis->getGroups()[0]->getDisplayName()
+            . $ocis->getGroups()[0]->getDisplayName(),
         );
 
     }
@@ -221,14 +221,14 @@ class GroupsTest extends OcisPhpSdkTestCase
         $this->assertCount(
             1,
             $groups,
-            "Expected one group but found " . count($groups)
+            "Expected one group but found " . count($groups),
         );
         foreach ($groups as $group) {
             $this->assertInstanceOf(
                 Group::class,
                 $group,
                 "Expected class " . Group::class
-                . " but got " . get_class($group)
+                . " but got " . get_class($group),
             );
             $this->assertIsString($group->getId());
             $this->assertIsString($group->getDisplayName());

--- a/tests/integration/Owncloud/OcisPhpSdk/NotificationTest.php
+++ b/tests/integration/Owncloud/OcisPhpSdk/NotificationTest.php
@@ -51,23 +51,23 @@ class NotificationTest extends OcisPhpSdkTestCase
         $this->assertContainsOnlyInstancesOf(
             Notification::class,
             $notifications,
-            "Array is not instance of " . Notification::class
+            "Array is not instance of " . Notification::class,
         );
         $this->assertCount(
             1,
             $notifications,
-            "Expected one notification but received " . count($notifications)
+            "Expected one notification but received " . count($notifications),
         );
         $this->assertSame(
             $sharerUser[0]->getDisplayName() .
             " shared to-share-test.txt with you",
             $notifications[0]->getMessage(),
-            "Wrong Notification received"
+            "Wrong Notification received",
         );
         $this->assertMatchesRegularExpression(
             '/' . $this->getUUIDv4Regex() . '/i',
             $notifications[0]->getId(),
-            "Incorrect Format of Notifications received"
+            "Incorrect Format of Notifications received",
         );
     }
 
@@ -79,7 +79,7 @@ class NotificationTest extends OcisPhpSdkTestCase
         $this->assertCount(
             count($notifications) - 1,
             $notificationsAfterDeletion,
-            "Notification should be deleted but exists"
+            "Notification should be deleted but exists",
         );
         $this->assertNotEquals($notifications, $notificationsAfterDeletion, "Deleted notification still exists");
     }

--- a/tests/integration/Owncloud/OcisPhpSdk/OcisPhpSdkTestCase.php
+++ b/tests/integration/Owncloud/OcisPhpSdk/OcisPhpSdkTestCase.php
@@ -90,7 +90,7 @@ class OcisPhpSdkTestCase extends TestCase
         }
         $guzzleClient = new Client([
             'base_uri' => $this->ocisUrl,
-            'verify' => false
+            'verify' => false,
         ]);
         $this->guzzleClient = $guzzleClient;
         return $this->guzzleClient;
@@ -99,15 +99,15 @@ class OcisPhpSdkTestCase extends TestCase
     protected function getAccessToken(string $username, string $password): string
     {
         $guzzleClient = $this->getGuzzleClient();
-        $response = $guzzleClient->post((string)$this->tokenUrl, [
+        $response = $guzzleClient->post((string) $this->tokenUrl, [
             'form_params' => [
                 'grant_type' => 'password',
                 'client_id' => self::CLIENT_ID,
                 'client_secret' => self::CLIENT_SECRET,
                 'username' => $username,
                 'password' => $password,
-                'scope' => 'openid profile email offline_access'
-            ]
+                'scope' => 'openid profile email offline_access',
+            ],
         ]);
         $accessTokenResponse = json_decode($response->getBody()->getContents(), true);
         if ($accessTokenResponse === null) {
@@ -183,7 +183,7 @@ class OcisPhpSdkTestCase extends TestCase
         return $ocis->getMyDrives(
             DriveOrder::NAME,
             OrderDirection::ASC,
-            DriveType::PERSONAL
+            DriveType::PERSONAL,
         )[0];
     }
 
@@ -224,7 +224,7 @@ class OcisPhpSdkTestCase extends TestCase
         $response = self::getWrapperGuzzleClient()->request(
             'PUT',
             '/config',
-            ['body' => '{"' . $key . '": "' . $value . '"}']
+            ['body' => '{"' . $key . '": "' . $value . '"}'],
         );
         if ($response->getStatusCode() !== 200) {
             throw new \Exception('Failed to set OCIS setting');
@@ -235,7 +235,7 @@ class OcisPhpSdkTestCase extends TestCase
     {
         $response = self::getWrapperGuzzleClient()->request(
             'DELETE',
-            '/rollback'
+            '/rollback',
         );
         if ($response->getStatusCode() !== 200) {
             throw new \Exception('Failed to reset OCIS settings');
@@ -252,7 +252,7 @@ class OcisPhpSdkTestCase extends TestCase
      * @throws \Exception
      */
     protected static function getPermissionsRoleIdByName(
-        string $permissionsRole
+        string $permissionsRole,
     ): string {
         switch ($permissionsRole) {
             case 'Viewer':

--- a/tests/integration/Owncloud/OcisPhpSdk/OcisResourceTest.php
+++ b/tests/integration/Owncloud/OcisPhpSdk/OcisResourceTest.php
@@ -48,7 +48,7 @@ class OcisResourceTest extends OcisPhpSdkTestCase
             $mountpoints = $ocis->getMyDrives(
                 DriveOrder::NAME,
                 OrderDirection::ASC,
-                DriveType::MOUNTPOINT
+                DriveType::MOUNTPOINT,
             );
             if (count($mountpoints) === 0) {
                 sleep(1);
@@ -86,94 +86,94 @@ class OcisResourceTest extends OcisPhpSdkTestCase
         $this->assertCount(
             4,
             $resources,
-            "Expected 4 resources but found " . count($resources)
+            "Expected 4 resources but found " . count($resources),
         );
 
         foreach ($resources as $resource) {
             $this->assertMatchesRegularExpression(
                 "/^" . $this->getFileIdRegex() . "$/i",
                 $resource->getId(),
-                "ResourceId doesn't match the expected format"
+                "ResourceId doesn't match the expected format",
             );
             $this->assertMatchesRegularExpression(
                 "/^\"[a-f0-9:.]{1,32}\"$/",
                 $resource->getEtag(),
-                "Resource Etag doesn't match the expected format"
+                "Resource Etag doesn't match the expected format",
             );
             $this->assertMatchesRegularExpression(
                 "?^" . $this->ocisUrl . '/f/' . $this->getFileIdRegex() . "$?i",
                 $resource->getPrivatelink(),
-                "Private Link of resource doesn't match the expected format"
+                "Private Link of resource doesn't match the expected format",
             );
             $this->assertThat(
                 $resource->getType(),
                 $this->logicalOr(
                     $this->equalTo("file"),
-                    $this->equalTo("folder")
+                    $this->equalTo("folder"),
                 ),
-                "Expected resource type be either file or folder but found " . $resource->getType()
+                "Expected resource type be either file or folder but found " . $resource->getType(),
             );
 
             $this->assertMatchesRegularExpression(
                 "/^" . $this->getSpaceIdRegex() . "$/i",
                 $resource->getSpaceId(),
-                "SpaceId doesn't match the expected format"
+                "SpaceId doesn't match the expected format",
             );
             $this->assertMatchesRegularExpression(
                 "/^" . $this->getFileIdRegex() . "$/i",
                 $resource->getParent(),
-                "Resource Parent doesn't match the expected format"
+                "Resource Parent doesn't match the expected format",
             );
             $this->assertThat(
                 $resource->getPermission(),
                 $this->logicalOr(
                     $this->equalTo("RDNVWZP"),
-                    $this->equalTo("RDNVCKZP")
+                    $this->equalTo("RDNVCKZP"),
                 ),
-                "Permission doesn't match"
+                "Permission doesn't match",
             );
 
             $this->assertEqualsWithDelta(
                 strtotime("now"),
                 strtotime($resource->getLastModifiedTime()),
                 60,
-                "Resources wasn't modified within 60 seconds"
+                "Resources wasn't modified within 60 seconds",
             );
             if ($resource->getType() === 'folder') {
                 $this->assertSame(
                     '',
                     $resource->getContentType(),
-                    "Expected content type be empty but found " . $resource->getContentType()
+                    "Expected content type be empty but found " . $resource->getContentType(),
                 );
             } else {
                 $this->assertSame(
                     'text/plain',
                     $resource->getContentType(),
-                    "Expected content type be text/plain but found " . $resource->getContentType()
+                    "Expected content type be text/plain but found " . $resource->getContentType(),
                 );
             }
 
             $this->assertFalse(
                 $resource->isFavorited(),
-                "Resource is not expected to be favorited"
+                "Resource is not expected to be favorited",
             );
             $this->assertSame(
                 [],
                 $resource->getTags(),
-                "Expected resource tag be empty array but found " . count($resource->getTags()) . " elements"
+                "Expected resource tag be empty array but found " . count($resource->getTags()) . " elements",
             );
             $this->assertIsInt(
                 $resource->getSize(),
-                "Expected resource size be of type integer but found " . getType($resource->getSize())
+                "Expected resource size be of type integer but found " . getType($resource->getSize()),
             );
             if ($resource->getType() === 'folder') {
                 $this->assertThat(
                     $resource->getName(),
                     $this->logicalOr(
                         $this->equalTo("subfolder"),
-                        $this->equalTo("secondfolder")
+                        $this->equalTo("secondfolder"),
                     ),
-                    "Expected resource name be subfolder or secondfolder but found " . $resource->getName()
+                    "Expected resource name be subfolder or secondfolder but found " . $resource->getName(),
                 );
             } else {
                 $this->assertStringContainsString('file.txt', $resource->getName());
@@ -196,21 +196,21 @@ class OcisResourceTest extends OcisPhpSdkTestCase
                     $this->assertSame(
                         'some content',
                         $content,
-                        "File content doesn't match"
+                        "File content doesn't match",
                     );
                     break;
                 case 'secondfile.txt':
                     $this->assertSame(
                         'some other content',
                         $content,
-                        "File content doesn't match"
+                        "File content doesn't match",
                     );
                     break;
                 case 'subfolder':
                     $this->assertSame(
                         '',
                         $content,
-                        "Expected folder be empty but found " . $content
+                        "Expected folder be empty but found " . $content,
                     );
                     break;
             }
@@ -248,21 +248,21 @@ class OcisResourceTest extends OcisPhpSdkTestCase
                     $this->assertSame(
                         'some content',
                         $content,
-                        "File content doesn't match"
+                        "File content doesn't match",
                     );
                     break;
                 case 'secondfile.txt':
                     $this->assertSame(
                         'some other content',
                         $content,
-                        "File content doesn't match"
+                        "File content doesn't match",
                     );
                     break;
                 case 'subfolder':
                     $this->assertSame(
                         '',
                         $content,
-                        "Expected folder be empty but found " . $content
+                        "Expected folder be empty but found " . $content,
                     );
                     break;
             }
@@ -276,18 +276,18 @@ class OcisResourceTest extends OcisPhpSdkTestCase
         $this->assertCount(
             1,
             $resources,
-            "Expected one resource but found " . count($resources)
+            "Expected one resource but found " . count($resources),
         );
         $this->assertSame(
             'uploaded.txt',
             $resources[0]->getName(),
-            "Expected 'uploaded.txt' file but found " . $resources[0]->getName()
+            "Expected 'uploaded.txt' file but found " . $resources[0]->getName(),
         );
         $content = $this->getContentOfResource425Save($resources[0]);
         $this->assertSame(
             'some content',
             $content,
-            "File content doesn't match"
+            "File content doesn't match",
         );
     }
 
@@ -299,18 +299,18 @@ class OcisResourceTest extends OcisPhpSdkTestCase
         $this->assertCount(
             1,
             $resources,
-            "Expected one resource but found " . count($resources)
+            "Expected one resource but found " . count($resources),
         );
         $this->assertSame(
             'uploaded.txt',
             $resources[0]->getName(),
-            "Expected 'uploaded.txt' file but found " . $resources[0]->getName()
+            "Expected 'uploaded.txt' file but found " . $resources[0]->getName(),
         );
         $content = $this->getContentOfResource425Save($resources[0]);
         $this->assertSame(
             'new content',
             $content,
-            "File content doesn't match"
+            "File content doesn't match",
         );
     }
 
@@ -333,18 +333,18 @@ class OcisResourceTest extends OcisPhpSdkTestCase
         $this->assertCount(
             1,
             $resources,
-            "Expected one resource but found " . count($resources)
+            "Expected one resource but found " . count($resources),
         );
         $this->assertSame(
             'uploaded.txt',
             $resources[0]->getName(),
-            "Expected 'uploaded.txt' file but found " . $resources[0]->getName()
+            "Expected 'uploaded.txt' file but found " . $resources[0]->getName(),
         );
         $content = $this->getContentOfResource425Save($resources[0]);
         $this->assertSame(
             'some content',
             $content,
-            "File content doesn't match"
+            "File content doesn't match",
         );
     }
 
@@ -387,18 +387,18 @@ class OcisResourceTest extends OcisPhpSdkTestCase
         $this->assertCount(
             1,
             $resources,
-            "Expected one resource but found " . count($resources)
+            "Expected one resource but found " . count($resources),
         );
         $this->assertSame(
             'uploaded.txt',
             $resources[0]->getName(),
-            "Expected 'uploaded.txt' file but found " . $resources[0]->getName()
+            "Expected 'uploaded.txt' file but found " . $resources[0]->getName(),
         );
         $content = $this->getContentOfResource425Save($resources[0]);
         $this->assertSame(
             'some content',
             $content,
-            "File content doesn't match"
+            "File content doesn't match",
         );
     }
 
@@ -410,7 +410,7 @@ class OcisResourceTest extends OcisPhpSdkTestCase
     {
         return [
             ['somefile.txt','file'],
-            ['secondfolder','folder']
+            ['secondfolder','folder'],
         ];
     }
     /**
@@ -427,14 +427,14 @@ class OcisResourceTest extends OcisPhpSdkTestCase
         $this->assertCount(
             1,
             $resourceInsideFolder,
-            "Expected one resources but found " . count($resourceInsideFolder)
+            "Expected one resources but found " . count($resourceInsideFolder),
         );
 
         $rootResourcesAfterMove = $this->personalDrive->getResources();
         $this->assertCount(
             count($rootResources) - 1,
             $rootResourcesAfterMove,
-            "Resource wasn't moved inside the folder"
+            "Resource wasn't moved inside the folder",
         );
 
         foreach ($rootResourcesAfterMove as $resource) {
@@ -446,7 +446,7 @@ class OcisResourceTest extends OcisPhpSdkTestCase
             $this->assertSame(
                 'some content',
                 $fileContent,
-                "File content doesn't match"
+                "File content doesn't match",
             );
         }
     }
@@ -458,7 +458,7 @@ class OcisResourceTest extends OcisPhpSdkTestCase
     {
         return [
             ['nonExistentFile.txt'],
-            ['nonExistentFile']
+            ['nonExistentFile'],
         ];
     }
     /**
@@ -479,7 +479,7 @@ class OcisResourceTest extends OcisPhpSdkTestCase
             $this->assertContainsOnlyInstancesOf(
                 SharingRole::class,
                 $role,
-                "Array contains not only 'SharingRole' items"
+                "Array contains not only 'SharingRole' items",
             );
         }
     }

--- a/tests/integration/Owncloud/OcisPhpSdk/OcisTest.php
+++ b/tests/integration/Owncloud/OcisPhpSdk/OcisTest.php
@@ -21,7 +21,7 @@ class OcisTest extends OcisPhpSdkTestCase
         $this->assertTrue(
             (is_array($drives) && count($drives) > 1),
             "Drives variable is expected to be an array but found to be " . gettype($drives) .
-        " and to have more than one element but found " . count($drives)
+        " and to have more than one element but found " . count($drives),
         );
     }
 
@@ -46,7 +46,7 @@ class OcisTest extends OcisPhpSdkTestCase
         }
         if (empty($sharedResource)) {
             throw new \Error(
-                "resource not found "
+                "resource not found ",
             );
         }
         $marie = $adminOcis->getUsers('marie')[0];
@@ -61,7 +61,7 @@ class OcisTest extends OcisPhpSdkTestCase
 
         if (empty($viewerRole)) {
             throw new \Error(
-                "viewer role not found "
+                "viewer role not found ",
             );
         }
         $sharedResource->invite($marie, $viewerRole);
@@ -70,19 +70,19 @@ class OcisTest extends OcisPhpSdkTestCase
         $this->assertContainsOnlyInstancesOf(
             Drive::class,
             $marieDrive,
-            "Expected Array to be an instance of " . Drive::class
+            "Expected Array to be an instance of " . Drive::class,
         );
         foreach ($marieDrive as $drive) {
             $this->assertNotSame(
                 'Admin Project Drive',
                 $drive->getName(),
-                $drive->getName() . " drive of Marie matches with admin drive "
+                $drive->getName() . " drive of Marie matches with admin drive ",
             );
             if ($drive->getType() === DriveType::MOUNTPOINT) {
                 $this->assertSame(
                     'sharedAdminFolder',
                     $drive->getName(),
-                    "Expected foldername to be 'sharedAdminFolder' but found " . $drive->getName()
+                    "Expected foldername to be 'sharedAdminFolder' but found " . $drive->getName(),
                 );
             }
         }
@@ -114,7 +114,7 @@ class OcisTest extends OcisPhpSdkTestCase
 
         if (empty($sharedResource)) {
             throw new \Error(
-                "resource not found "
+                "resource not found ",
             );
         }
 
@@ -130,7 +130,7 @@ class OcisTest extends OcisPhpSdkTestCase
 
         if (empty($viewerRole)) {
             throw new \Error(
-                "viewer role not found "
+                "viewer role not found ",
             );
         }
         $sharedResource->invite($katherine, $viewerRole);
@@ -140,7 +140,7 @@ class OcisTest extends OcisPhpSdkTestCase
             $this->assertInstanceOf(
                 Drive::class,
                 $drive,
-                "Expected class to be 'Drive' but found " . get_class($drive)
+                "Expected class to be 'Drive' but found " . get_class($drive),
             );
             $this->assertThat(
                 $drive->getType(),
@@ -150,7 +150,7 @@ class OcisTest extends OcisPhpSdkTestCase
                     $this->equalTo(DriveType::VIRTUAL),
                 ),
                 "Expected drivetype to be either 'PROJECT' or 'PERSONAL' or 'VIRTUAL' but found "
-                . print_r($drive->getType(), true)
+                . print_r($drive->getType(), true),
             );
             if ($drive->getType() === DriveType::PROJECT) {
                 $this->assertThat(
@@ -162,14 +162,14 @@ class OcisTest extends OcisPhpSdkTestCase
                     ),
                     "Expected drivename to be either:"
                     . "'katherine Project Drive' or 'Sport Project Drive' or 'Management Project Drive' but found "
-                    . $drive->getName()
+                    . $drive->getName(),
                 );
             }
             if ($drive->getType() === DriveType::MOUNTPOINT) {
                 $this->assertSame(
                     'sharedAdminFolder',
                     $drive->getName(),
-                    "Expected foldername to be 'sharedAdminFolder' but found " . $drive->getName()
+                    "Expected foldername to be 'sharedAdminFolder' but found " . $drive->getName(),
                 );
             }
         }
@@ -208,7 +208,7 @@ class OcisTest extends OcisPhpSdkTestCase
             $adminPersonalDrive = $adminOcis -> getMyDrives(
                 DriveOrder::NAME,
                 OrderDirection::ASC,
-                DriveType::PERSONAL
+                DriveType::PERSONAL,
             )[0];
 
             $adminPersonalDrive->createFolder('sharedAdminFolder');
@@ -222,7 +222,7 @@ class OcisTest extends OcisPhpSdkTestCase
             }
             if (empty($sharedResource)) {
                 throw new \Error(
-                    "resource not found "
+                    "resource not found ",
                 );
             }
 
@@ -238,7 +238,7 @@ class OcisTest extends OcisPhpSdkTestCase
 
             if (empty($viewerRole)) {
                 throw new \Error(
-                    "viewer role not found "
+                    "viewer role not found ",
                 );
             }
 
@@ -248,18 +248,18 @@ class OcisTest extends OcisPhpSdkTestCase
         $drives = $adminOcis->getAllDrives(
             DriveOrder::NAME,
             OrderDirection::ASC,
-            $driveType
+            $driveType,
         );
         $this->assertContainsOnlyInstancesOf(
             Drive::class,
             $drives,
-            "Expected Array to be an instance of " . Drive::class
+            "Expected Array to be an instance of " . Drive::class,
         );
         foreach ($drives as $drive) {
             $this->assertSame(
                 $drive->getType(),
                 $driveType,
-                "Drivetype mismatch"
+                "Drivetype mismatch",
             );
             if ($drive->getType() === DriveType::PROJECT) {
                 $this->assertThat(
@@ -268,24 +268,24 @@ class OcisTest extends OcisPhpSdkTestCase
                         // @phpstan-ignore-next-line because the test is skipped
                         $this->equalTo($managementDrive->getName()),
                         // @phpstan-ignore-next-line because the test is skipped
-                        $this->equalTo($sportDrive->getName())
+                        $this->equalTo($sportDrive->getName()),
                     ),
                     "Expected drivename to be either 'Management Project Drive' or 'Sport Project Drive' but found "
-                    . $drive->getName()
+                    . $drive->getName(),
                 );
             }
             if ($drive->getType() === DriveType::MOUNTPOINT) {
                 $this->assertSame(
                     'sharedAdminFolder',
                     $drive->getName(),
-                    "Expected drivename to be 'sharedAdminFolder' but found " . $drive->getName()
+                    "Expected drivename to be 'sharedAdminFolder' but found " . $drive->getName(),
                 );
             }
             if ($drive->getType() === DriveType::VIRTUAL) {
                 $this->assertSame(
                     'Shares',
                     $drive->getName(),
-                    "Expected drivename to be 'Shares' but found " . $drive->getName()
+                    "Expected drivename to be 'Shares' but found " . $drive->getName(),
                 );
             }
         }
@@ -300,32 +300,32 @@ class OcisTest extends OcisPhpSdkTestCase
         $this->assertInstanceOf(
             Drive::class,
             $drive,
-            "Expected class to be 'Drive' but found " . get_class($drive)
+            "Expected class to be 'Drive' but found " . get_class($drive),
         );
         $this->assertSame(
             $drive->getId(),
             $sportDrive->getId(),
             "Expected driveid to be " . $drive->getId()
-            . " but found " . $sportDrive->getId()
+            . " but found " . $sportDrive->getId(),
         );
         $this->assertSame(
             $drive->getName(),
             $sportDrive->getName(),
-            "Expect drivename to be " . $drive->getName() .  " but found " . $sportDrive->getName()
+            "Expect drivename to be " . $drive->getName() . " but found " . $sportDrive->getName(),
         );
         $this->assertSame(
             $drive->getType(),
             $sportDrive->getType(),
-            "Drivetype mismatch"
+            "Drivetype mismatch",
         );
         $this->assertEquals(
             $drive->getRoot(),
             $sportDrive->getRoot(),
             "Expected drive root to be " . $drive->getRoot()
-            . " but found " . $sportDrive->getRoot()
+            . " but found " . $sportDrive->getRoot(),
         );
         $this->markTestIncomplete(
-            'libre graph issue-149 sends broken quota object while creating drive'
+            'libre graph issue-149 sends broken quota object while creating drive',
         );
         //  $this->assertSame($sportDrive, $drive);
     }
@@ -334,21 +334,21 @@ class OcisTest extends OcisPhpSdkTestCase
     {
         $ocis = $this->getOcis('admin', 'admin');
         $countDrivesAtStart = count(
-            $ocis->getMyDrives()
+            $ocis->getMyDrives(),
         );
         $drive = $ocis->createDrive('first test drive');
         $this->createdDrives[] = $drive->getId();
         $this->assertMatchesRegularExpression(
             "/^" . $this->getUUIDv4Regex() . '\$' . $this->getUUIDv4Regex() . "$/i",
             $drive->getId(),
-            "Driveid doesn't match the expected format"
+            "Driveid doesn't match the expected format",
         );
         // there should be one more drive
         $this->assertCount(
             $countDrivesAtStart + 1,
             $ocis->getMyDrives(),
             "Expected drive count to be " . ($countDrivesAtStart + 1)
-            . " but found " . count($ocis->getMyDrives())
+            . " but found " . count($ocis->getMyDrives()),
         );
     }
 
@@ -412,36 +412,36 @@ class OcisTest extends OcisPhpSdkTestCase
         $this->assertCount(
             2,
             $groups,
-            "Expected group to be 2 but found " . count($groups)
+            "Expected group to be 2 but found " . count($groups),
         );
         foreach ($groups as $group) {
             $this->assertInstanceOf(
                 Group::class,
                 $group,
-                "Expected class to be 'Group' but found " . get_class($group)
+                "Expected class to be 'Group' but found " . get_class($group),
             );
             $this->assertIsString(
                 $group->getId(),
-                "Expected groupId to be string but found " . gettype($group->getId())
+                "Expected groupId to be string but found " . gettype($group->getId()),
             );
             $this->assertIsString(
                 $group->getDisplayName(),
-                "Expected groupname type to be string but found " . gettype($group->getDisplayName())
+                "Expected groupname type to be string but found " . gettype($group->getDisplayName()),
             );
             $this->assertIsArray(
                 $group->getGroupTypes(),
-                "Expected grouptype to be Array but found " . gettype($group->getGroupTypes())
+                "Expected grouptype to be Array but found " . gettype($group->getGroupTypes()),
             );
             $this->assertIsArray(
                 $group->getMembers(),
-                "Expected group members type to be Array but found " . gettype($group->getMembers())
+                "Expected group members type to be Array but found " . gettype($group->getMembers()),
             );
         }
         $groupDisplayName = [$philosophyHatersGroup->getDisplayName(),$physicsLoversGroup->getDisplayName()];
         $this->assertTrue(
             $groupDisplayName === [$groupName[0],$groupName[1]],
             "Expected group displayname to be $groupName[0] and $groupName[1] but found "
-            . implode(' and ', $groupDisplayName)
+            . implode(' and ', $groupDisplayName),
         );
     }
 
@@ -458,13 +458,13 @@ class OcisTest extends OcisPhpSdkTestCase
         $this->assertCount(
             1,
             $groups,
-            "Expected group count to be 1 but found " . count($groups)
+            "Expected group count to be 1 but found " . count($groups),
         );
         foreach ($groups as $group) {
             $this->assertGreaterThan(
                 0,
                 count($group->getMembers()),
-                "Expected member count to be greater than 0 but found " . count($group->getMembers())
+                "Expected member count to be greater than 0 but found " . count($group->getMembers()),
             );
         }
     }
@@ -496,14 +496,14 @@ class OcisTest extends OcisPhpSdkTestCase
         $this->assertCount(
             count($groupDisplayName),
             $groups,
-            "Group count doesn't match "
+            "Group count doesn't match ",
         );
         for ($i = 0; $i < count($groups); $i++) {
             $this->assertSame(
                 $groupDisplayName[$i],
                 $groups[$i]->getDisplayName(),
                 "Expected group display name to be " . $groupDisplayName[$i]
-                . " but found " . $groups[$i]->getDisplayName()
+                . " but found " . $groups[$i]->getDisplayName(),
             );
         }
     }
@@ -515,7 +515,7 @@ class OcisTest extends OcisPhpSdkTestCase
     {
         return [
             [OrderDirection::ASC, "ph", ["philosophyhaters", "physicslovers"]],
-            [OrderDirection::DESC, "ph", ["physicslovers", "philosophyhaters"]]
+            [OrderDirection::DESC, "ph", ["physicslovers", "philosophyhaters"]],
         ];
     }
 
@@ -537,14 +537,14 @@ class OcisTest extends OcisPhpSdkTestCase
         $this->assertCount(
             count($resultGroups),
             $groups,
-            "Expected group count to be " . count($resultGroups) . " but found " . count($groups)
+            "Expected group count to be " . count($resultGroups) . " but found " . count($groups),
         );
         for ($i = 0; $i < count($groups); $i++) {
             $this->assertSame(
                 $resultGroups[$i],
                 $groups[$i]->getDisplayName(),
                 "Expected group display name to be " . $resultGroups[$i]
-                . " but found " . $groups[$i]->getDisplayName()
+                . " but found " . $groups[$i]->getDisplayName(),
             );
         }
     }
@@ -565,12 +565,12 @@ class OcisTest extends OcisPhpSdkTestCase
         $this->assertCount(
             1,
             $ocis->getGroups(),
-            "Expected group count to be 1 but found " . count($ocis->getGroups())
+            "Expected group count to be 1 but found " . count($ocis->getGroups()),
         );
         $this->assertSame(
             "physicslovers",
             $ocis->getGroups()[0]->getDisplayName(),
-            "Expected group display name to be 'physicslovers' but found " . $ocis->getGroups()[0]->getDisplayName()
+            "Expected group display name to be 'physicslovers' but found " . $ocis->getGroups()[0]->getDisplayName(),
         );
         $this->createdGroups = [$physicsLoversGroup];
     }
@@ -587,29 +587,29 @@ class OcisTest extends OcisPhpSdkTestCase
             $expectedResource->getId(),
             $resource->getId(),
             "Expected resource id to be " . $expectedResource->getId()
-            . " but found " . $resource->getId()
+            . " but found " . $resource->getId(),
         );
         $this->assertSame(
             'somefile.txt',
             $resource->getName(),
-            "Expected resource name to be 'somefile.txt' but found " . $resource->getName()
+            "Expected resource name to be 'somefile.txt' but found " . $resource->getName(),
         );
         $this->assertSame(
             'file',
             $resource->getType(),
-            "Expected resource type to be 'file' but found " . $resource->getType()
+            "Expected resource type to be 'file' but found " . $resource->getType(),
         );
         $this->assertSame(
             12,
             $resource->getSize(),
-            "Expected resource size to be 12 but found " . $resource->getSize()
+            "Expected resource size to be 12 but found " . $resource->getSize(),
         );
         $content = $this->getContentOfResource425Save($resource);
         $this->assertSame('some content', $content, "File content doesn't match");
         $this->assertSame(
             $personalDrive->getId(),
             $resource->getSpaceId(),
-            "Drive id doesn't match with the space id of the resource"
+            "Drive id doesn't match with the space id of the resource",
         );
     }
 
@@ -625,32 +625,32 @@ class OcisTest extends OcisPhpSdkTestCase
             $expectedResource->getId(),
             $resource->getId(),
             "Expected resource id to be " . $expectedResource->getId() . " but found "
-            . $resource->getId()
+            . $resource->getId(),
         );
         $this->assertSame(
             'myfolder',
             $resource->getName(),
-            "Expected resource name to be 'myfolder' but found " . $resource->getName()
+            "Expected resource name to be 'myfolder' but found " . $resource->getName(),
         );
         $this->assertSame(
             'folder',
             $resource->getType(),
-            "Expected resource type to be 'folder' but found " . $resource->getType()
+            "Expected resource type to be 'folder' but found " . $resource->getType(),
         );
         $this->assertSame(
             0,
             $resource->getSize(),
-            "Expected resource size to be 0 but found " . $resource->getSize()
+            "Expected resource size to be 0 but found " . $resource->getSize(),
         );
         $this->assertSame(
             '',
             $resource->getContent(),
-            "Expected resource isn't a folder"
+            "Expected resource isn't a folder",
         ); // getting a folder does not return any content
         $this->assertSame(
             $personalDrive->getId(),
             $resource->getSpaceId(),
-            "Drive id doesn't match with the space id of the resource"
+            "Drive id doesn't match with the space id of the resource",
         );
     }
 
@@ -667,32 +667,32 @@ class OcisTest extends OcisPhpSdkTestCase
             $expectedResource->getId(),
             $resource->getId(),
             "Expected resource id to be " . $expectedResource->getId() . " but found "
-            . $resource->getId()
+            . $resource->getId(),
         );
         $this->assertSame(
             'myfolder',
             $resource->getName(),
-            "Expected resource name to be 'myfolder' but found " . $resource->getName()
+            "Expected resource name to be 'myfolder' but found " . $resource->getName(),
         );
         $this->assertSame(
             'folder',
             $resource->getType(),
-            "Expected resource type to be 'folder' but found " . $resource->getType()
+            "Expected resource type to be 'folder' but found " . $resource->getType(),
         );
         $this->assertSame(
             12,
             $resource->getSize(),
-            "Expected resource size to be 12 but found " . $resource->getSize()
+            "Expected resource size to be 12 but found " . $resource->getSize(),
         );
         $this->assertSame(
             '',
             $resource->getContent(),
-            "Expected resource isn't a folder"
+            "Expected resource isn't a folder",
         ); // getting a folder does not return any content
         $this->assertSame(
             $personalDrive->getId(),
             $resource->getSpaceId(),
-            "Drive id doesn't match with the space id of the resource"
+            "Drive id doesn't match with the space id of the resource",
         );
     }
 
@@ -710,23 +710,23 @@ class OcisTest extends OcisPhpSdkTestCase
             $expectedResource->getId(),
             $resource->getId(),
             "Expected resource id to be " . $expectedResource->getId() . " but found "
-            . $resource->getId()
+            . $resource->getId(),
         );
 
         $this->assertSame(
             'somefile.txt',
             $resource->getName(),
-            "Expected resource name to be 'somefile.txt' but found " . $resource->getName()
+            "Expected resource name to be 'somefile.txt' but found " . $resource->getName(),
         );
         $this->assertSame(
             'file',
             $resource->getType(),
-            "Expected resource type to be 'file' but found " . $resource->getType()
+            "Expected resource type to be 'file' but found " . $resource->getType(),
         );
         $this->assertSame(
             12,
             $resource->getSize(),
-            "Expected resource size to be 12 but found " . $resource->getSize()
+            "Expected resource size to be 12 but found " . $resource->getSize(),
         );
         $content = $this->getContentOfResource425Save($resource);
 
@@ -734,7 +734,7 @@ class OcisTest extends OcisPhpSdkTestCase
         $this->assertSame(
             $personalDrive->getId(),
             $resource->getSpaceId(),
-            "Drive id doesn't match with the space id of the resource"
+            "Drive id doesn't match with the space id of the resource",
         );
     }
 

--- a/tests/integration/Owncloud/OcisPhpSdk/ResourceInviteTest.php
+++ b/tests/integration/Owncloud/OcisPhpSdk/ResourceInviteTest.php
@@ -70,18 +70,18 @@ class ResourceInviteTest extends OcisPhpSdkTestCase
         $this->assertSame(
             $this->fileToShare->getId(),
             $share->getResourceId(),
-            "ResourceId doesn't match with Shared ResourceId"
+            "ResourceId doesn't match with Shared ResourceId",
         );
         $receivedShares = $this->getSharedWithMeWaitTillShareIsAccepted($this->einsteinOcis);
         $this->assertCount(
             1,
             $receivedShares,
-            "Failed to share resource " . $this->fileToShare->getName() . " with Einstein"
+            "Failed to share resource " . $this->fileToShare->getName() . " with Einstein",
         );
         $this->assertSame(
             $this->fileToShare->getName(),
             $receivedShares[0]->getName(),
-            "Expected resource name to be " . $this->fileToShare->getName() . " but found " . $receivedShares[0]->getName()
+            "Expected resource name to be " . $this->fileToShare->getName() . " but found " . $receivedShares[0]->getName(),
         );
     }
 
@@ -92,19 +92,19 @@ class ResourceInviteTest extends OcisPhpSdkTestCase
         $this->assertSame(
             $this->fileToShare->getId(),
             $share->getResourceId(),
-            "ResourceId doesn't match with Shared ResourceId"
+            "ResourceId doesn't match with Shared ResourceId",
         );
         $receivedShares = $this->getSharedWithMeWaitTillShareIsAccepted($this->marieOcis);
         $this->assertCount(
             1,
             $receivedShares,
-            "Failed to share resource " . $this->fileToShare->getName() . " with Marie"
+            "Failed to share resource " . $this->fileToShare->getName() . " with Marie",
         );
         $this->assertSame(
             "to-share-test.txt",
             $receivedShares[0]->getName(),
             "Expected resource name to be " . $this->fileToShare->getName()
-            . " but found " . $receivedShares[0]->getName()
+            . " but found " . $receivedShares[0]->getName(),
         );
     }
 
@@ -112,7 +112,7 @@ class ResourceInviteTest extends OcisPhpSdkTestCase
     {
         $philosophyHatersGroup =  $this->ocis->createGroup(
             'philosophyhaters',
-            'philosophy haters group'
+            'philosophy haters group',
         );
         $this->createdGroups = [$philosophyHatersGroup];
         $philosophyHatersGroup->addUser($this->einstein);
@@ -120,19 +120,19 @@ class ResourceInviteTest extends OcisPhpSdkTestCase
         $this->assertSame(
             $this->fileToShare->getId(),
             $share->getResourceId(),
-            "ResourceId doesn't match with Shared ResourceId"
+            "ResourceId doesn't match with Shared ResourceId",
         );
         $receivedShares = $this->getSharedWithMeWaitTillShareIsAccepted($this->einsteinOcis);
         $this->assertCount(
             1,
             $receivedShares,
-            "Failed to share resource " . $this->fileToShare->getName() . " with group "
+            "Failed to share resource " . $this->fileToShare->getName() . " with group ",
         );
         $this->assertSame(
             $this->fileToShare->getName(),
             $receivedShares[0]->getName(),
             "Expected resource name to be " . $this->fileToShare->getName()
-            . " but found " . $receivedShares[0]->getName()
+            . " but found " . $receivedShares[0]->getName(),
         );
     }
 
@@ -159,32 +159,32 @@ class ResourceInviteTest extends OcisPhpSdkTestCase
             \DateTimeImmutable::class,
             $shareResourceExpirationDateTime,
             "Expected class to be 'DateTimeImmutable' but found "
-            . print_r($shareResourceExpirationDateTime, true)
+            . print_r($shareResourceExpirationDateTime, true),
         );
         $this->assertSame(
             $tomorrow->getTimestamp(),
             $shareResourceExpirationDateTime->getTimestamp(),
             "Expected timestamp of created share of resource to be " . $tomorrow->getTimestamp() . " but found "
-            . $shareResourceExpirationDateTime->getTimestamp()
+            . $shareResourceExpirationDateTime->getTimestamp(),
         );
         $createdShares = $this->ocis->getSharedByMe();
         $this->assertCount(
             1,
             $createdShares,
-            $this->fileToShare->getName() . " couldn't be shared"
+            $this->fileToShare->getName() . " couldn't be shared",
         );
         $createdSharesExpirationDateTime =  $createdShares[0]->getExpiration();
         $this->assertInstanceOf(
             \DateTimeImmutable::class,
             $createdSharesExpirationDateTime,
             "Expected class to be 'DateTimeImmutable' but found "
-            . print_r($createdSharesExpirationDateTime, true)
+            . print_r($createdSharesExpirationDateTime, true),
         );
         $this->assertSame(
             $tomorrow->getTimestamp(),
             $createdSharesExpirationDateTime->getTimestamp(),
             "Expected timestamp of shared resource to be " . $tomorrow->getTimestamp() . " but found "
-            . $createdSharesExpirationDateTime->getTimestamp()
+            . $createdSharesExpirationDateTime->getTimestamp(),
         );
     }
 
@@ -204,42 +204,42 @@ class ResourceInviteTest extends OcisPhpSdkTestCase
             \DateTimeImmutable::class,
             $shareResourceExpirationDateTime,
             "Expected class to be 'DateTimeImmutable' but found "
-            . print_r($shareResourceExpirationDateTime, true)
+            . print_r($shareResourceExpirationDateTime, true),
         );
         // The returned expiry is in UTC timezone (2 hours earlier than the expiry time in Kyiv)
         $this->assertSame(
             "Thu, 01 Jan 2060 10:00:00 +0000",
             $shareResourceExpirationDateTime->format('r'),
-            "Expected expiration datetime of shared resource doesn't match"
+            "Expected expiration datetime of shared resource doesn't match",
         );
         $this->assertSame(
             "Z",
             $shareResourceExpirationDateTime->getTimezone()->getName(),
-            "Expected timezone to be Z but found " . $shareResourceExpirationDateTime->getTimezone()->getName()
+            "Expected timezone to be Z but found " . $shareResourceExpirationDateTime->getTimezone()->getName(),
         );
         $createdShares = $this->ocis->getSharedByMe();
         $this->assertCount(
             1,
             $createdShares,
-            "Expected share created to be 1 but found " . count($createdShares)
+            "Expected share created to be 1 but found " . count($createdShares),
         );
         $createdSharesExpirationDateTime = $createdShares[0]->getExpiration();
         $this->assertInstanceOf(
             \DateTimeImmutable::class,
             $createdSharesExpirationDateTime,
             "Expected class to be 'DateTimeImmutable' but found "
-            . print_r($createdSharesExpirationDateTime, true)
+            . print_r($createdSharesExpirationDateTime, true),
         );
         // The returned expiry is in UTC timezone (2 hours earlier than the expiry time in Kyiv)
         $this->assertSame(
             "Thu, 01 Jan 2060 10:00:00 +0000",
             $createdSharesExpirationDateTime->format('r'),
-            "Expected expiration datetime of created share of resource doesn't match "
+            "Expected expiration datetime of created share of resource doesn't match ",
         );
         $this->assertSame(
             "Z",
             $createdSharesExpirationDateTime->getTimezone()->getName(),
-            "Expected timezone to be Z but found " . $createdSharesExpirationDateTime->getTimezone()->getName()
+            "Expected timezone to be Z but found " . $createdSharesExpirationDateTime->getTimezone()->getName(),
         );
     }
 
@@ -247,7 +247,7 @@ class ResourceInviteTest extends OcisPhpSdkTestCase
     {
         $philosophyHatersGroup =  $this->ocis->createGroup(
             'philosophyhaters',
-            'philosophy haters group'
+            'philosophy haters group',
         );
         $this->createdGroups = [$philosophyHatersGroup];
         $philosophyHatersGroup->addUser($this->einstein);
@@ -258,17 +258,17 @@ class ResourceInviteTest extends OcisPhpSdkTestCase
         $this->assertSame(
             "Albert Einstein",
             $shares[0]->getReceiver()->getDisplayName(),
-            "Expected receiver display name to be Albert Einstein but found " . $shares[0]->getReceiver()->getDisplayName()
+            "Expected receiver display name to be Albert Einstein but found " . $shares[0]->getReceiver()->getDisplayName(),
         );
         $this->assertSame(
             "Marie Curie",
             $shares[1]->getReceiver()->getDisplayName(),
-            "Expected receiver display name to be Marie Curie but found " . $shares[1]->getReceiver()->getDisplayName()
+            "Expected receiver display name to be Marie Curie but found " . $shares[1]->getReceiver()->getDisplayName(),
         );
         $this->assertSame(
             "philosophyhaters",
             $shares[2]->getReceiver()->getDisplayName(),
-            "Expected receiver display name to be philosophyhaters but found " . $shares[2]->getReceiver()->getDisplayName()
+            "Expected receiver display name to be philosophyhaters but found " . $shares[2]->getReceiver()->getDisplayName(),
         );
     }
 
@@ -276,7 +276,7 @@ class ResourceInviteTest extends OcisPhpSdkTestCase
     {
         $philosophyHatersGroup =  $this->ocis->createGroup(
             'philosophyhaters',
-            'philosophy haters group'
+            'philosophy haters group',
         );
         $this->createdGroups = [$philosophyHatersGroup];
         $philosophyHatersGroup->addUser($this->einstein);
@@ -290,37 +290,37 @@ class ResourceInviteTest extends OcisPhpSdkTestCase
         $this->assertCount(
             6,
             $shares,
-            "Expected count of shared resources to be 6 but found " . count($shares)
+            "Expected count of shared resources to be 6 but found " . count($shares),
         );
         for($i = 0; $i < 6; $i++) {
             $this->assertInstanceOf(
                 ShareCreated::class,
                 $shares[$i],
                 "Expected class to be 'ShareCreated' but found "
-                . get_class($shares[$i])
+                . get_class($shares[$i]),
             );
             $this->assertSame(
                 $this->personalDrive->getId(),
                 $shares[$i]->getDriveId(),
-                "Driveid doesn't match"
+                "Driveid doesn't match",
             );
             $this->assertThat(
                 $shares[$i]->getResourceId(),
                 $this->logicalOr(
                     $this->equalTo($this->folderToShare->getId()),
-                    $this->equalTo($this->fileToShare->getId())
+                    $this->equalTo($this->fileToShare->getId()),
                 ),
-                "Resource Id doesn't match"
+                "Resource Id doesn't match",
             );
             $this->assertThat(
                 $shares[$i]->getReceiver()->getDisplayName(),
                 $this->logicalOr(
                     $this->equalTo("philosophyhaters"),
                     $this->equalTo("Marie Curie"),
-                    $this->equalTo("Albert Einstein")
+                    $this->equalTo("Albert Einstein"),
                 ),
                 "Expected display name of Receiver be either philosophyhaters,Marie Curie or Albert Einstein
-                but found " . $shares[$i]->getReceiver()->getDisplayName()
+                but found " . $shares[$i]->getReceiver()->getDisplayName(),
             );
 
         }

--- a/tests/integration/Owncloud/OcisPhpSdk/ResourceShareLinkTest.php
+++ b/tests/integration/Owncloud/OcisPhpSdk/ResourceShareLinkTest.php
@@ -58,7 +58,7 @@ class ResourceShareLinkTest extends OcisPhpSdkTestCase
         SharingLinkType $type,
         bool $validForFile,
         bool $validForFolder,
-        string $issue
+        string $issue,
     ): void {
         if ($issue !== '') {
             $this->markTestSkipped($issue);
@@ -88,14 +88,14 @@ class ResourceShareLinkTest extends OcisPhpSdkTestCase
             \DateTimeImmutable::class,
             $createdLinkExpirationDateTime,
             "Expected class to be 'DateTimeImmutable' but found "
-            . print_r($createdLinkExpirationDateTime, true)
+            . print_r($createdLinkExpirationDateTime, true),
         );
         $this->assertSame(
             $tomorrow->modify(
-                "+1 day -1 second"
+                "+1 day -1 second",
             )->getTimestamp(),
             $createdLinkExpirationDateTime->getTimestamp(),
-            "Link expiration timestamp mismatch"
+            "Link expiration timestamp mismatch",
         );
         $createdShares = $this->ocis->getSharedByMe();
         $createdSharesExpirationDateTime = $createdShares[0]->getExpiration();
@@ -103,14 +103,14 @@ class ResourceShareLinkTest extends OcisPhpSdkTestCase
             \DateTimeImmutable::class,
             $createdSharesExpirationDateTime,
             "Expected class to be 'DateTimeImmutable' but found "
-            . print_r($createdSharesExpirationDateTime, true)
+            . print_r($createdSharesExpirationDateTime, true),
         );
         $this->assertSame(
             $tomorrow->modify(
-                "+1 day -1 second"
+                "+1 day -1 second",
             )->getTimestamp(),
             $createdSharesExpirationDateTime->getTimestamp(),
-            "Link expiration timestamp mismatch"
+            "Link expiration timestamp mismatch",
         );
     }
 
@@ -130,42 +130,42 @@ class ResourceShareLinkTest extends OcisPhpSdkTestCase
             \DateTimeImmutable::class,
             $createdLinkExpirationDateTime,
             "Expected class to be 'DateTimeImmutable' but found "
-            . print_r($createdLinkExpirationDateTime, true)
+            . print_r($createdLinkExpirationDateTime, true),
         );
         $this->assertSame(
             "Thu, 01 Jan 2060 21:59:59 +0000",
             $createdLinkExpirationDateTime->format('r'),
-            "Expected expiration datetime of shared resource doesn't match"
+            "Expected expiration datetime of shared resource doesn't match",
         );
         $this->assertSame(
             "Z",
             $createdLinkExpirationDateTime->getTimezone()->getName(),
-            "Expected timezone to be Z but found " . $createdLinkExpirationDateTime->getTimezone()->getName()
+            "Expected timezone to be Z but found " . $createdLinkExpirationDateTime->getTimezone()->getName(),
         );
 
         $createdShares = $this->ocis->getSharedByMe();
         $this->assertCount(
             1,
             $createdShares,
-            "Expected count of created share to be 1 but found " . count($createdShares)
+            "Expected count of created share to be 1 but found " . count($createdShares),
         );
         $createdSharesExpirationDateTime = $createdShares[0]->getExpiration();
         $this->assertInstanceOf(
             \DateTimeImmutable::class,
             $createdSharesExpirationDateTime,
             "Expected class to be 'DateTimeImmutable' but found "
-            . print_r($createdSharesExpirationDateTime, true)
+            . print_r($createdSharesExpirationDateTime, true),
         );
         // The returned expiry is in UTC timezone (2 hours earlier than the expiry time in Kyiv)
         $this->assertSame(
             "Thu, 01 Jan 2060 21:59:59 +0000",
             $createdSharesExpirationDateTime->format('r'),
-            "Expected expiration datetime of created share of the resource doesn't match"
+            "Expected expiration datetime of created share of the resource doesn't match",
         );
         $this->assertSame(
             "Z",
             $createdSharesExpirationDateTime->getTimezone()->getName(),
-            "Expected timezone to be Z but found " . $createdSharesExpirationDateTime->getTimezone()->getName()
+            "Expected timezone to be Z but found " . $createdSharesExpirationDateTime->getTimezone()->getName(),
         );
     }
 
@@ -179,12 +179,12 @@ class ResourceShareLinkTest extends OcisPhpSdkTestCase
         $this->assertEquals(
             $expectedExpirationDate,
             $link->getExpiration(),
-            "Expiration DateTime mismatch with original sharing link"
+            "Expiration DateTime mismatch with original sharing link",
         );
         $this->assertEquals(
             $expectedExpirationDate,
             $linkFromSharedByMe->getExpiration(),
-            "Expiration DateTime mismatch with link from shared-by-me"
+            "Expiration DateTime mismatch with link from shared-by-me",
         );
     }
 

--- a/tests/integration/Owncloud/OcisPhpSdk/ShareCreatedModifyTest.php
+++ b/tests/integration/Owncloud/OcisPhpSdk/ShareCreatedModifyTest.php
@@ -57,7 +57,7 @@ class ShareCreatedModifyTest extends OcisPhpSdkTestCase
                 ShareCreated::class,
                 $share,
                 "Expected class to be 'ShareCreated' but found "
-                . get_class($share)
+                . get_class($share),
             );
             if ($share->getReceiver()->getDisplayName() === 'Albert Einstein') {
                 $share->delete();
@@ -68,17 +68,17 @@ class ShareCreatedModifyTest extends OcisPhpSdkTestCase
         $this->assertCount(
             1,
             $this->ocis->getSharedByMe(),
-            "Expected count of Shared resource doesn't match"
+            "Expected count of Shared resource doesn't match",
         );
         $this->assertCount(
             0,
             $this->getSharedWithMeWaitTillShareIsAccepted($this->einsteinOcis),
-            "Failed to unshare resource to Einstein"
+            "Failed to unshare resource to Einstein",
         );
         $this->assertCount(
             1,
             $this->getSharedWithMeWaitTillShareIsAccepted($this->marieOcis),
-            "Expected shared resource for marie be 1 but found " . count($this->marieOcis->getSharedWithMe())
+            "Expected shared resource for marie be 1 but found " . count($this->marieOcis->getSharedWithMe()),
         );
     }
 
@@ -86,7 +86,7 @@ class ShareCreatedModifyTest extends OcisPhpSdkTestCase
     {
         $philosophyHatersGroup =  $this->ocis->createGroup(
             'philosophyhaters',
-            'philosophy haters group'
+            'philosophy haters group',
         );
         $this->createdGroups = [$philosophyHatersGroup];
         $philosophyHatersGroup->addUser($this->einstein);
@@ -100,7 +100,7 @@ class ShareCreatedModifyTest extends OcisPhpSdkTestCase
                 ShareCreated::class,
                 $share,
                 "Expected class to be 'ShareCreated' but found "
-                . get_class($share)
+                . get_class($share),
             );
             if ($share->getReceiver()->getDisplayName() === 'philosophyhaters') {
                 $share->delete();
@@ -110,17 +110,17 @@ class ShareCreatedModifyTest extends OcisPhpSdkTestCase
         $this->assertCount(
             2,
             $this->ocis->getSharedByMe(),
-            "Expected shared resource count to be 2 but found " . count($this->ocis->getSharedByMe())
+            "Expected shared resource count to be 2 but found " . count($this->ocis->getSharedByMe()),
         );
         $this->assertCount(
             1,
             $this->getSharedWithMeWaitTillShareIsAccepted($this->einsteinOcis),
-            "Shared resources was unshared to the group"
+            "Shared resources was unshared to the group",
         );
         $this->assertCount(
             1,
             $this->getSharedWithMeWaitTillShareIsAccepted($this->marieOcis),
-            "Expected shared resource count to be 1 but found " . count($this->marieOcis->getSharedWithMe())
+            "Expected shared resource count to be 1 but found " . count($this->marieOcis->getSharedWithMe()),
         );
     }
 
@@ -138,7 +138,7 @@ class ShareCreatedModifyTest extends OcisPhpSdkTestCase
     {
         $this->expectException(NotFoundException::class);
         $permission = new Permission([
-            'id' => 'does not exist'
+            'id' => 'does not exist',
         ]);
         $token = $this->getAccessToken('admin', 'admin');
         $share = new ShareCreated(
@@ -147,7 +147,7 @@ class ShareCreatedModifyTest extends OcisPhpSdkTestCase
             $this->fileToShare->getSpaceId(),
             ['verify' => false],
             $this->ocisUrl,
-            $token
+            $token,
         );
         $share->delete();
     }
@@ -162,13 +162,13 @@ class ShareCreatedModifyTest extends OcisPhpSdkTestCase
             \DateTimeImmutable::class,
             $expirationDateTime,
             "Expected class to be 'DateTimeImmutable' but found "
-            . print_r($expirationDateTime, true)
+            . print_r($expirationDateTime, true),
         );
         $this->assertSame(
             $tomorrow->getTimestamp(),
             $expirationDateTime->getTimestamp(),
             "Expected timestamp of shared resource to be " . $tomorrow->getTimestamp() . " but found "
-            . $expirationDateTime->getTimestamp()
+            . $expirationDateTime->getTimestamp(),
         );
     }
 
@@ -183,13 +183,13 @@ class ShareCreatedModifyTest extends OcisPhpSdkTestCase
             \DateTimeImmutable::class,
             $expirationDateTime,
             "Expected class to be 'DateTimeImmutable' but found "
-            . print_r($expirationDateTime, true)
+            . print_r($expirationDateTime, true),
         );
         $this->assertSame(
             $tomorrow->getTimestamp(),
             $expirationDateTime->getTimestamp(),
             "Expected timestamp of shared resource to be " . $tomorrow->getTimestamp() . " but found "
-            . $expirationDateTime->getTimestamp()
+            . $expirationDateTime->getTimestamp(),
         );
     }
 
@@ -204,7 +204,7 @@ class ShareCreatedModifyTest extends OcisPhpSdkTestCase
         $this->assertEquals(
             $shareFromInvite->getExpiration(),
             $sharedByMeShares[0]->getExpiration(),
-            "Expected DateTime of shared resources from Sharer and Receiver doesn't match"
+            "Expected DateTime of shared resources from Sharer and Receiver doesn't match",
         );
     }
 

--- a/tests/integration/Owncloud/OcisPhpSdk/ShareGetShareByMeTest.php
+++ b/tests/integration/Owncloud/OcisPhpSdk/ShareGetShareByMeTest.php
@@ -54,22 +54,22 @@ class ShareGetShareByMeTest extends OcisPhpSdkTestCase
             ShareCreated::class,
             $myShare[0],
             "Expected class " . ShareCreated::class
-                . " but got " . get_class($myShare[0])
+                . " but got " . get_class($myShare[0]),
         );
         $this->assertSame(
             'Albert Einstein',
             $myShare[0]->getReceiver()->getDisplayName(),
-            "Expected receiver display name to be 'Albert Einstein' but found " . $myShare[0]->getReceiver()->getDisplayName()
+            "Expected receiver display name to be 'Albert Einstein' but found " . $myShare[0]->getReceiver()->getDisplayName(),
         );
         $this->assertSame(
             $this->sharedResource->getId(),
             $myShare[0]->getResourceId(),
-            "ResourceId doesn't match with Shared ResourceId"
+            "ResourceId doesn't match with Shared ResourceId",
         );
         $this->assertSame(
             $this->personalDrive->getId(),
             $myShare[0]->getDriveId(),
-            "Drive Id doesn't match"
+            "Drive Id doesn't match",
         );
     }
 
@@ -79,24 +79,24 @@ class ShareGetShareByMeTest extends OcisPhpSdkTestCase
             SharingLinkType::VIEW,
             new \DateTimeImmutable(date('Y', strtotime('+1 year'))),
             self::VALID_LINK_PASSWORD,
-            ''
+            '',
         );
         $myShare = $this->ocis->getSharedByMe();
         $this->assertInstanceOf(
             ShareLink::class,
             $myShare[0],
             "Expected class " . ShareLink::class
-            . " but got " . get_class($myShare[0])
+            . " but got " . get_class($myShare[0]),
         );
         $this->assertSame(
             $this->sharedResource->getId(),
             $myShare[0]->getResourceId(),
-            "ResourceId doesn't match with Shared ResourceId"
+            "ResourceId doesn't match with Shared ResourceId",
         );
         $this->assertSame(
             $this->personalDrive->getId(),
             $myShare[0]->getDriveId(),
-            "DriveId doesn't match"
+            "DriveId doesn't match",
         );
     }
 
@@ -107,31 +107,31 @@ class ShareGetShareByMeTest extends OcisPhpSdkTestCase
             SharingLinkType::VIEW,
             new \DateTimeImmutable(date('Y', strtotime('+1 year'))),
             self::VALID_LINK_PASSWORD,
-            ''
+            '',
         );
         $myShares = $this->ocis->getSharedByMe();
         $this->assertInstanceOf(
             ShareCreated::class,
             $myShares[0],
             "Expected class " . ShareCreated::class
-            . " but got " . get_class($myShares[0])
+            . " but got " . get_class($myShares[0]),
         );
         $this->assertInstanceOf(
             ShareLink::class,
             $myShares[1],
             "Expected class " . ShareLink::class
-            . " but got " . get_class($myShares[1])
+            . " but got " . get_class($myShares[1]),
         );
         foreach ($myShares as $myshare) {
             $this->assertSame(
                 $this->sharedResource->getId(),
                 $myshare->getResourceId(),
-                "ResourceId doesn't match with shared resourceId"
+                "ResourceId doesn't match with shared resourceId",
             );
             $this->assertSame(
                 $this->personalDrive->getId(),
                 $myshare->getDriveId(),
-                "DriveId doesn't match"
+                "DriveId doesn't match",
             );
         }
     }

--- a/tests/integration/Owncloud/OcisPhpSdk/ShareGetSharedWithMeTest.php
+++ b/tests/integration/Owncloud/OcisPhpSdk/ShareGetSharedWithMeTest.php
@@ -71,58 +71,58 @@ class ShareGetSharedWithMeTest extends OcisPhpSdkTestCase
             ShareReceived::class,
             $receivedShare,
             "Expected class to be 'ShareReceived' but found "
-            . get_class($receivedShare)
+            . get_class($receivedShare),
         );
         $this->assertGreaterThanOrEqual(
             1,
             strlen($receivedShare->getRemoteItemId()),
-            "Expected the length of remote item id to be greater than 1"
+            "Expected the length of remote item id to be greater than 1",
         );
         $this->assertNotNull($receivedShare->getId(), "Expected received share id to not be null");
         $this->assertGreaterThanOrEqual(
             1,
             strlen($receivedShare->getId()),
-            " The length of received share id to be greater than 1 "
+            " The length of received share id to be greater than 1 ",
         );
         $this->assertSame(
             $this->fileToShare->getName(),
             $receivedShare->getName(),
-            "Expected shared file to be " . $this->fileToShare->getName() . " but found " . $receivedShare->getName()
+            "Expected shared file to be " . $this->fileToShare->getName() . " but found " . $receivedShare->getName(),
         );
         $this->assertSame(
             $this->fileToShare->getEtag(),
             $receivedShare->getEtag(),
-            "Resource Etag of shared resource doesn't match"
+            "Resource Etag of shared resource doesn't match",
         );
         $this->assertSame(
             $this->fileToShare->getId(),
             $receivedShare->getRemoteItemId(),
-            "The file-id of the remote item in the receive share is different to the id of the shared file"
+            "The file-id of the remote item in the receive share is different to the id of the shared file",
         );
 
         $this->assertFalse($receivedShare->isUiHidden(), "Expected receive share to be hidden");
         $this->assertTrue(
             $receivedShare->isClientSynchronized(),
-            "Expected received share to be client synchronized, but found not synced"
+            "Expected received share to be client synchronized, but found not synced",
         );
         $this->assertEqualsWithDelta(
             time(),
             $receivedShare->getLastModifiedDateTime()->getTimestamp(),
             120,
-            "Expected Shared resource was last modified within 120 seconds of the current time"
+            "Expected Shared resource was last modified within 120 seconds of the current time",
         );
         $this->assertThat(
             $receivedShare->getCreatedByDisplayName(),
             $this->logicalOr(
                 $this->equalTo("Admin"),
-                $this->equalTo("Admin Admin")
+                $this->equalTo("Admin Admin"),
             ),
-            "Expected owner name to be 'Marie Curie' but found " . $receivedShare->getCreatedByDisplayName()
+            "Expected owner name to be 'Marie Curie' but found " . $receivedShare->getCreatedByDisplayName(),
         );
         $this->assertGreaterThanOrEqual(
             1,
             strlen($receivedShare->getCreatedByUserId()),
-            "Expected the length of ownerId of receive share to be greater than or equal to 1"
+            "Expected the length of ownerId of receive share to be greater than or equal to 1",
         );
     }
 
@@ -130,7 +130,7 @@ class ShareGetSharedWithMeTest extends OcisPhpSdkTestCase
     {
         $philosophyHatersGroup =  $this->ocis->createGroup(
             'philosophyhaters',
-            'philosophy haters group'
+            'philosophy haters group',
         );
         $this->createdGroups = [$philosophyHatersGroup];
         $philosophyHatersGroup->addUser($this->einstein);
@@ -142,32 +142,32 @@ class ShareGetSharedWithMeTest extends OcisPhpSdkTestCase
                 ShareReceived::class,
                 $receivedShare,
                 "Expected class to be 'ShareReceived' but found "
-                . get_class($receivedShare)
+                . get_class($receivedShare),
             );
         }
         $this->assertCount(
             2,
             $receivedShares,
-            "Expected two shares but found " . count($receivedShares)
+            "Expected two shares but found " . count($receivedShares),
         );
         for($i = 0; $i < 2; $i++) {
             $this->assertThat(
                 $receivedShares[$i]->getName(),
                 $this->logicalOr(
                     $this->equalTo($this->fileToShare->getName()),
-                    $this->equalTo($this->folderToShare->getName())
+                    $this->equalTo($this->folderToShare->getName()),
                 ),
                 "Expected shared resource name to be " . $this->fileToShare->getName() . " or " . $this->folderToShare->getName() .
-                " but found " . $receivedShares[$i]->getName()
+                " but found " . $receivedShares[$i]->getName(),
             );
             $this->assertThat(
                 $receivedShares[$i]->getRemoteItemId(),
                 $this->logicalOr(
                     $this->equalTo($this->fileToShare->getId()),
-                    $this->equalTo($this->folderToShare->getId())
+                    $this->equalTo($this->folderToShare->getId()),
                 ),
                 "Expected shared resource Id to be " . $this->fileToShare->getId() . " or " . $this->folderToShare->getId() .
-                " but found " . $receivedShares[$i]->getRemoteItemId()
+                " but found " . $receivedShares[$i]->getRemoteItemId(),
             );
         }
 
@@ -177,7 +177,7 @@ class ShareGetSharedWithMeTest extends OcisPhpSdkTestCase
     {
         $philosophyHatersGroup =  $this->ocis->createGroup(
             'philosophyhaters',
-            'philosophy haters group'
+            'philosophy haters group',
         );
         $this->createdGroups = [$philosophyHatersGroup];
         $philosophyHatersGroup->addUser($this->einstein);
@@ -189,27 +189,27 @@ class ShareGetSharedWithMeTest extends OcisPhpSdkTestCase
                 ShareReceived::class,
                 $receivedShare,
                 "Expected class to be 'ShareReceived' but found "
-                . get_class($receivedShare)
+                . get_class($receivedShare),
             );
             $permissions = $receivedShare->getRemoteItem()->getPermissions() ?? [];
             $this->assertCount(
                 2,
                 $permissions,
-                "Expected two shares but found " . count($receivedShares)
+                "Expected two shares but found " . count($receivedShares),
             );
         }
 
         $this->assertSame(
             $receivedShares[0]->getName(),
             $this->fileToShare->getName(),
-            "Expected resource name to be " .  $receivedShares[0]->getName()
-            . " but found " . $this->fileToShare->getName()
+            "Expected resource name to be " . $receivedShares[0]->getName()
+            . " but found " . $this->fileToShare->getName(),
         );
         $this->assertSame(
             $receivedShares[0]->getRemoteItemId(),
             $this->fileToShare->getId(),
-            "Expected resource id to be " .  $receivedShares[0]->getRemoteItemId()
-            . " but found " . $this->fileToShare->getId()
+            "Expected resource id to be " . $receivedShares[0]->getRemoteItemId()
+            . " but found " . $this->fileToShare->getId(),
         );
     }
 
@@ -217,7 +217,7 @@ class ShareGetSharedWithMeTest extends OcisPhpSdkTestCase
     {
         $philosophyHatersGroup =  $this->ocis->createGroup(
             'philosophyhaters',
-            'philosophy haters group'
+            'philosophy haters group',
         );
         $this->createdGroups = [$philosophyHatersGroup];
         $philosophyHatersGroup->addUser($this->einstein);
@@ -230,19 +230,19 @@ class ShareGetSharedWithMeTest extends OcisPhpSdkTestCase
         $shareDrive = $this->einsteinOcis->getMyDrives(
             DriveOrder::NAME,
             OrderDirection::ASC,
-            DriveType::VIRTUAL
+            DriveType::VIRTUAL,
         )[0];
         $resourcesInShareJail = $shareDrive->getResources();
         $this->assertCount(
             2,
             $receivedShares,
-            "Expected two receive shares but found " . count($receivedShares)
+            "Expected two receive shares but found " . count($receivedShares),
         );
         // the resources in the share-jail are merged if received by different ways
         $this->assertCount(
             2,
             $resourcesInShareJail,
-            "Expected two receive shares but found " . count($resourcesInShareJail)
+            "Expected two receive shares but found " . count($resourcesInShareJail),
         );
         foreach ($resourcesInShareJail as $resource) {
             $foundMatchingShare = false;

--- a/tests/integration/Owncloud/OcisPhpSdk/ShareTestGetSharedWithMeNotSyncedSharesTest.php
+++ b/tests/integration/Owncloud/OcisPhpSdk/ShareTestGetSharedWithMeNotSyncedSharesTest.php
@@ -60,53 +60,53 @@ class ShareTestGetSharedWithMeNotSyncedSharesTest extends OcisPhpSdkTestCase
             ShareReceived::class,
             $receivedShare,
             "Expected class to be 'ShareReceived' but found "
-            . get_class($receivedShare)
+            . get_class($receivedShare),
         );
         $this->assertGreaterThanOrEqual(
             1,
             strlen($receivedShare->getRemoteItemId()),
-            "Expected the length of remote item id to be greater than 1"
+            "Expected the length of remote item id to be greater than 1",
         );
         $this->assertSame(
             $this->fileToShare->getName(),
             $receivedShare->getName(),
-            "Expected shared file to be " . $this->fileToShare->getName() . " but found " . $receivedShare->getName()
+            "Expected shared file to be " . $this->fileToShare->getName() . " but found " . $receivedShare->getName(),
         );
         $this->assertFalse($receivedShare->isUiHidden(), "Expected receive share to be hidden");
         $this->assertFalse(
             $receivedShare->isClientSynchronized(),
-            "Expected received share to be client synchronized, but found not synced"
+            "Expected received share to be client synchronized, but found not synced",
         );
         $this->assertMatchesRegularExpression(
             '/^' . $this->getUUIDv4Regex() . '\$' . $this->getUUIDv4Regex() . '!' . $this->getUUIDv4Regex() . ':' . $this->getUUIDv4Regex() . ':' . $this->getUUIDv4Regex() . '$/i',
             $receivedShare->getId(),
-            "Shareid doesn't match the expected format"
+            "Shareid doesn't match the expected format",
         );
         $this->assertSame(
             $this->fileToShare->getId(),
             $receivedShare->getRemoteItemId(),
-            "The file-id of the remote item in the receive share is different to the id of the shared file"
+            "The file-id of the remote item in the receive share is different to the id of the shared file",
         );
         $this->assertMatchesRegularExpression(
             "/^\"[a-f0-9:.]{1,32}\"$/",
             $receivedShare->getEtag(),
-            "Resource Etag doesn't match the expected format"
+            "Resource Etag doesn't match the expected format",
         );
         $this->assertEqualsWithDelta(
             time(),
             $receivedShare->getLastModifiedDateTime()->getTimestamp(),
             120,
-            "Expected Shared resource was last modified within 120 seconds of the current time"
+            "Expected Shared resource was last modified within 120 seconds of the current time",
         );
         $this->assertStringContainsString(
             'Admin',
             $receivedShare->getCreatedByDisplayName(),
-            "Expected owner name to be 'Admin' but found " . $receivedShare->getCreatedByDisplayName()
+            "Expected owner name to be 'Admin' but found " . $receivedShare->getCreatedByDisplayName(),
         );
         $this->assertMatchesRegularExpression(
             '/' . $this->getUUIDv4Regex() . '/',
             $receivedShare->getCreatedByUserId(),
-            "OwnerId of the received share doesn't match the expected format"
+            "OwnerId of the received share doesn't match the expected format",
         );
     }
 }

--- a/tests/integration/Owncloud/OcisPhpSdk/UsersTest.php
+++ b/tests/integration/Owncloud/OcisPhpSdk/UsersTest.php
@@ -18,12 +18,12 @@ class UsersTest extends OcisPhpSdkTestCase
             'Owncloud\OcisPhpSdk\User',
             $users,
             null,
-            "Array contains not only 'User' items"
+            "Array contains not only 'User' items",
         );
         $this->assertGreaterThanOrEqual(
             3,
             count($users),
-            "Expected at least 3 users, but found " . count($users)
+            "Expected at least 3 users, but found " . count($users),
         );
     }
 
@@ -37,17 +37,17 @@ class UsersTest extends OcisPhpSdkTestCase
             'Owncloud\OcisPhpSdk\User',
             $users,
             null,
-            "Array contains not only 'User' items"
+            "Array contains not only 'User' items",
         );
         $this->assertGreaterThanOrEqual(
             1,
             count($users),
-            "Expected at least 1 user, but found " . count($users)
+            "Expected at least 1 user, but found " . count($users),
         );
         $this->assertSame(
             'Marie Curie',
             $users[0]->getDisplayName(),
-            "Username should be 'Marie Curie' but found " . $users[0]->getDisplayName()
+            "Username should be 'Marie Curie' but found " . $users[0]->getDisplayName(),
         );
     }
 
@@ -63,17 +63,17 @@ class UsersTest extends OcisPhpSdkTestCase
             'Owncloud\OcisPhpSdk\User',
             $users,
             null,
-            "Array contains not only 'User' items"
+            "Array contains not only 'User' items",
         );
         $this->assertGreaterThanOrEqual(
             1,
             count($users),
-            "Expected at least 1 user, but found " . count($users)
+            "Expected at least 1 user, but found " . count($users),
         );
         $this->assertSame(
             'Albert Einstein',
             $users[0]->getDisplayName(),
-            "Username should be 'Albert Einstein' but found " . $users[0]->getDisplayName()
+            "Username should be 'Albert Einstein' but found " . $users[0]->getDisplayName(),
         );
     }
 

--- a/tests/unit/Owncloud/OcisPhpSdk/EducationUserTest.php
+++ b/tests/unit/Owncloud/OcisPhpSdk/EducationUserTest.php
@@ -21,7 +21,7 @@ class EducationUserTest extends TestCase
                 "display_name" => "displayname",
                 "mail" => "mail@mail.com",
                 "on_premises_sam_account_name" => "sd",
-            ]))
+            ])),
         ]);
         /** @phan-suppress-next-line PhanUndeclaredMethod */
         $user = $ocis->getEducationUsers();

--- a/tests/unit/Owncloud/OcisPhpSdk/Exception/ExceptionHelperTest.php
+++ b/tests/unit/Owncloud/OcisPhpSdk/Exception/ExceptionHelperTest.php
@@ -60,7 +60,7 @@ class ExceptionHelperTest extends TestCase
         string $originalExceptionToUse,
         string $exceptionMessage,
         int    $exceptionStatusCode,
-        string $expectedExceptionClass
+        string $expectedExceptionClass,
     ): void {
         $expectedExceptionMessage = $exceptionMessage;
         if ($originalExceptionToUse === "GuzzleHttpRequestException") {

--- a/tests/unit/Owncloud/OcisPhpSdk/OcisTest.php
+++ b/tests/unit/Owncloud/OcisPhpSdk/OcisTest.php
@@ -25,9 +25,9 @@ class OcisTest extends TestCase
     {
         $this->assertSame(
             [
-                'headers' => ['Authorization' => 'Bearer token']
+                'headers' => ['Authorization' => 'Bearer token'],
             ],
-            Ocis::createGuzzleConfig([], 'token')
+            Ocis::createGuzzleConfig([], 'token'),
         );
     }
 
@@ -36,9 +36,9 @@ class OcisTest extends TestCase
         $this->assertEquals(
             [
                 'headers' => ['Authorization' => 'Bearer token'],
-                'verify' => false
+                'verify' => false,
             ],
-            Ocis::createGuzzleConfig(['verify' => false], 'token')
+            Ocis::createGuzzleConfig(['verify' => false], 'token'),
         );
     }
 
@@ -48,10 +48,10 @@ class OcisTest extends TestCase
             [
                 'headers' => [
                     'Authorization' => 'Bearer token',
-                    'X-something' => 'X-Data'
-                ]
+                    'X-something' => 'X-Data',
+                ],
             ],
-            Ocis::createGuzzleConfig(['headers' => ['X-something' => 'X-Data']], 'token')
+            Ocis::createGuzzleConfig(['headers' => ['X-something' => 'X-Data']], 'token'),
         );
     }
 
@@ -75,7 +75,7 @@ class OcisTest extends TestCase
         $ocis = new Ocis(
             'https://localhost:9200',
             'doesNotMatter',
-            ['drivesApi' => $createDriveMock]
+            ['drivesApi' => $createDriveMock],
         );
         $ocis->createDrive('driveName');
     }
@@ -86,7 +86,7 @@ class OcisTest extends TestCase
         $this->expectExceptionMessage(
             "[0] cURL error 6: Could not resolve host: localhost-does-not-exist " .
             "(see https://curl.haxx.se/libcurl/c/libcurl-errors.html) " .
-            "for https://localhost-does-not-exist:9200/graph/v1.0/drives"
+            "for https://localhost-does-not-exist:9200/graph/v1.0/drives",
         );
         $ocis = new Ocis('https://localhost-does-not-exist:9200', 'doesNotMatter');
         $ocis->createDrive('driveName');
@@ -102,7 +102,7 @@ class OcisTest extends TestCase
         $ocis = new Ocis(
             'https://localhost:9200',
             'doesNotMatter',
-            ['drivesApi' => $createDriveMock]
+            ['drivesApi' => $createDriveMock],
         );
         $ocis->createDrive('driveName');
     }
@@ -123,7 +123,7 @@ class OcisTest extends TestCase
             'https://localhost:9200',
             'tokenWhenCreated',
             /* @phpstan-ignore-next-line */
-            [ 'guzzle' => $this->setUpMocksForOcisVersion(), 'drivesGetDrivesApi' => $drivesGetDrivesApi]
+            [ 'guzzle' => $this->setUpMocksForOcisVersion(), 'drivesGetDrivesApi' => $drivesGetDrivesApi],
         );
         $drives = $ocis->getAllDrives();
         foreach ($drives as $drive) {
@@ -139,7 +139,7 @@ class OcisTest extends TestCase
     {
         $ocis = $this->setupMocksForNotificationTests(
             '{"ocs":{"data":[{"notification_id":"123"},{"notification_id":"456"}]}}',
-            'tokenWhenCreated'
+            'tokenWhenCreated',
         );
         $notifications = $ocis->getNotifications();
         $this->assertSame('tokenWhenCreated', $notifications[0]->getAccessToken());
@@ -176,7 +176,7 @@ class OcisTest extends TestCase
 
     private function setupMocksForNotificationTests(
         string $responseContent,
-        string $token = 'doesNotMatter'
+        string $token = 'doesNotMatter',
     ): Ocis {
         $streamMock = $this->createMock(StreamInterface::class);
         $streamMock->method('getContents')->willReturn($responseContent);
@@ -195,7 +195,7 @@ class OcisTest extends TestCase
         return [
             [""],
             ["data,"],
-            ["{data:}"]
+            ["{data:}"],
         ];
     }
 
@@ -206,7 +206,7 @@ class OcisTest extends TestCase
     {
         $this->expectException(InvalidResponseException::class);
         $this->expectExceptionMessage(
-            'Notification response is invalid. Content: "' . $responseContent . '"'
+            'Notification response is invalid. Content: "' . $responseContent . '"',
         );
         $ocis = $this->setupMocksForNotificationTests($responseContent);
         $ocis->getNotifications();
@@ -221,7 +221,7 @@ class OcisTest extends TestCase
             ['{"ocs":{"meta":{"message":"","status":"","statuscode":200}}}'],
             ['{"ocs": null}'],
             ['{}'],
-            ['{"ocs":{"meta":{"message":"","status":"","statuscode":200},"data":"string"}}']
+            ['{"ocs":{"meta":{"message":"","status":"","statuscode":200},"data":"string"}}'],
         ];
     }
 
@@ -229,11 +229,11 @@ class OcisTest extends TestCase
      * @dataProvider invalidOcsNotificationResponse
      */
     public function testGetNotificationInvalidOcsData(
-        string $responseContent
+        string $responseContent,
     ): void {
         $this->expectException(InvalidResponseException::class);
         $this->expectExceptionMessage(
-            'Notification response is invalid. Content: "' . $responseContent . '"'
+            'Notification response is invalid. Content: "' . $responseContent . '"',
         );
         $ocis = $this->setupMocksForNotificationTests($responseContent);
         $ocis->getNotifications();
@@ -247,7 +247,7 @@ class OcisTest extends TestCase
         return [
             ['{"ocs":{"data":[{"notification_id":""}]}}'],
             ['{"ocs":{"data":[{"notification_id":123}]}}'],
-            ['{"ocs":{"data":[{"notificationId":"123"}]}}']
+            ['{"ocs":{"data":[{"notificationId":"123"}]}}'],
         ];
     }
 
@@ -255,11 +255,11 @@ class OcisTest extends TestCase
      * @dataProvider invalidOrMissingIdInOcsNotificationResponse
      */
     public function testGetNotificationMissingOrInvalidId(
-        string $responseContent
+        string $responseContent,
     ): void {
         $this->expectException(InvalidResponseException::class);
         $this->expectExceptionMessage(
-            'Id is invalid or missing in notification response. Content: "' . $responseContent . '"'
+            'Id is invalid or missing in notification response. Content: "' . $responseContent . '"',
         );
         $ocis = $this->setupMocksForNotificationTests($responseContent);
         $ocis->getNotifications();
@@ -291,97 +291,97 @@ class OcisTest extends TestCase
         return [
             [
                 [],
-                true
+                true,
             ],
             [
                 ['verify' => false],
-                true
+                true,
             ],
             [
                 ['headers' => ['X-something' => 'X-Data']],
-                true
+                true,
             ],
             [
                 ['headers' => ['X-something' => 'X-Data', 'X-some-other' => 'X-Data']],
-                true
+                true,
             ],
             [
                 ['headers' => 'string'],
-                false
+                false,
             ],
             [
                 ['headers' => null],
-                false
+                false,
             ],
             [
                 ['headers' => ['X-something' => 'X-Data'], 'verify' => false],
-                true
+                true,
             ],
             [
                 ['headers' => ['X-something' => 'X-Data'], 'verify' => 'false'],
-                false
+                false,
             ],
             [
                 ['headers' => ['X-something' => 'X-Data'], 'verify' => 'true'],
-                false
+                false,
             ],
             [
                 ['headers' => ['X-something' => 'X-Data'], 'verify' => '1'],
-                false
+                false,
             ],
             [
                 ['headers' => ['X-something' => 'X-Data'], 'verify' => '0'],
-                false
+                false,
             ],
             [
                 ['headers' => ['X-something' => 'X-Data'], 'verify' => 1],
-                false
+                false,
             ],
             [
                 ['headers' => ['X-something' => 'X-Data'], 'verify' => 0],
-                false
+                false,
             ],
             [
                 ['headers' => ['X-something' => 'X-Data'], 'verify' => true],
-                true
+                true,
             ],
             [
                 ['crud' => 'some value'],
-                false
+                false,
             ],
             [
                 ['crud' => 'some value', 'verify' => false],
-                false
+                false,
             ],
             [
                 ['webfinger' => true],
-                true
+                true,
             ]
             ,
             [
                 ['webfinger' => false],
-                true
+                true,
             ],
             [
                 ['webfinger' => 'true'],
-                false
+                false,
             ],
             [
                 ['webfinger' => null],
-                false
+                false,
             ],
             [
                 ['guzzle' => new Client()],
-                true
+                true,
             ],
             [
                 ['guzzle' => null],
-                false
+                false,
             ],
             [
                 ['guzzle' => 'Guzzle'],
-                false
-            ]
+                false,
+            ],
         ];
     }
 
@@ -391,7 +391,7 @@ class OcisTest extends TestCase
      */
     public function testIsConnectionConfigValid(
         array $connectionConfig,
-        bool $expectedResult
+        bool $expectedResult,
     ): void {
         $this->assertSame($expectedResult, Ocis::isConnectionConfigValid($connectionConfig));
     }

--- a/tests/unit/Owncloud/OcisPhpSdk/OcisWebfingerTest.php
+++ b/tests/unit/Owncloud/OcisPhpSdk/OcisWebfingerTest.php
@@ -17,16 +17,16 @@ class OcisWebfingerTest extends TestCase
         $tokenHeader = [
             "alg" => "PS256",
             "kid" => "private-key",
-            "typ" => "JWT"
+            "typ" => "JWT",
         ];
         $tokenPayload = [
             "iss" => "https://sso.example.com",
             // this will generate a token that will contain `-` and `_` after base64Url encoding
-            "special" => "????>>>????>>>"
+            "special" => "????>>>????>>>",
         ];
 
-        $base64EncodedToken = base64_encode((string)json_encode($tokenHeader)) . "." .
-            base64_encode((string)json_encode($tokenPayload, JSON_UNESCAPED_UNICODE)) .
+        $base64EncodedToken = base64_encode((string) json_encode($tokenHeader)) . "." .
+            base64_encode((string) json_encode($tokenPayload, JSON_UNESCAPED_UNICODE)) .
             ".signatureDoesNotMatter";
         // the token needs to be base64Url encoded not just base64
         // see https://jwt.io/introduction/
@@ -73,8 +73,8 @@ class OcisWebfingerTest extends TestCase
             /* @phpstan-ignore-next-line because receiving a MockObject */
             [
                 'webfinger' => true,
-                'guzzle' => $this->getGuzzleMock()
-            ]
+                'guzzle' => $this->getGuzzleMock(),
+            ],
         );
         $this->assertSame("https://abc.drive.example.com", $ocis->getServiceUrl());
     }
@@ -117,7 +117,7 @@ class OcisWebfingerTest extends TestCase
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage(
-            'Could not decode token. ' . $expectedExceptionMessage
+            'Could not decode token. ' . $expectedExceptionMessage,
         );
         /** @phan-suppress-next-line PhanNoopNew we expect an exception, so do not assign the result */
         new Ocis(
@@ -126,8 +126,8 @@ class OcisWebfingerTest extends TestCase
             /* @phpstan-ignore-next-line because receiving a MockObject */
             [
                 'webfinger' => true,
-                'guzzle' => $this->getGuzzleMock()
-            ]
+                'guzzle' => $this->getGuzzleMock(),
+            ],
         );
     }
 
@@ -170,8 +170,8 @@ class OcisWebfingerTest extends TestCase
             /* @phpstan-ignore-next-line because receiving a MockObject */
             [
                 'webfinger' => true,
-                'guzzle' => $this->getGuzzleMock($responseContent)
-            ]
+                'guzzle' => $this->getGuzzleMock($responseContent),
+            ],
         );
     }
 }

--- a/tests/unit/Owncloud/OcisPhpSdk/ResourceInviteTest.php
+++ b/tests/unit/Owncloud/OcisPhpSdk/ResourceInviteTest.php
@@ -31,7 +31,7 @@ class ResourceInviteTest extends TestCase
                 'display_name' => 'Albert Einstein',
                 'mail' => 'einstein@owncloud.np',
                 'on_premises_sam_account_name' => 'albert-einstein',
-            ]
+            ],
         );
         $einstein = new User($openAPIUser);
 
@@ -39,7 +39,7 @@ class ResourceInviteTest extends TestCase
             [
                 'id' => 'uuid-of-smart-people-group',
                 'display_name' => 'smart-people',
-            ]
+            ],
         );
         $accessToken = "acstok";
         $smartPeopleGroup = new Group($openAPIGroup, "url", [], $accessToken);
@@ -55,12 +55,12 @@ class ResourceInviteTest extends TestCase
                             new DriveRecipient(
                                 [
                                     'object_id' => 'uuid-of-einstein',
-                                ]
+                                ],
                             ),
                         ],
                         'roles' => ['uuid-of-the-role'],
-                    ]
-                )
+                    ],
+                ),
             ],
             // set expiry time
             [
@@ -73,13 +73,13 @@ class ResourceInviteTest extends TestCase
                                 [
                                     'object_id' => 'uuid-of-smart-people-group',
                                     'at_libre_graph_recipient_type' => 'group',
-                                ]
+                                ],
                             ),
                         ],
                         'roles' => ['uuid-of-the-role'],
-                        'expiration_date_time' => new \DateTimeImmutable('2022-12-31 01:02:03.456789Z')
-                    ]
-                )
+                        'expiration_date_time' => new \DateTimeImmutable('2022-12-31 01:02:03.456789Z'),
+                    ],
+                ),
             ],
             // set expiry time, with conversion to UTC/Z timezone
             [
@@ -91,13 +91,13 @@ class ResourceInviteTest extends TestCase
                             new DriveRecipient(
                                 [
                                     'object_id' => 'uuid-of-einstein',
-                                ]
+                                ],
                             ),
                         ],
                         'roles' => ['uuid-of-the-role'],
-                        'expiration_date_time' => new \DateTimeImmutable('2021-01-01 12:00:43.123456Z')
-                    ]
-                )
+                        'expiration_date_time' => new \DateTimeImmutable('2021-01-01 12:00:43.123456Z'),
+                    ],
+                ),
             ],
         ];
     }
@@ -108,7 +108,7 @@ class ResourceInviteTest extends TestCase
     public function testInvite(
         User|Group $recipient,
         ?\DateTimeImmutable $expiration,
-        DriveItemInvite $expectedInviteData
+        DriveItemInvite $expectedInviteData,
     ): void {
         $permission = $this->createMock(Permission::class);
         $permission->method('getId')
@@ -129,20 +129,20 @@ class ResourceInviteTest extends TestCase
             200 => [
                 '{http://owncloud.org/ns}id' => 'uuid-of-the-resource',
                 '{http://owncloud.org/ns}spaceid' => 'uuid-of-the-drive',
-            ]
+            ],
         ];
 
         $resource = new OcisResource(
             $resourceMetadata,
             $connectionConfig,
             'http://ocis',
-            $accessToken
+            $accessToken,
         );
 
         $openAPIRole = new UnifiedRoleDefinition(
             [
                 'id' => 'uuid-of-the-role',
-                'display_name' => 'Manager'
+                'display_name' => 'Manager',
             ],
         );
         $role = new SharingRole($openAPIRole);
@@ -163,7 +163,7 @@ class ResourceInviteTest extends TestCase
                     'display_name' => 'Manager',
                     'description' => 'description',
                     'weight' => 'at_libre_graph_weight',
-                ],"Invalid id returned for user ''"
+                ],"Invalid id returned for user ''",
             ],
             [
                 [
@@ -171,7 +171,7 @@ class ResourceInviteTest extends TestCase
                     'display_name' => 'Manager',
                     'description' => 'description',
                     'weight' => 2,
-                ],"Invalid id returned for user ''"
+                ],"Invalid id returned for user ''",
             ],
             [
                 [
@@ -179,7 +179,7 @@ class ResourceInviteTest extends TestCase
                     'display_name' => '',
                     'description' => 'description',
                     'weight' => 4,
-                ],"Invalid display name returned for user ''"
+                ],"Invalid display name returned for user ''",
             ],
             [
                 [
@@ -187,7 +187,7 @@ class ResourceInviteTest extends TestCase
                     'display_name' => null,
                     'description' => 'description',
                     'weight' => 6,
-                ],"Invalid display name returned for user ''"
+                ],"Invalid display name returned for user ''",
             ],
             [
                 [
@@ -195,7 +195,7 @@ class ResourceInviteTest extends TestCase
                     'display_name' => 'Manager',
                     'description' => '',
                     'weight' => 5,
-                ],"Invalid description returned for user ''"
+                ],"Invalid description returned for user ''",
             ],
             [
                 [
@@ -203,7 +203,7 @@ class ResourceInviteTest extends TestCase
                     'display_name' => 'Manager',
                     'description' => null,
                     'weight' => 24,
-                ],"Invalid description returned for user ''"
+                ],"Invalid description returned for user ''",
             ],
             [
                 [
@@ -211,7 +211,7 @@ class ResourceInviteTest extends TestCase
                     'display_name' => 'Manager',
                     'description' => 'description',
                     'weight' => '',
-                ],"Invalid weight returned for user ''"
+                ],"Invalid weight returned for user ''",
             ],
             [
                 [
@@ -219,7 +219,7 @@ class ResourceInviteTest extends TestCase
                     'display_name' => 'Manager',
                     'description' => 'description',
                     'weight' => null,
-                ],"Invalid weight returned for user ''"
+                ],"Invalid weight returned for user ''",
             ],
         ];
     }

--- a/tests/unit/Owncloud/OcisPhpSdk/ResourceLinkTest.php
+++ b/tests/unit/Owncloud/OcisPhpSdk/ResourceLinkTest.php
@@ -32,8 +32,8 @@ class ResourceLinkTest extends TestCase
                         'type' => SharingLinkType::VIEW,
                         'password' => self::PASSWORD,
                         'expiration_date_time' => null,
-                        'display_name' => null
-                    ]
+                        'display_name' => null,
+                    ],
                 ),
             ],
             // create a link setting all data
@@ -47,8 +47,8 @@ class ResourceLinkTest extends TestCase
                         'type' => SharingLinkType::EDIT,
                         'password' => self::PASSWORD,
                         'expiration_date_time' => new \DateTime('2022-12-31 01:02:03.456789Z'),
-                        'display_name' => 'the name of the link'
-                    ]
+                        'display_name' => 'the name of the link',
+                    ],
                 ),
             ],
             // set expiry time, with conversion to UTC/Z timezone
@@ -62,8 +62,8 @@ class ResourceLinkTest extends TestCase
                         'type' => SharingLinkType::EDIT,
                         'password' => self::PASSWORD,
                         'expiration_date_time' => new \DateTime('2020-12-31 23:00:43.123456Z'),
-                        'display_name' => null
-                    ]
+                        'display_name' => null,
+                    ],
                 ),
             ],
         ];
@@ -83,7 +83,7 @@ class ResourceLinkTest extends TestCase
             $resourceMetadata,
             $connectionConfig, // @phpstan-ignore-line 'drivesPermissionsApi' is a MockObject
             'http://ocis',
-            $accessToken
+            $accessToken,
         );
     }
     /**
@@ -94,7 +94,7 @@ class ResourceLinkTest extends TestCase
         ?\DateTimeImmutable $expiration,
         ?string $password,
         ?string $displayName,
-        DriveItemCreateLink $expectedCreateLinkData
+        DriveItemCreateLink $expectedCreateLinkData,
     ): void {
         $permissionMock = $this->createMock(Permission::class);
         $permissionMock->method('getId')

--- a/tests/unit/Owncloud/OcisPhpSdk/ResourceTest.php
+++ b/tests/unit/Owncloud/OcisPhpSdk/ResourceTest.php
@@ -29,7 +29,7 @@ class ResourceTest extends TestCase
     {
         return [
             ['{DAV:}collection', 'folder'],
-            [null, 'file']
+            [null, 'file'],
         ];
     }
 
@@ -44,7 +44,7 @@ class ResourceTest extends TestCase
             $metadata,
             [],
             '',
-            $accessToken
+            $accessToken,
         );
     }
     /**
@@ -122,7 +122,7 @@ class ResourceTest extends TestCase
         int|string $actualSize,
         int|string $expectedSize,
         null|string $data,
-        string $sizeKey
+        string $sizeKey,
     ): void {
         $metadata = [];
         $metadata[200]['{DAV:}resourcetype'] = new ResourceType($data);
@@ -227,7 +227,7 @@ class ResourceTest extends TestCase
         $resource = $this->createOcisResource($metadata);
         $result = $resource->isFavorited();
         $this->assertIsBool($result);
-        $this->assertSame($result, (bool)$value);
+        $this->assertSame($result, (bool) $value);
     }
 
     /**

--- a/tests/unit/Owncloud/OcisPhpSdk/UserTest.php
+++ b/tests/unit/Owncloud/OcisPhpSdk/UserTest.php
@@ -112,7 +112,7 @@ class UserTest extends TestCase
         $this->expectException(InvalidResponseException::class);
         $errorKey = $data["errorKey"];
         $this->expectExceptionMessage(
-            "Invalid $errorKey returned for user '" . print_r($data[$data["key"] ?? ""], true) . "'"
+            "Invalid $errorKey returned for user '" . print_r($data[$data["key"] ?? ""], true) . "'",
         );
         $libUser = new User(
             [
@@ -120,7 +120,7 @@ class UserTest extends TestCase
                 "display_name" => $data["display_name"],
                 "mail" => $data["mail"],
                 "on_premises_sam_account_name" => $data["on_premises_sam_account_name"],
-            ]
+            ],
         );
         $user = new SdkUser($libUser);
         $user->getDisplayName();

--- a/tests/unit/Owncloud/OcisPhpSdk/WebDavClientTest.php
+++ b/tests/unit/Owncloud/OcisPhpSdk/WebDavClientTest.php
@@ -22,8 +22,8 @@ class WebDavClientTest extends TestCase
                 [
                     CURLOPT_HTTPAUTH => CURLAUTH_BEARER,
                     CURLOPT_XOAUTH2_BEARER => 'token',
-                    CURLOPT_HTTPHEADER => ['X-Header: X-value', 'Y-Header: Y-value']
-                ]
+                    CURLOPT_HTTPHEADER => ['X-Header: X-value', 'Y-Header: Y-value'],
+                ],
             ],
             [
                 ['verify' => false],
@@ -32,8 +32,8 @@ class WebDavClientTest extends TestCase
                     CURLOPT_HTTPAUTH => CURLAUTH_BEARER,
                     CURLOPT_XOAUTH2_BEARER => 'token',
                     CURLOPT_SSL_VERIFYPEER => false,
-                    CURLOPT_SSL_VERIFYHOST => false
-                ]
+                    CURLOPT_SSL_VERIFYHOST => false,
+                ],
             ],
             [
                 ['proxy' => 'http://proxy'],
@@ -41,8 +41,8 @@ class WebDavClientTest extends TestCase
                 [
                     CURLOPT_HTTPAUTH => CURLAUTH_BEARER,
                     CURLOPT_XOAUTH2_BEARER => 'token',
-                    CURLOPT_PROXY => 'http://proxy'
-                ]
+                    CURLOPT_PROXY => 'http://proxy',
+                ],
             ],
             [
                 ['proxy' => ['http' => 'http://proxy', 'https' => 'https://sslproxy']],
@@ -50,8 +50,8 @@ class WebDavClientTest extends TestCase
                 [
                     CURLOPT_HTTPAUTH => CURLAUTH_BEARER,
                     CURLOPT_XOAUTH2_BEARER => 'token',
-                    CURLOPT_PROXY => 'https://sslproxy'
-                ]
+                    CURLOPT_PROXY => 'https://sslproxy',
+                ],
             ],
             [
                 ['proxy' => ['http' => 'http://proxy', 'https' => 'https://sslproxy']],
@@ -59,35 +59,35 @@ class WebDavClientTest extends TestCase
                 [
                     CURLOPT_HTTPAUTH => CURLAUTH_BEARER,
                     CURLOPT_XOAUTH2_BEARER => 'token',
-                    CURLOPT_PROXY => 'http://proxy'
-                ]
+                    CURLOPT_PROXY => 'http://proxy',
+                ],
             ],
             [
                 ['proxy' =>
                     [
                         'http' => 'http://proxy',
                         'https' => 'https://sslproxy',
-                        'no' => ['no-proxy', 'also-no-proxy']]
+                        'no' => ['no-proxy', 'also-no-proxy']],
                 ],
                 'http://no-proxy',
                 [
                     CURLOPT_HTTPAUTH => CURLAUTH_BEARER,
                     CURLOPT_XOAUTH2_BEARER => 'token',
-                ]
+                ],
             ],
             [
                 ['proxy' =>
                     [
                         'http' => 'http://proxy',
                         'https' => 'https://sslproxy',
-                        'no' => ['no-proxy', 'also-no-proxy']]
+                        'no' => ['no-proxy', 'also-no-proxy']],
                 ],
                 'https://also-no-proxy',
                 [
                     CURLOPT_HTTPAUTH => CURLAUTH_BEARER,
                     CURLOPT_XOAUTH2_BEARER => 'token',
-                ]
-            ]
+                ],
+            ],
         ];
     }
 
@@ -106,7 +106,7 @@ class WebDavClientTest extends TestCase
 
         $curlSettings = $webDavClient->createCurlSettings(
             $connectionConfig,
-            $accessToken
+            $accessToken,
         );
         $this->assertSame($expectedCurlSettingsArray, $curlSettings);
     }


### PR DESCRIPTION
https://www.php-fig.org/per/coding-style/ extends PSR-12 and specifies the coding style for newer PHP features. See the link documentation for details.

We could require this style - it's to be discussed. This is what happens to code if we use PER-CS2.0 and let php-cs-fixer reformat the code.

The main differences seem to be:
- a space is required between a cast (like `(int)`) and the variable that it applies to.
- when there is a comma-separated list of things (function parameters, array items etc.) then the last item in the list must end with a comma. This syntax is valid in newish versions of PHP, it makes it easier to add another item to the list (minimizing the diff listing)
- empty classes can have the `{}` at the end of the class declaration `class MyException extends Exception {}`