### PR TITLE
ignoring phpstan info from documentation

### DIFF
--- a/phpdoc.dist.xml
+++ b/phpdoc.dist.xml
@@ -19,6 +19,12 @@
             <visibility>public</visibility>
             <include-source>true</include-source>
             <default-package-name>OcisPhpSdk</default-package-name>
+            <ignore-tags>
+                <ignore-tag>phpstan-import-type</ignore-tag>
+                <ignore-tag>phpstan-var</ignore-tag>
+                <ignore-tag>phpstan-param</ignore-tag>
+                <ignore-tag>phpstan-type</ignore-tag>
+            </ignore-tags>
         </api>
 
     </version>


### PR DESCRIPTION
previously phpstan variable were shown in the documentation 

before:
![image](https://github.com/user-attachments/assets/bbe3b8eb-1a14-4c9e-b883-e9f8ab1d813b)

now this pr ignores those phpstan variable when generating the docs

after:
![image](https://github.com/user-attachments/assets/31436d03-daa4-4b15-aefb-120e4ce04928)
