### PR TITLE
feat(ci): enable php integration tests on nightly run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ on:
 env:
   COMPOSER_HOME: ${{ github.workspace }}/.cache/composer
   DEFAULT_PHP_VERSION: '8.1'
+  COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 jobs:
   php-checks:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,6 +187,7 @@ jobs:
     name: php integration tests (${{ matrix.php-version}}-${{ matrix.branch }}${{ matrix.branch == 'master' && matrix.php-version == '8.1' && '-with-coverage' || '' }})
     runs-on: ubuntu-latest
     needs: build-ocis
+    if: always() && (success() || github.event_name == 'schedule')
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
nightly run somehow seems to be skipping `php-integration-tests` seen in https://github.com/owncloud/ocis-php-sdk/actions/runs/25140787866

- enabled `php-integration-tests` on nightly run
- added composer token env because of https://github.com/owncloud/ocis-php-sdk/actions/runs/25036938385/job/73330777501#step:5:13 

simulated nightly run: https://github.com/owncloud/ocis-php-sdk/actions/runs/25147380397 [9d05209](https://github.com/owncloud/ocis-php-sdk/commit/9d05209033d16117f49d69be476ff96e316af37c)