### PR TITLE
Exclude unnecessary files during composer installation.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,14 @@
+.phan/ export-ignore
+docs/ export-ignore
+tests/ export-ignore
+.drone.env export-ignore
+.drone.star export-ignore
+.gitattributes export-ignore
+.gitignore export-ignore
+.php-cs-fixer.dist.php export-ignore
+Makefile export-ignore
+docs-hugo-header.md export-ignore
+phpdoc.dist.xml export-ignore
+phpstan.neon export-ignore
+phpunit.xml export-ignore
+sonar-project.properties export-ignore


### PR DESCRIPTION
When installing ocis-php-sdk, all folders and files are included, resulting in a large package size that may inconvenience users. To address this, a .gitattributes file is added to exclude unnecessary files and folders, keeping the installation lightweight.