### PR TITLE
feat(ci): disable not needed pipelines on nightly run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ env:
 jobs:
   php-checks:
     name: php checks
+    if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
 
     steps:
@@ -46,6 +47,7 @@ jobs:
 
   php-unit-tests:
     name: php unit tests (${{ matrix.php-version }}-with-coverage)
+    if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     needs: php-checks
     strategy:
@@ -85,6 +87,7 @@ jobs:
     name: buildOcis
     runs-on: ubuntu-latest
     needs: php-checks
+    if: always() && (success() || github.event_name == 'schedule')
     strategy:
       fail-fast: false
       matrix:
@@ -285,6 +288,7 @@ jobs:
 
   docs:
     name: docs
+    if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     needs: [php-unit-tests, php-integration-tests]
     steps:
@@ -318,6 +322,7 @@ jobs:
 
   sonar-analysis:
     name: sonar analysis
+    if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     needs: [php-unit-tests, php-integration-tests]
     steps:


### PR DESCRIPTION
disabled pipelines (php checks, php unit tests, docs, sonar analysis) that are not needed on nightly run, as nightly run seems to be running all those stages https://github.com/owncloud/ocis-php-sdk/actions/runs/25026770047