### PR TITLE
fix commit id checking script

### DIFF
--- a/tests/scripts/get-latest-ocis-commit-id.sh
+++ b/tests/scripts/get-latest-ocis-commit-id.sh
@@ -11,7 +11,7 @@ if [[ "$1" == "master" ]]; then
   # Update the OCIS_COMMITID in the drone.env file
   sed -i "s/^OCIS_COMMITID=.*/OCIS_COMMITID=$latest_commit_id/" "$env_file"
   cat ./.drone.env
-elif [[ "$1" == "stable-5.0" ]]; then
+elif [[ "$1" == "stable-7.1" ]]; then
   sed -i "s/^OCIS_STABLE_COMMITID=.*/OCIS_STABLE_COMMITID=$latest_commit_id/" "$env_file"
   cat ./.drone.env
 else


### PR DESCRIPTION
**JIRA:** [OCISDEV-58](https://kiteworks.atlassian.net/browse/OCISDEV-58)
---
We are using stable-7.1 now so the script that checks for commit id failed

https://drone.owncloud.com/owncloud/ocis-php-sdk/2167/3/1

This PR updates the script