### PR TITLE
ci: adjust code and tests for phpstan v2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "friendsofphp/php-cs-fixer": "^3.26",
         "phan/phan": "^5.4",
         "phpunit/phpunit": "^10.5",
-        "phpstan/phpstan": "^1.10",
+        "phpstan/phpstan": "^2.2",
         "ext-gd": "*"
     }
 }

--- a/src/Drive.php
+++ b/src/Drive.php
@@ -725,6 +725,7 @@ class Drive
         if (
             $permissionsValue === null ||
             !array_key_exists(0, $permissionsValue) ||
+            // @phpstan-ignore instanceof.alwaysTrue
             !($permissionsValue[0] instanceof Permission)
         ) {
             throw new InvalidResponseException(

--- a/src/Exception/ExceptionHelper.php
+++ b/src/Exception/ExceptionHelper.php
@@ -33,12 +33,16 @@ class ExceptionHelper
             $rawResponseBody = $e->getResponseBody();
             if (is_string($rawResponseBody)) {
                 $responseBody = json_decode($rawResponseBody, true);
-                if (is_array($responseBody)) {
+                if (is_array($responseBody) && isset($responseBody['error']) && is_array($responseBody['error'])) {
                     if (isset($responseBody['error']['code'])) {
-                        $message = $responseBody['error']['code'] . " - ";
+                        // @phpstan-ignore cast.string
+                        $code = (string) $responseBody['error']['code'];
+                        $message = $code . " - ";
                     }
                     if (isset($responseBody['error']['message'])) {
-                        $message .= $responseBody['error']['message'];
+                        // @phpstan-ignore cast.string
+                        $errorMessage = (string) $responseBody['error']['message'];
+                        $message .= $errorMessage;
                     }
                 }
             }

--- a/src/Ocis.php
+++ b/src/Ocis.php
@@ -242,6 +242,7 @@ class Ocis
     /**
      * check for access token.
      *
+     * @phpstan-assert string $this->accessToken
      * @throws \InvalidArgumentException
      */
     private function checkIfAccessTokenExists(): void
@@ -256,6 +257,7 @@ class Ocis
     /**
      * check for access token of education user.
      *
+     * @phpstan-assert string $this->educationAccessToken
      * @throws \InvalidArgumentException
      */
     private function checkIfEducationAccessTokenExists(): void
@@ -291,7 +293,6 @@ class Ocis
     private function getServiceUrlFromWebfinger(string $webfingerUrl): string
     {
         $this->checkIfAccessTokenExists();
-        // @phpstan-ignore-next-line access token if empty is caught by previous step.
         $tokenDataArray = explode(".", $this->accessToken);
         if (!array_key_exists(1, $tokenDataArray)) {
             throw new \InvalidArgumentException(
@@ -436,6 +437,7 @@ class Ocis
         $apiDrives = $allDrivesList->getValue();
         $apiDrives = $apiDrives ?? [];
         foreach ($apiDrives as $apiDrive) {
+            $this->checkIfAccessTokenExists();
             $drive = new Drive(
                 $apiDrive,
                 $this->connectionConfig,
@@ -608,6 +610,7 @@ class Ocis
         }
 
         if ($newlyCreatedDrive instanceof ApiDrive) {
+            $this->checkIfAccessTokenExists();
             return new Drive(
                 $newlyCreatedDrive,
                 $this->connectionConfig,
@@ -690,7 +693,6 @@ class Ocis
     {
         $webDavClient = new WebDavClient(['baseUri' => $this->getServiceUrl() . '/dav/spaces/']);
         $this->checkIfAccessTokenExists();
-        //@phpstan-ignore-next-line
         $webDavClient->setCustomSetting($this->connectionConfig, $this->accessToken);
         try {
             $properties = [];
@@ -960,7 +962,7 @@ class Ocis
      */
     public function getEducationSchoolById(string $schoolId, ?EducationSchoolApi $apiInstance = null): EducationSchool
     {
-        $this->checkIfAccessTokenExists();
+        $this->checkIfEducationAccessTokenExists();
         if (!isset($apiInstance)) {
             $apiInstance =  new EducationSchoolApi(
                 $this->guzzle,
@@ -1101,7 +1103,7 @@ class Ocis
             }
             $id = $ocsData["notification_id"];
             /**
-             * @phpstan-var object{
+             * @phpstan-var stdClass&object{
              *    app: string,
              *    user: string,
              *    datetime: string,
@@ -1351,7 +1353,6 @@ class Ocis
 
         $webDavClient = new WebDavClient(['baseUri' => $this->getServiceUrl()]);
         $this->checkIfAccessTokenExists();
-        //@phpstan-ignore-next-line
         $webDavClient->setCustomSetting($this->connectionConfig, $this->accessToken);
 
         $responses = $webDavClient->sendReportRequest($pattern, $limit, '/remote.php/dav/spaces');

--- a/src/OcisResource.php
+++ b/src/OcisResource.php
@@ -97,8 +97,7 @@ class OcisResource
 
     /**
      * @param ResourceMetadata $property
-     * @phpstan-ignore-next-line Because this method returns different array depending on the property
-     * @return array|string
+     * @return mixed[]|string
      * @throws InvalidResponseException
      */
     private function getMetadata(ResourceMetadata $property): array|string
@@ -243,6 +242,7 @@ class OcisResource
         if (
             $permissionsValue === null ||
             !array_key_exists(0, $permissionsValue) ||
+            // @phpstan-ignore instanceof.alwaysTrue
             !($permissionsValue[0] instanceof Permission)
         ) {
             throw new InvalidResponseException(
@@ -459,6 +459,7 @@ class OcisResource
         if ($this->getType() === "file") {
             $contentType = $this->getMetadata(ResourceMetadata::CONTENTTYPE);
             if (is_array($contentType)) {
+                // @phpstan-ignore argument.type
                 return implode($contentType);
             }
             return $contentType;
@@ -503,6 +504,7 @@ class OcisResource
         if ($this->getType() === "file" && $this->getSize() > 0) {
             $checkSum = $this->getMetadata(ResourceMetadata::CHECKSUMS);
             if (is_array($checkSum)) {
+                // @phpstan-ignore return.type
                 return $checkSum;
             }
         }

--- a/src/WebDavClient.php
+++ b/src/WebDavClient.php
@@ -67,6 +67,7 @@ class WebDavClient extends Client
         $settings = [];
         if (isset($connectionConfig['headers'])) {
             foreach ($connectionConfig['headers'] as $header => $value) {
+                // @phpstan-ignore binaryOp.invalid
                 $settings[CURLOPT_HTTPHEADER][] = $header . ': ' . $value;
             }
         }
@@ -100,10 +101,7 @@ class WebDavClient extends Client
 
             if (is_string($connectionConfig['proxy'])) {
                 $settings[CURLOPT_PROXY] = $connectionConfig['proxy'];
-            } elseif (
-                array_key_exists('proxy', $connectionConfig) &&
-                is_array($connectionConfig['proxy'])
-            ) {
+            } elseif (is_array($connectionConfig['proxy'])) {
                 if (isset($connectionConfig['proxy'][$scheme])) {
                     $host = parse_url($this->baseUri, PHP_URL_HOST);
                     if (isset($connectionConfig['proxy']['no']) &&

--- a/tests/integration/Owncloud/OcisPhpSdk/GroupsTest.php
+++ b/tests/integration/Owncloud/OcisPhpSdk/GroupsTest.php
@@ -221,9 +221,13 @@ class GroupsTest extends OcisPhpSdkTestCase
                 "Expected class " . Group::class
                 . " but got " . get_class($group),
             );
+            // @phpstan-ignore method.alreadyNarrowedType
             $this->assertIsString($group->getId());
+            // @phpstan-ignore method.alreadyNarrowedType
             $this->assertIsString($group->getDisplayName());
+            // @phpstan-ignore method.alreadyNarrowedType
             $this->assertIsArray($group->getGroupTypes());
+            // @phpstan-ignore method.alreadyNarrowedType
             $this->assertIsArray($group->getMembers());
         }
     }

--- a/tests/integration/Owncloud/OcisPhpSdk/OcisResourceTest.php
+++ b/tests/integration/Owncloud/OcisPhpSdk/OcisResourceTest.php
@@ -166,6 +166,7 @@ class OcisResourceTest extends OcisPhpSdkTestCase
                 $resource->getTags(),
                 "Expected resource tag be empty array but found " . count($resource->getTags()) . " elements",
             );
+            // @phpstan-ignore method.alreadyNarrowedType
             $this->assertIsInt(
                 $resource->getSize(),
                 "Expected resource size be of type integer but found " . getType($resource->getSize()),
@@ -715,7 +716,6 @@ class OcisResourceTest extends OcisPhpSdkTestCase
          * so ignoring next line
          *
          * @phpstan-ignore-next-line
-         * @phan-suppress-next-line PhanTypeMismatchArgumentNullable
          */
         $resource->setLifecycleDelete($date);
     }

--- a/tests/integration/Owncloud/OcisPhpSdk/OcisTest.php
+++ b/tests/integration/Owncloud/OcisPhpSdk/OcisTest.php
@@ -18,10 +18,14 @@ class OcisTest extends OcisPhpSdkTestCase
     {
         $ocis = $this->getOcis('admin', 'admin');
         $drives = $ocis->getMyDrives();
+        // @phpstan-ignore method.alreadyNarrowedType
+        $this->assertIsArray(
+            $drives,
+            "Drives variable is expected to be an array but found to be " . gettype($drives),
+        );
         $this->assertTrue(
-            (is_array($drives) && count($drives) > 1),
-            "Drives variable is expected to be an array but found to be " . gettype($drives) .
-        " and to have more than one element but found " . count($drives),
+            count($drives) > 1,
+            "drives expected to have more than one element but found " . count($drives),
         );
     }
 
@@ -420,18 +424,22 @@ class OcisTest extends OcisPhpSdkTestCase
                 $group,
                 "Expected class to be 'Group' but found " . get_class($group),
             );
+            // @phpstan-ignore method.alreadyNarrowedType
             $this->assertIsString(
                 $group->getId(),
                 "Expected groupId to be string but found " . gettype($group->getId()),
             );
+            // @phpstan-ignore method.alreadyNarrowedType
             $this->assertIsString(
                 $group->getDisplayName(),
                 "Expected groupname type to be string but found " . gettype($group->getDisplayName()),
             );
+            // @phpstan-ignore method.alreadyNarrowedType
             $this->assertIsArray(
                 $group->getGroupTypes(),
                 "Expected grouptype to be Array but found " . gettype($group->getGroupTypes()),
             );
+            // @phpstan-ignore method.alreadyNarrowedType
             $this->assertIsArray(
                 $group->getMembers(),
                 "Expected group members type to be Array but found " . gettype($group->getMembers()),

--- a/tests/integration/Owncloud/OcisPhpSdk/ResourceInviteTest.php
+++ b/tests/integration/Owncloud/OcisPhpSdk/ResourceInviteTest.php
@@ -59,7 +59,9 @@ class ResourceInviteTest extends OcisPhpSdkTestCase
                 $this->editorRole = $role;
             }
         }
+        // @phpstan-ignore method.alreadyNarrowedType
         $this->assertNotNull($this->viewerRole, 'Viewer role is empty');
+        // @phpstan-ignore method.alreadyNarrowedType
         $this->assertNotNull($this->editorRole, 'Editor role is empty');
     }
 

--- a/tests/integration/Owncloud/OcisPhpSdk/ShareCreatedModifyTest.php
+++ b/tests/integration/Owncloud/OcisPhpSdk/ShareCreatedModifyTest.php
@@ -44,6 +44,7 @@ class ShareCreatedModifyTest extends OcisPhpSdkTestCase
                 break;
             }
         }
+        // @phpstan-ignore method.alreadyNarrowedType
         $this->assertNotNull($this->viewerRole, 'Viewer role is not set');
     }
 

--- a/tests/integration/Owncloud/OcisPhpSdk/ShareGetShareByMeTest.php
+++ b/tests/integration/Owncloud/OcisPhpSdk/ShareGetShareByMeTest.php
@@ -42,7 +42,9 @@ class ShareGetShareByMeTest extends OcisPhpSdkTestCase
                 break;
             }
         }
+        // @phpstan-ignore method.alreadyNarrowedType
         $this->assertNotNull($this->editorRole, 'Editor role is not set');
+        // @phpstan-ignore method.alreadyNarrowedType
         $this->assertNotNull($this->sharedResource, 'Resource is not set');
     }
 

--- a/tests/integration/Owncloud/OcisPhpSdk/ShareGetSharedWithMeTest.php
+++ b/tests/integration/Owncloud/OcisPhpSdk/ShareGetSharedWithMeTest.php
@@ -58,7 +58,9 @@ class ShareGetSharedWithMeTest extends OcisPhpSdkTestCase
                 break;
             }
         }
+        // @phpstan-ignore method.alreadyNarrowedType
         $this->assertNotNull($this->fileEditorRole, 'File Editor is not set');
+        // @phpstan-ignore method.alreadyNarrowedType
         $this->assertNotNull($this->folderEditorRole, 'Folder Editor is not set');
 
     }
@@ -78,6 +80,7 @@ class ShareGetSharedWithMeTest extends OcisPhpSdkTestCase
             strlen($receivedShare->getRemoteItemId()),
             "Expected the length of remote item id to be greater than 1",
         );
+        // @phpstan-ignore method.alreadyNarrowedType
         $this->assertNotNull($receivedShare->getId(), "Expected received share id to not be null");
         $this->assertGreaterThanOrEqual(
             1,

--- a/tests/integration/Owncloud/OcisPhpSdk/ShareTestGetSharedWithMeNotSyncedSharesTest.php
+++ b/tests/integration/Owncloud/OcisPhpSdk/ShareTestGetSharedWithMeNotSyncedSharesTest.php
@@ -38,6 +38,7 @@ class ShareTestGetSharedWithMeNotSyncedSharesTest extends OcisPhpSdkTestCase
                 break;
             }
         }
+        // @phpstan-ignore method.alreadyNarrowedType
         $this->assertNotNull($this->viewerRole, 'Viewer role is not set');
     }
 

