### PR TITLE
Use singular "identity" for variable name

### DIFF
--- a/src/Ocis.php
+++ b/src/Ocis.php
@@ -796,7 +796,7 @@ class Ocis
                 $this->graphApiConfig,
             );
         }
-        $identities = new ObjectIdentity(["issuer" => $issuer,"issuer_assigned_id" => $issuerAssignedId]);
+        $identity = new ObjectIdentity(["issuer" => $issuer,"issuer_assigned_id" => $issuerAssignedId]);
         $educationUser = new EducationUserModel([
             "display_name" => $displayName,
             "surname" => $surname,
@@ -804,7 +804,7 @@ class Ocis
             "mail" => $mail,
             "on_premises_sam_account_name" => $onPremisesSAMAccountName,
             "primary_role" => $primaryRole,
-            "identities" => [$identities],
+            "identities" => [$identity],
         ]);
 
         try {


### PR DESCRIPTION
There is only one identity object held in this variable.

See comment https://github.com/owncloud/ocis-php-sdk/pull/263/files#r1764598622