### PR TITLE
Add support for group rename

### DIFF
--- a/src/Group.php
+++ b/src/Group.php
@@ -202,4 +202,32 @@ class Group
             throw ExceptionHelper::getHttpErrorException($e);
         }
     }
+
+    /**
+     * Rename group
+     *
+     * @param string $name
+     *
+     * @return bool
+     * @throws BadRequestException
+     * @throws ForbiddenException
+     * @throws HttpException
+     * @throws InternalServerErrorException
+     * @throws InvalidResponseException
+     * @throws NotFoundException
+     * @throws UnauthorizedException
+     */
+    public function rename(string $name): bool
+    {
+        $apiInstance = new GroupApi($this->guzzle, $this->graphApiConfig);
+        $groupProperties = new OpenApiGroup([
+            "display_name" => $name,
+        ], );
+        try {
+            $apiInstance->updateGroup($this->getId(), $groupProperties);
+            return true;
+        } catch (ApiException $e) {
+            throw ExceptionHelper::getHttpErrorException($e);
+        }
+    }
 }

--- a/tests/integration/Owncloud/OcisPhpSdk/GroupsTest.php
+++ b/tests/integration/Owncloud/OcisPhpSdk/GroupsTest.php
@@ -263,4 +263,34 @@ class GroupsTest extends OcisPhpSdkTestCase
         $ocis->deleteGroupByID("thisgroupdoesnotexist");
     }
 
+    public function testRenameGroup(): void
+    {
+        $ocis = $this->getOcis('admin', 'admin');
+        $philosophyHatersGroup =  $ocis->createGroup("philosophyhaters", "philosophy haters group");
+        $this->createdGroups = [$philosophyHatersGroup];
+        $groups = $ocis->getGroups("philosophyhaters");
+        $isGroupRenamed = $groups[0]->rename("researchers");
+
+        $this->assertTrue($isGroupRenamed, "Group rename failed");
+
+        $groupsAfterRename = $ocis->getGroups();
+        $this->assertCount(
+            1,
+            $groupsAfterRename,
+            "Expected one group but found " . count($groupsAfterRename),
+        );
+
+        $this->assertSame(
+            "researchers",
+            $groupsAfterRename[0]->getDisplayName(),
+            "Expected group name to be researchers but found " . $groupsAfterRename[0]->getDisplayName(),
+        );
+        $this->assertNotSame(
+            "philosophyhaters",
+            $groupsAfterRename[0]->getDisplayName(),
+            "Expected group name to be rename in researchers but found " . $groupsAfterRename[0]->getDisplayName(),
+        );
+
+    }
+
 }


### PR DESCRIPTION
This PR add function rename under Group class and add test coverage too.
Part of 
- https://github.com/owncloud/ocis-php-sdk/issues/256