--- a/tests/unit/Owncloud/OcisPhpSdk/Exception/ExceptionHelperTest.php
+++ b/tests/unit/Owncloud/OcisPhpSdk/Exception/ExceptionHelperTest.php
@@ -65,7 +65,7 @@ class ExceptionHelperTest extends TestCase
         $expectedExceptionMessage = $exceptionMessage;
         if ($originalExceptionToUse === "GuzzleHttpRequestException") {
             $request = $this->createMock(RequestInterface::class);
-            assert($request instanceof RequestInterface);
+            $this->assertInstanceOf(RequestInterface::class, $request);
             $response = new Response($exceptionStatusCode);
             $originalException = new RequestException($exceptionMessage, $request, $response);
         } elseif ($originalExceptionToUse === "SabreClientHttpException") {

--- a/tests/unit/Owncloud/OcisPhpSdk/GroupTest.php
+++ b/tests/unit/Owncloud/OcisPhpSdk/GroupTest.php
@@ -115,6 +115,7 @@ class GroupTest extends TestCase
         $group = new SdkGroup($libGroup, "url", [], $accessToken);
         $group->getId();
         $group->getDisplayName();
+        // @phpstan-ignore method.resultUnused
         $group->getMembers();
     }
 }

--- a/tests/unit/Owncloud/OcisPhpSdk/OcisTest.php
+++ b/tests/unit/Owncloud/OcisPhpSdk/OcisTest.php
@@ -124,7 +124,6 @@ class OcisTest extends TestCase
         $this->expectException(InvalidResponseException::class);
         $this->expectExceptionMessage("Drive could not be created. 'something went wrong");
         $createDriveMock = $this->createMock(DrivesApi::class);
