### PR TITLE
access token optional function added

### DIFF
--- a/tests/unit/Owncloud/OcisPhpSdk/OcisTest.php
+++ b/tests/unit/Owncloud/OcisPhpSdk/OcisTest.php
@@ -55,6 +55,22 @@ class OcisTest extends TestCase
         );
     }
 
+    public function testCheckInvalidGuzzleClient(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage("Invalid guzzle client.");
+        $ocis = new Ocis('https://localhost:9200');
+    }
+
+    public function testCreateDriveWithNoAccessToken(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $ocis = new Ocis('https://localhost:9200');
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage("This function cannot be used because no access token was provided.");
+        $ocis->createDrive('driveName', 10);
+    }
+
     public function testCreateDriveWithInvalidQuota(): void
     {
         $this->expectException(\InvalidArgumentException::class);

--- a/tests/unit/Owncloud/OcisPhpSdk/OcisTest.php
+++ b/tests/unit/Owncloud/OcisPhpSdk/OcisTest.php
@@ -62,13 +62,43 @@ class OcisTest extends TestCase
         $ocis = new Ocis('https://localhost:9200');
     }
 
-    public function testCreateDriveWithNoAccessToken(): void
+    /**
+     * @return array<array{string, array<mixed>}>
+     */
+    public static function noAccessTokenCaseDataProvider(): array
     {
-        $this->expectException(\InvalidArgumentException::class);
-        $ocis = new Ocis('https://localhost:9200');
+        return [
+            ['getAllDrives', []],
+            ['getMyDrives', []],
+            ['getDriveById', ['1']],
+            ['getGroups', []],
+            ['createDrive', ['driveName']],
+            ['getResourceById', ['1']],
+            ['getUsers', ['einstein']],
+            ['getUserById', ['einsteinId']],
+            ['createGroup', ['philosophyhaters']],
+            ['getGroupById', ['1']],
+            ['deleteGroupByID', ['1']],
+            ['getSharedWithMe', []],
+            ['getSharedByMe', []],
+            ['searchResource', ['*hello*']],
+            ['getNotifications', []],
+        ];
+    }
+
+    /**
+     * @param array<mixed> $parameter
+     * @dataProvider noAccessTokenCaseDataProvider
+     */
+    public function testWithNoAccessToken(string $method, array $parameter): void
+    {
+        $ocis = new Ocis(
+            serviceUrl: 'https://localhost:9200',
+            educationAccessToken: "doesNotMatter",
+        );
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage("This function cannot be used because no access token was provided.");
-        $ocis->createDrive('driveName', 10);
+        $ocis->$method(...$parameter);
     }
 
     public function testCreateDriveWithInvalidQuota(): void


### PR DESCRIPTION
The access token is made optional because the education user can work without that token and has its own education access token. 
`setEducationGuzzleClient` is removed because the setter is not necessary for the SDK.  It can be set from outside by giving them in `educationAccessToken`
The new implementation is done in a way that if both token isn't provided, the error will be thrown in object creation.
 Each function that uses accesstoken is checked on their own function body. 