### PR TITLE
chore: enforce php-cs-fixer single_space_around_construct

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -5,5 +5,10 @@ $finder = PhpCsFixer\Finder::create()
 
 $config = new PhpCsFixer\Config();
 $config->setFinder($finder);
-$config->setRules(['@PSR12' => true]);
+$config->setRules(
+    [
+        '@PSR12' => true,
+        'single_space_around_construct' => true,
+    ]
+);
 return $config;

--- a/src/BaseUser.php
+++ b/src/BaseUser.php
@@ -2,8 +2,8 @@
 
 namespace Owncloud\OcisPhpSdk;
 
-use  OpenAPI\Client\Model\User;
-use  OpenAPI\Client\Model\EducationUser;
+use OpenAPI\Client\Model\User;
+use OpenAPI\Client\Model\EducationUser;
 use Owncloud\OcisPhpSdk\Exception\InvalidResponseException;
 
 class BaseUser

--- a/src/Drive.php
+++ b/src/Drive.php
@@ -627,7 +627,7 @@ class Drive
      */
     public function invite(User|Group $recipient, SharingRole $role, ?\DateTimeImmutable $expiration = null): Permission
     {
-        if(version_compare($this->ocisVersion, self::MIN_OCIS_VERSION_DRIVE_INVITE, '<')) {
+        if (version_compare($this->ocisVersion, self::MIN_OCIS_VERSION_DRIVE_INVITE, '<')) {
             throw new EndPointNotImplementedException(Ocis::ENDPOINT_NOT_IMPLEMENTED_ERROR_MESSAGE);
         }
 
@@ -685,7 +685,7 @@ class Drive
      */
     public function getRoles(): array
     {
-        if(version_compare($this->ocisVersion, self::MIN_OCIS_VERSION_DRIVE_INVITE, '<')) {
+        if (version_compare($this->ocisVersion, self::MIN_OCIS_VERSION_DRIVE_INVITE, '<')) {
             throw new EndPointNotImplementedException(Ocis::ENDPOINT_NOT_IMPLEMENTED_ERROR_MESSAGE);
         }
         $apiRoles = $this->sendGetPermissionsRequest()->getAtLibreGraphPermissionsRolesAllowedValues();
@@ -768,7 +768,7 @@ class Drive
      */
     public function getPermissions(): array
     {
-        if(version_compare($this->ocisVersion, self::MIN_OCIS_VERSION_DRIVE_INVITE, '<')) {
+        if (version_compare($this->ocisVersion, self::MIN_OCIS_VERSION_DRIVE_INVITE, '<')) {
             throw new EndPointNotImplementedException(Ocis::ENDPOINT_NOT_IMPLEMENTED_ERROR_MESSAGE);
         }
         $permissions = $this->sendGetPermissionsRequest()->getValue();

--- a/src/Group.php
+++ b/src/Group.php
@@ -173,7 +173,7 @@ class Group
         } catch (ApiException $e) {
             throw ExceptionHelper::getHttpErrorException($e);
         }
-        foreach($this->members as $memberIndex => $member) {
+        foreach ($this->members as $memberIndex => $member) {
             if ($member->getId() === $user->getId()) {
                 unset($this->members[$memberIndex]);
             }

--- a/src/Ocis.php
+++ b/src/Ocis.php
@@ -318,7 +318,7 @@ class Ocis
      */
     public function getOcisVersion(): string
     {
-        if(($this->ocisVersion)) {
+        if (($this->ocisVersion)) {
             return $this->ocisVersion;
         } else {
             $response = $this->guzzle->get($this->serviceUrl . '/ocs/v1.php/cloud/capabilities');
@@ -1099,7 +1099,7 @@ class Ocis
                 throw new InvalidResponseException("Invalid permissions provided");
             }
             foreach ($share->getPermissions() as $apiSharePermission) {
-                if($apiSharePermission->getLink() === null) {
+                if ($apiSharePermission->getLink() === null) {
                     $shares[] = new ShareCreated(
                         $apiSharePermission,
                         $resourceId,

--- a/tests/integration/Owncloud/OcisPhpSdk/DriveTest.php
+++ b/tests/integration/Owncloud/OcisPhpSdk/DriveTest.php
@@ -503,7 +503,7 @@ class DriveTest extends OcisPhpSdkTestCase
         $katherineDrives = $katherineOcis->getMyDrives();
         $projectDriveFound = false;
 
-        foreach($katherineDrives as $drive) {
+        foreach ($katherineDrives as $drive) {
             if ($drive->getType() === DriveType::PROJECT) {
                 $projectDriveFound = true;
                 $this->assertThat(

--- a/tests/integration/Owncloud/OcisPhpSdk/GroupsTest.php
+++ b/tests/integration/Owncloud/OcisPhpSdk/GroupsTest.php
@@ -152,7 +152,7 @@ class GroupsTest extends OcisPhpSdkTestCase
             ]
         );
         $sdkUser = new \Owncloud\OcisPhpSdk\User($user);
-        $groups = $ocis->getGroups(search:"philosophyhaters");
+        $groups = $ocis->getGroups(search: "philosophyhaters");
         $this->assertGreaterThanOrEqual(1, $groups);
         $groups[0]->addUser($sdkUser);
     }
@@ -167,7 +167,7 @@ class GroupsTest extends OcisPhpSdkTestCase
         $physicsLoversGroup =  $ocis->createGroup("physicslovers", "physics lovers group");
         $this->createdGroups = [$physicsLoversGroup];
         $users = $marieOcis->getUsers('marie');
-        $groups = $marieOcis->getGroups(search:"physicslovers");
+        $groups = $marieOcis->getGroups(search: "physicslovers");
         $this->assertGreaterThanOrEqual(1, $groups);
         if (getenv('OCIS_VERSION') === "stable") {
             $this->expectException(UnauthorizedException::class);

--- a/tests/integration/Owncloud/OcisPhpSdk/OcisTest.php
+++ b/tests/integration/Owncloud/OcisPhpSdk/OcisTest.php
@@ -391,7 +391,7 @@ class OcisTest extends OcisPhpSdkTestCase
      */
     public static function groupNameList(): array
     {
-        return[
+        return [
             [["philosophyhaters", "physicslovers"]],
         ];
     }

--- a/tests/integration/Owncloud/OcisPhpSdk/ResourceInviteTest.php
+++ b/tests/integration/Owncloud/OcisPhpSdk/ResourceInviteTest.php
@@ -292,7 +292,7 @@ class ResourceInviteTest extends OcisPhpSdkTestCase
             $shares,
             "Expected count of shared resources to be 6 but found " . count($shares)
         );
-        for($i = 0; $i < 6; $i++) {
+        for ($i = 0; $i < 6; $i++) {
             $this->assertInstanceOf(
                 ShareCreated::class,
                 $shares[$i],

--- a/tests/integration/Owncloud/OcisPhpSdk/ShareGetSharedWithMeTest.php
+++ b/tests/integration/Owncloud/OcisPhpSdk/ShareGetSharedWithMeTest.php
@@ -150,7 +150,7 @@ class ShareGetSharedWithMeTest extends OcisPhpSdkTestCase
             $receivedShares,
             "Expected two shares but found " . count($receivedShares)
         );
-        for($i = 0; $i < 2; $i++) {
+        for ($i = 0; $i < 2; $i++) {
             $this->assertThat(
                 $receivedShares[$i]->getName(),
                 $this->logicalOr(

--- a/tests/unit/Owncloud/OcisPhpSdk/ResourceLinkTest.php
+++ b/tests/unit/Owncloud/OcisPhpSdk/ResourceLinkTest.php
@@ -130,7 +130,7 @@ class ResourceLinkTest extends TestCase
         $permissionMock = $this->createMock(Permission::class);
         $drivesPermissionsApi = $this->createMock(DrivesPermissionsApi::class);
         $drivesPermissionsApi->method('createLink')->willReturn($permissionMock);
-        $link = $this->createResource($drivesPermissionsApi)->createSharingLink(password:self::PASSWORD);
+        $link = $this->createResource($drivesPermissionsApi)->createSharingLink(password: self::PASSWORD);
         $link->getPermissionId();
     }
 
@@ -142,7 +142,7 @@ class ResourceLinkTest extends TestCase
         $permissionMock->method('getId')->willReturn('uuid-of-the-permission');
         $drivesPermissionsApi = $this->createMock(DrivesPermissionsApi::class);
         $drivesPermissionsApi->method('createLink')->willReturn($permissionMock);
-        $link = $this->createResource($drivesPermissionsApi)->createSharingLink(password:self::PASSWORD);
+        $link = $this->createResource($drivesPermissionsApi)->createSharingLink(password: self::PASSWORD);
         $link->getType();
     }
 
@@ -157,7 +157,7 @@ class ResourceLinkTest extends TestCase
         $drivesPermissionsApi = $this->createMock(DrivesPermissionsApi::class);
         $drivesPermissionsApi->method('createLink')->willReturn($permissionMock);
 
-        $link = $this->createResource($drivesPermissionsApi)->createSharingLink(password:self::PASSWORD);
+        $link = $this->createResource($drivesPermissionsApi)->createSharingLink(password: self::PASSWORD);
         $link->getWebUrl();
     }
 
@@ -173,7 +173,7 @@ class ResourceLinkTest extends TestCase
         $drivesPermissionsApi = $this->createMock(DrivesPermissionsApi::class);
         $drivesPermissionsApi->method('createLink')->willReturn($permissionMock);
 
-        $link = $this->createResource($drivesPermissionsApi)->createSharingLink(password:self::PASSWORD);
+        $link = $this->createResource($drivesPermissionsApi)->createSharingLink(password: self::PASSWORD);
         $link->getType();
     }
 }


### PR DESCRIPTION
When reviewing PRs I notice that we sometimes write:
`if(`
`foreach(`
and sometimes:
`if (`
`foreach (`

PSR-12 does not enforce if there must be a space before the opening `(` or not. But we should be consistent.

In other repos we always have a single space before the `(`

Add the optional php-cs-fixer rule https://cs.symfony.com/doc/rules/language_construct/single_space_around_construct.html