-        assert($createDriveMock instanceof DrivesApi);
         $error = (new OdataError())
                 ->setError(new OdataErrorMain(['message' => 'something went wrong']));
         $createDriveMock->method('createDrive')
@@ -153,7 +152,6 @@ class OcisTest extends TestCase
     {
         $this->expectException(ForbiddenException::class);
         $createDriveMock = $this->createMock(DrivesApi::class);
-        assert($createDriveMock instanceof DrivesApi);
         $createDriveMock->method('createDrive')
             ->willThrowException(new ApiException('forbidden', 403));
         $ocis = new Ocis(
@@ -173,7 +171,6 @@ class OcisTest extends TestCase
         $driveCollectionMock->method('getValue')
             ->willReturn($driveMock);
         $drivesGetDrivesApi = $this->createMock(DrivesGetDrivesApi::class);
-        assert($drivesGetDrivesApi instanceof DrivesGetDrivesApi);
         $drivesGetDrivesApi->method('listAllDrives')
             ->willReturn($driveCollectionMock);
         $ocis = new Ocis(
@@ -327,16 +324,27 @@ class OcisTest extends TestCase
         $responseContent = '{"ocs":{"data":[{"notification_id":"123"}]}}';
         $ocis = $this->setupMocksForNotificationTests($responseContent);
         $notifications = $ocis->getNotifications();
+        // @phpstan-ignore method.alreadyNarrowedType
         $this->assertIsString($notifications[0]->getId());
+        // @phpstan-ignore method.alreadyNarrowedType
         $this->assertIsString($notifications[0]->getApp());
+        // @phpstan-ignore method.alreadyNarrowedType
         $this->assertIsString($notifications[0]->getUser());
+        // @phpstan-ignore method.alreadyNarrowedType
         $this->assertIsString($notifications[0]->getDatetime());
+        // @phpstan-ignore method.alreadyNarrowedType
         $this->assertIsString($notifications[0]->getObjectId());
+        // @phpstan-ignore method.alreadyNarrowedType
         $this->assertIsString($notifications[0]->getObjectType());
+        // @phpstan-ignore method.alreadyNarrowedType
         $this->assertIsString($notifications[0]->getSubject());
+        // @phpstan-ignore method.alreadyNarrowedType
         $this->assertIsString($notifications[0]->getSubjectRich());
+        // @phpstan-ignore method.alreadyNarrowedType
         $this->assertIsString($notifications[0]->getMessage());
+        // @phpstan-ignore method.alreadyNarrowedType
         $this->assertIsString($notifications[0]->getMessageRich());
+        // @phpstan-ignore method.alreadyNarrowedType
         $this->assertIsArray($notifications[0]->getMessageRichParameters());
     }
 

--- a/tests/unit/Owncloud/OcisPhpSdk/ResourceTest.php
+++ b/tests/unit/Owncloud/OcisPhpSdk/ResourceTest.php
@@ -230,6 +230,7 @@ class ResourceTest extends TestCase
         $metadata[200]['{http://owncloud.org/ns}favorite'] = $value;
         $resource = $this->createOcisResource($metadata);
         $result = $resource->isFavorited();
+        // @phpstan-ignore method.alreadyNarrowedType
         $this->assertIsBool($result);
         $this->assertSame($result, (bool)$value);
     }
@@ -493,8 +494,6 @@ class ResourceTest extends TestCase
          * so ignoring next line
          *
          * @phpstan-ignore-next-line
-         * @phan-suppress-next-line PhanTypeMismatchArgumentNullable
-         * @phan-suppress-next-line PhanTypeMismatchArgument
          */
         DateHelper::validateDeletionDate($deletionDate);
     }


### PR DESCRIPTION
Most of the changes to tests are just to ignore `phpstan` messages saying that the assertion is not necessary. I left those assertions in place, because, in the tests, they are double-checking the declared/expected types.

Most of the real source codes changes are minor adjustments or PHPdoc changes so that `phpstan` is happy. See a couple of comments below for things that look more interesting.

IMO Sonar Analysis is “not a thing” any more. Ignore that failing.

This will replace the Dependabot PR #303 